### PR TITLE
[ISSUE-110]: Pipeline apk

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./android/app/build/outputs/apk/release/app-release.apk
-          asset_name: DFX-Btc-Wallet-${{ env.VERSION_NAME }}(${{ env.NEW_BUILD_NUMBER }}).apk
+          asset_name: DFX-Btc-Wallet-${{ github.ref_name }}.apk
           asset_content_type: application/vnd.android.package-archive
 
       - name: Upload artifact
@@ -92,6 +92,15 @@ jobs:
         with:
           upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: ./android/app/build/outputs/apk/release/app-release.apk.idsig
-          asset_name: DFX-Btc-Wallet-${{ env.VERSION_NAME }}(${{ env.NEW_BUILD_NUMBER }}).apk.idsig
+          asset_name: DFX-Btc-Wallet-${{ github.ref_name }}.apk.idsig
           asset_content_type: application/octet-stream
 
+      - name: Upload artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./android/app/build/outputs/bundle/release/app-release.aab
+          asset_name: DFX-Btc-Wallet-${{ github.ref_name }}.aab
+          asset_content_type: application/octet-stream

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -1,9 +1,18 @@
 name: BuildReleaseApk
-on: [pull_request]
+
+on:
+  push:
+    tags:
+      - 'v*'  # This triggers the workflow on any tag starting with 'v'
+  
 
 jobs:
   buildReleaseApk:
     runs-on: macos-latest
+
+    permissions:
+      contents: write
+      actions: read
 
     steps:
       - name: Checkout project
@@ -12,9 +21,9 @@ jobs:
           fetch-depth: "0"
 
       - name: Specify node version
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Use npm caches
         uses: actions/cache@v2
@@ -23,25 +32,66 @@ jobs:
           key: ${{ runner.os }}-npm-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-npm-
-
       - name: Use specific Java version for sdkmanager to work
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
 
       - name: Install node_modules
         run: npm install --production
 
+      - name: Extract Version Name
+        id: version_name
+        run: |
+          VERSION_NAME=$(grep versionName android/app/build.gradle | awk '{print $2}' | tr -d '"')
+          echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
+          echo "::set-output name=version_name::$VERSION_NAME"
+      - name: Generate Build Number based on timestamp
+        run: |
+          NEW_BUILD_NUMBER=$(date +%s)
+          echo "NEW_BUILD_NUMBER=$NEW_BUILD_NUMBER" >> $GITHUB_ENV
+          echo "::set-output name=build_number::$NEW_BUILD_NUMBER"
       - name: Build
         env:
           KEYSTORE_FILE_HEX: ${{ secrets.KEYSTORE_FILE_HEX }}
           KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
+          BUILD_NUMBER: ${{ env.NEW_BUILD_NUMBER }}
         run: ./scripts/build-release-apk.sh
 
       - uses: actions/upload-artifact@v2
         if: success()
         with:
-          name: apk
+          name: DFX-Btc-Wallet-${{ env.VERSION_NAME }}(${{ env.NEW_BUILD_NUMBER }}).apk
           path: ./android/app/build/outputs/apk/release/app-release.apk
+      
+      - uses: cardinalby/git-get-release-action@v1
+        id: get_release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag: ${{ github.ref_name }}   
+
+      - name: Upload artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./android/app/build/outputs/apk/release/app-release.apk
+          asset_name: DFX-Btc-Wallet-${{ env.VERSION_NAME }}(${{ env.NEW_BUILD_NUMBER }}).apk
+          asset_content_type: application/vnd.android.package-archive
+
+      - name: Upload artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
+          asset_path: ./android/app/build/outputs/apk/release/app-release.apk.idsig
+          asset_name: DFX-Btc-Wallet-${{ env.VERSION_NAME }}(${{ env.NEW_BUILD_NUMBER }}).apk.idsig
+          asset_content_type: application/octet-stream
+

--- a/scripts/build-release-apk.sh
+++ b/scripts/build-release-apk.sh
@@ -1,21 +1,29 @@
 #!/bin/bash
 
 
-# assumes 2 env variables: KEYSTORE_FILE_HEX & KEYSTORE_PASSWORD
+# Assumes the following env variables: 
+#
+#
+# --> KEYSTORE_FILE_HEX : hex encoded keystore file
 #
 # PS. to turn file to hex and back:
 #     $ xxd -plain test.txt > test.hex
 #     $ xxd -plain -revert test.hex test2.txt
-
+#
+# --> KEYSTORE_PASSWORD : Password for the keystore
+#
+# --> KEYSTORE_KEY_PASSWORD : Password for the key
+#
+# --> KEYSTORE_ALIAS : Alias of the key
+#
 
 echo $KEYSTORE_FILE_HEX > bluewallet-release-key.keystore.hex
 xxd -plain -revert bluewallet-release-key.keystore.hex > ./android/bluewallet-release-key.keystore
+cp ./android/bluewallet-release-key.keystore ./android/app/bluewallet-release-key.keystore
 rm bluewallet-release-key.keystore.hex
 
 cd android
-TIMESTAMP=$(date +%s)
+TIMESTAMP=$(date +%s | sed 's/...$//')
 sed -i'.original'  "s/versionCode 1/versionCode $TIMESTAMP/g" app/build.gradle
-./gradlew assembleRelease
-mv ./app/build/outputs/apk/release/app-release-unsigned.apk ./app/build/outputs/apk/release/app-release.apk
-$ANDROID_HOME/build-tools/30.0.2/apksigner sign --ks ./bluewallet-release-key.keystore   --ks-pass=pass:$KEYSTORE_PASSWORD ./app/build/outputs/apk/release/app-release.apk
-
+./gradlew assembleRelease -P MYAPP_UPLOAD_STORE_FILE=./bluewallet-release-key.keystore -P MYAPP_UPLOAD_KEY_ALIAS=$KEYSTORE_ALIAS -P MYAPP_UPLOAD_STORE_PASSWORD=$KEYSTORE_PASSWORD -P MYAPP_UPLOAD_KEY_PASSWORD=$KEYSTORE_KEY_PASSWORD
+$ANDROID_HOME/build-tools/33.0.2/apksigner sign --ks ./bluewallet-release-key.keystore   --ks-pass=pass:$KEYSTORE_PASSWORD ./app/build/outputs/apk/release/app-release.apk

--- a/scripts/build-release-apk.sh
+++ b/scripts/build-release-apk.sh
@@ -26,4 +26,5 @@ cd android
 TIMESTAMP=$(date +%s | sed 's/...$//')
 sed -i'.original'  "s/versionCode 1/versionCode $TIMESTAMP/g" app/build.gradle
 ./gradlew assembleRelease -P MYAPP_UPLOAD_STORE_FILE=./bluewallet-release-key.keystore -P MYAPP_UPLOAD_KEY_ALIAS=$KEYSTORE_ALIAS -P MYAPP_UPLOAD_STORE_PASSWORD=$KEYSTORE_PASSWORD -P MYAPP_UPLOAD_KEY_PASSWORD=$KEYSTORE_KEY_PASSWORD
+./gradlew bundleRelease -P MYAPP_UPLOAD_STORE_FILE=./bluewallet-release-key.keystore -P MYAPP_UPLOAD_KEY_ALIAS=$KEYSTORE_ALIAS -P MYAPP_UPLOAD_STORE_PASSWORD=$KEYSTORE_PASSWORD -P MYAPP_UPLOAD_KEY_PASSWORD=$KEYSTORE_KEY_PASSWORD
 $ANDROID_HOME/build-tools/33.0.2/apksigner sign --ks ./bluewallet-release-key.keystore   --ks-pass=pass:$KEYSTORE_PASSWORD ./app/build/outputs/apk/release/app-release.apk


### PR DESCRIPTION
closes #110


When ones create a release in this repo, GitHub Actions will be triggered, building the APK and attach it to the release along with the signature file.

For this work, the following **Repository Secrets** must be set:

--> KEYSTORE_FILE_HEX : hex encoded keystore file
--> KEYSTORE_PASSWORD : Password for the keystore
--> KEYSTORE_KEY_PASSWORD : Password for the key
--> KEYSTORE_ALIAS : Alias of the key

See this repo dummy repo to see these changes in action:
https://github.com/Danswar/pipeline-test