### PR TITLE
[NO-TASK]: Not store tokens on the device storage

### DIFF
--- a/api/dfx/contexts/session.context.tsx
+++ b/api/dfx/contexts/session.context.tsx
@@ -52,10 +52,6 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): JSX.El
   const [isAvailable, setIsAvailable] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
 
-  useEffect(() => {
-    dfxSession.get().then(setSessions);
-  }, [dfxSession]);
-
   function isExpired(token?: string): boolean {
     if (!token) return true;
 
@@ -111,7 +107,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): JSX.El
   async function createAccessToken(walletId: string): Promise<string> {
     if (walletId === mainWalletId) {
       if (!mainAddress) throw new Error('Address is not defined');
-      const signature = await getOwnershipProof();  
+      const signature = await getOwnershipProof();
       return await createSession(mainAddress, signature);
     } else {
       const wallet = wallets.find((w: any) => w.getID?.() === walletId);


### PR DESCRIPTION
Tokens now live on the application state rather than in device's storage, so they will be renew when the app fresh start. 

### Edge cases.

- If the app is closed, tokens will be gone and new ones will be used when the app starts again.
- If the app is put into background, tokens will be reused from app state when it goes front-ground.
- If the app gets terminated by the system (like in background for too long), tokens will be gone and new ones will be used when the app starts again.
