### PR TITLE
[NO-TASK]: Prevent duplicate wallet registration in addWallet

### DIFF
--- a/blue_modules/storage-context.js
+++ b/blue_modules/storage-context.js
@@ -250,6 +250,7 @@ export const BlueStorageProvider = ({ children }) => {
   };
 
   const addWallet = wallet => {
+    if (BlueApp.wallets.some(w => w.getID() === wallet.getID())) return;
     BlueApp.wallets.push(wallet);
     setWallets([...BlueApp.getWallets()]);
   };


### PR DESCRIPTION
Guard BlueStorageContext.addWallet against pushing a wallet whose getID() already exists in BlueApp.wallets. Multisig wallets have a deterministic ID (hash of cosigners + fingerprints), so re-running the create or import flow with the same inputs would otherwise push the same wallet twice and surface as duplicate entries in the wallet carousel. addAndSaveWallet already had this check; addWallet did not.