### PR TITLE
Fix multisig cosigner match rejecting valid seeds on import (#176 bug 2)

### DIFF
--- a/__mocks__/react-native-config.js
+++ b/__mocks__/react-native-config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/class/multisig-cosigner-match.ts
+++ b/class/multisig-cosigner-match.ts
@@ -1,0 +1,44 @@
+import { MultisigHDWallet } from './wallets/multisig-hd-wallet';
+
+/**
+ * DFX-custom helper for the "import multisig" flow: determines whether a seed (mnemonic + optional
+ * BIP39 passphrase) belongs to one of `wallet`'s cosigners, returning its 1-based index, or -1.
+ *
+ * Kept out of MultisigHDWallet (BlueWallet-derived) so that class stays identical to upstream and
+ * doesn't conflict on fork sync. BlueWallet has no equivalent matcher; the check is DFX-specific.
+ *
+ * Matches by master fingerprint first (robust regardless of derivation path, passphrase or xpub
+ * encoding), then falls back to deriving the xpub at each cosigner's own path with the passphrase —
+ * the same derivation BlueWallet uses internally for cosigners.
+ */
+export function findCosignerIndexForSeed(wallet: MultisigHDWallet, mnemonic?: string, passphrase?: string): number {
+  if (!mnemonic) return -1;
+
+  let fingerprint: string | undefined;
+  try {
+    fingerprint = MultisigHDWallet.mnemonicToFingerprint(mnemonic, passphrase as string);
+  } catch {
+    fingerprint = undefined;
+  }
+
+  const cosigners = wallet.getCosigners();
+  for (let index = 1; index <= cosigners.length; index++) {
+    const cosigner = cosigners[index - 1];
+
+    if (fingerprint && wallet.getFingerprint(index) === fingerprint) return index;
+    if (cosigner === mnemonic) return index;
+    if (!MultisigHDWallet.isXpubString(cosigner)) continue;
+
+    const path = wallet.getCustomDerivationPathForCosigner(index);
+    if (!path) continue;
+
+    try {
+      const derivedXpub = MultisigHDWallet.seedToXpub(mnemonic, path, passphrase);
+      if (MultisigHDWallet.zpubToXpub(cosigner) === MultisigHDWallet.zpubToXpub(derivedXpub)) return index;
+    } catch {
+      // not derivable at this cosigner's path; keep looking
+    }
+  }
+
+  return -1;
+}

--- a/screen/selftest.js
+++ b/screen/selftest.js
@@ -15,7 +15,9 @@ import {
   HDSegwitBech32Wallet,
   HDAezeedWallet,
   SLIP39LegacyP2PKHWallet,
+  MultisigHDWallet,
 } from '../class';
+import { findCosignerIndexForSeed } from '../class/multisig-cosigner-match';
 import ecc from '../blue_modules/noble_ecc';
 const bitcoin = require('bitcoinjs-lib');
 const BlueCrypto = require('react-native-blue-crypto');
@@ -186,7 +188,12 @@ export default class Selftest extends Component {
           },
         ];
 
-        const txNew2 = wallet.createTransaction(utxos2, [{ value: 90000, address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }], 1, wallet.getAddress());
+        const txNew2 = wallet.createTransaction(
+          utxos2,
+          [{ value: 90000, address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }],
+          1,
+          wallet.getAddress(),
+        );
         const tx = bitcoin.Transaction.fromHex(txNew2.tx.toHex());
         assertStrictEqual(
           txNew2.tx.toHex(),
@@ -308,15 +315,163 @@ export default class Selftest extends Component {
 
       if (isRN) {
         await step('Linking.canOpenURL(https)', async () => {
-          assertStrictEqual(
-            await Linking.canOpenURL('https://github.com/BlueWallet/BlueWallet/'),
-            true,
-            'Linking can not open https url',
-          );
+          assertStrictEqual(await Linking.canOpenURL('https://github.com/BlueWallet/BlueWallet/'), true, 'Linking can not open https url');
         });
       } else {
         log('- Linking: skipped (not RN)');
       }
+
+      await step('MultisigHDWallet P2WSH (native segwit) 2-of-3 create + fully sign tx', async () => {
+        const { wallet, address, psbt, tx } = buildSignedMultisig('native');
+        assertStrictEqual(address, 'bc1qqxuxfjvqcwyz3anmdptgj3rtas5c0w6h9p0yanqqx2yz0s25ceaqv9m44p', 'multisig native address');
+        assertStrictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2, 'multisig native sig count');
+        assertStrictEqual(!!tx, true, 'multisig native tx not finalized');
+        assertStrictEqual(
+          tx.toHex(),
+          '02000000000101674858a6180c3b8de3ff97c99118a43cc282d18d756b5b53aa8d70d673b52e9300000000000000008002905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac582600000000000022002035fa0b090f91f329cd5d96af493d593d0f454a8e8012526f8dcd5887e297ab0a0400483045022100b46ca1f3b336b0dcdd9304dbae7356de12b41ccd362206578e4fcbeb5976a2380220639b2de612084ca4880412452a8652e05070766b5884497e566b86cf85b98cbf0147304402205674ca71e69475a603b0470abd2b6e9b4715c28ddd44c93664adab033a1c49da022047aa6866fb08d6c68035b3e20d9f12453afaddd683ce3a8c72b02fb33801843001695221027ea237a4bcce5a375de67f7a094f5e9ab4fc466390e8f56658ed1c44488f84c82103d28f7015d5091c6a0dd4d84ff85c59eaf6d8d6795559da446eb2602fade078852103dc1953c2756c7c58d4f48ca1bbba767f414fd236bf4d662b67721ac626c514e053ae00000000',
+          'multisig native tx hex',
+        );
+        const parsed = bitcoin.Transaction.fromHex(tx.toHex());
+        assertStrictEqual(parsed.ins.length, 1, 'multisig native inputs');
+        assertStrictEqual(parsed.outs.length, 2, 'multisig native outputs');
+        assertStrictEqual(
+          bitcoin.address.fromOutputScript(parsed.outs[0].script),
+          '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB',
+          'multisig native recipient',
+        );
+      });
+
+      await step('MultisigHDWallet P2SH-P2WSH (wrapped segwit) 2-of-3 create + fully sign tx', async () => {
+        const { wallet, address, psbt, tx } = buildSignedMultisig('wrapped');
+        assertStrictEqual(address, '3HF9PMvQvRgcjN54XXdLAJf8BF34txtd3t', 'multisig wrapped address');
+        assertStrictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2, 'multisig wrapped sig count');
+        assertStrictEqual(!!tx, true, 'multisig wrapped tx not finalized');
+        assertStrictEqual(
+          tx.toHex(),
+          '02000000000101c1d353f3fd6ae4462a2a577c6a6727569d054d43c39e7ea71e4083d519160ccb00000000232200209ef56844d943322c25447dcfb149070a1b1973b323e75f4f2f386ca54aea5eb50000008002905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac352600000000000017a91415d70ea28b1cc1714e0e18731ce85ecd7e4d31cd870400483045022100896c0b63e70d0bfb5892a244cfb9f7d7d20afe6422cc1ed1bca842f0987f8e9a02207298445a94942fb0a78a9d9cb3c7bea782ce86e3c62da3b146d17064cd15eca4014730440220496cddc837802f1a5a2f22094822d1b90ce9d76b3687e8f325451fe8100204340220565c0d2ea63bfb8737e5d9cdbdb38bd331ec57f8ad05c17dc61bd2664f63f7b90169522102b373a8edcc14f4ba3276635e6c9ac782202aa327e8de8a4618f8063f569324152103abe5ccc0a6ddf20e02e27ca4829a4bcf288849f5d137db19559dd2ab23236dbe2103ad59934d6296d1041357fe385a82b0d55d50fbfd8fad4ea6729b583c9294a21253ae00000000',
+          'multisig wrapped tx hex',
+        );
+        const parsed = bitcoin.Transaction.fromHex(tx.toHex());
+        assertStrictEqual(parsed.ins.length, 1, 'multisig wrapped inputs');
+        assertStrictEqual(parsed.outs.length, 2, 'multisig wrapped outputs');
+        assertStrictEqual(
+          bitcoin.address.fromOutputScript(parsed.outs[0].script),
+          '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB',
+          'multisig wrapped recipient',
+        );
+      });
+
+      await step('MultisigHDWallet P2SH (legacy) 2-of-3 create + fully sign tx', async () => {
+        const { wallet, address, psbt, tx } = buildSignedMultisig('legacy');
+        assertStrictEqual(address, '37xAGrCeryNrNo6hSUxHQM6KqddrpY79vh', 'multisig legacy address');
+        assertStrictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2, 'multisig legacy sig count');
+        assertStrictEqual(!!tx, true, 'multisig legacy tx not finalized');
+        assertStrictEqual(
+          tx.toHex(),
+          '0200000001244e9b60cd50fc2e3d5effa0928928500160eb41439006b7b2a58f7410c9e7b000000000fdfe0000483045022100fe90a753908be0664041f6d097ffae2a06b9fdd857ebc9e8d4265195beecb524022017129a95d83923b8af6554b736b1fd8df45223f31d47f1202541b7f2f483e3550148304502210085970b3703d1f85c1e91ed39040f2a13e9b75c1a3cbadaeaf5891af71dc5b23f022059ae19e8ee187329430664b6be2e69b799ece6cbe87ffe4bc85a2a1450708cf6014c69522102928ce56c258522767df7385d9a5f4beaf599d310f52b510a4cf01c762749bb7a21034c2273445591185bb37ebb08010d53e85c3791e3fa56c1756284fdf17206a0102103bf9331688d29fff59100b437d3bdf4f14a671b1da13ce57d01eb5d109ab5d1c053ae0000008002905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac962500000000000017a914d48975225be4992d7cb576744a72e64b7ad6713e8700000000',
+          'multisig legacy tx hex',
+        );
+        const parsed = bitcoin.Transaction.fromHex(tx.toHex());
+        assertStrictEqual(parsed.ins.length, 1, 'multisig legacy inputs');
+        assertStrictEqual(parsed.outs.length, 2, 'multisig legacy outputs');
+        assertStrictEqual(
+          bitcoin.address.fromOutputScript(parsed.outs[0].script),
+          '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB',
+          'multisig legacy recipient',
+        );
+      });
+
+      await step('MultisigHDWallet 2-of-3 single-device partial sign (1 of 2)', async () => {
+        // realistic case: this device holds only its own seed; the other two cosigners are xpubs.
+        // it can contribute one signature and must hand the PSBT to a second signer to finalize.
+        const w = new MultisigHDWallet();
+        w.setNativeSegwit();
+        w.setDerivationPath(MULTISIG_PATHS.native);
+        w.addCosigner(MULTISIG_SEED_1);
+        w.addCosigner(
+          MultisigHDWallet.seedToXpub(MULTISIG_SEED_2, MULTISIG_PATHS.native),
+          MultisigHDWallet.mnemonicToFingerprint(MULTISIG_SEED_2, ''),
+        );
+        w.addCosigner(
+          MultisigHDWallet.seedToXpub(MULTISIG_SEED_3, MULTISIG_PATHS.native),
+          MultisigHDWallet.mnemonicToFingerprint(MULTISIG_SEED_3, ''),
+        );
+        w.setM(2);
+        assertStrictEqual(
+          w._getExternalAddressByIndex(0),
+          'bc1qqxuxfjvqcwyz3anmdptgj3rtas5c0w6h9p0yanqqx2yz0s25ceaqv9m44p',
+          'multisig partial address',
+        );
+        const { psbt, tx } = fundAndSpendMultisig(w);
+        assertStrictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1, 'multisig partial sig count');
+        assertStrictEqual(psbt.data.inputs[0].partialSig.length, 1, 'multisig partial partialSig');
+        assertStrictEqual(!!tx, false, 'multisig partial must not be finalized');
+        assertStrictEqual(typeof psbt.toBase64(), 'string', 'multisig partial PSBT serializable');
+      });
+
+      await step('MultisigHDWallet export/import round-trip preserves addresses', async () => {
+        const { wallet } = buildSignedMultisig('native');
+        const imported = new MultisigHDWallet();
+        imported.setSecret(wallet.getSecret());
+        assertStrictEqual(imported._getExternalAddressByIndex(0), wallet._getExternalAddressByIndex(0), 'multisig round-trip external');
+        assertStrictEqual(imported._getInternalAddressByIndex(0), wallet._getInternalAddressByIndex(0), 'multisig round-trip internal');
+      });
+
+      await step('MultisigHDWallet 2-of-3 cosigner with BIP39 passphrase -> address', async () => {
+        const w = new MultisigHDWallet();
+        w.setDerivationPath("m/48'/0'/0'/2'");
+        w.addCosigner(
+          'salon smoke bubble dolphin powder govern rival sport better arrest certain manual',
+          undefined,
+          undefined,
+          '9WDdFSZX4d6mPxkr',
+        );
+        w.addCosigner('chaos word void picture gas update shop wave task blossom close inner', undefined, undefined, 'E5jMAzsf464Hgwns');
+        w.addCosigner(
+          'plate inform scissors pill asset scatter people emotion dose primary together expose',
+          undefined,
+          undefined,
+          'RyBFfLr7weK3nDUG',
+        );
+        w.setM(2);
+        assertStrictEqual(
+          w._getExternalAddressByIndex(0),
+          'bc1q8rks34ypj5edxx82f7z7yzy4qy6dynfhcftjs9axzr2ml37p4pfs7j4uvm',
+          'multisig passphrase address',
+        );
+      });
+
+      await step('MultisigHDWallet custom per-cosigner derivation paths -> address', async () => {
+        const secret =
+          '# CoboVault Multisig setup file (created on D37EAD88)\n#\nName: CV_33B5B91A_2-2\nPolicy: 2 of 2\nFormat: P2WSH\n\n' +
+          "# derivation: m/47'/0'/0'/1'\n" +
+          'D37EAD88: Zpub74ijpfhERJNjhCKXRspTdLJV5eoEmSRZdHqDvp9kVtdVEyiXk7pXxRbfZzQvsDFpfDHEHVtVpx4Dz9DGUWGn2Xk5zG5u45QTMsYS2vjohNQ\n\n' +
+          "# derivation: m/46'/0'/0'/1'\n" +
+          '168DD603: Zpub75mAE8EjyxSzoyPmGnd5E6MyD7ALGNndruWv52xpzimZQKukwvEfXTHqmH8nbbc6ccP5t2aM3mws3pKYSnKpKMMytdbNEZFUxKzztYFM8Pn\n';
+        const w = new MultisigHDWallet();
+        w.setSecret(secret);
+        assertStrictEqual(w.getCustomDerivationPathForCosigner(1), "m/47'/0'/0'/1'", 'multisig custom path 1');
+        assertStrictEqual(w.getCustomDerivationPathForCosigner(2), "m/46'/0'/0'/1'", 'multisig custom path 2');
+        assertStrictEqual(
+          w._getExternalAddressByIndex(0),
+          'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85',
+          'multisig custom-path address',
+        );
+      });
+
+      await step('Multisig cosigner match: own seed recognised in xpub-only config', async () => {
+        const source = buildSignedMultisig('native').wallet;
+        const config = new MultisigHDWallet();
+        config.setSecret(source.getXpub()); // public coordination setup, no private keys
+        assertStrictEqual(findCosignerIndexForSeed(config, MULTISIG_SEED_1), 1, 'cosigner match seed 1');
+        assertStrictEqual(findCosignerIndexForSeed(config, MULTISIG_SEED_2), 2, 'cosigner match seed 2');
+        assertStrictEqual(findCosignerIndexForSeed(config, MULTISIG_SEED_3), 3, 'cosigner match seed 3');
+        assertStrictEqual(
+          findCosignerIndexForSeed(config, 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art'),
+          -1,
+          'cosigner match rejects stranger',
+        );
+      });
 
       log(`all tests passed in ${Date.now() - tStart}ms`);
     } catch (Err) {
@@ -402,6 +557,50 @@ export default class Selftest extends Component {
       </SafeBlueArea>
     );
   }
+}
+
+const MULTISIG_SEED_1 = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const MULTISIG_SEED_2 = 'chaos word void picture gas update shop wave task blossom close inner';
+const MULTISIG_SEED_3 = 'plate inform scissors pill asset scatter people emotion dose primary together expose';
+const MULTISIG_PATHS = { native: "m/48'/0'/0'/2'", wrapped: "m/48'/0'/0'/1'", legacy: "m/45'" };
+
+function setMultisigFormat(w, kind) {
+  if (kind === 'native') w.setNativeSegwit();
+  else if (kind === 'wrapped') w.setWrappedSegwit();
+  else w.setLegacy();
+}
+
+// funds a multisig wallet with a synthetic prev-tx and spends it (so signing needs no network)
+function fundAndSpendMultisig(w) {
+  const address = w._getExternalAddressByIndex(0);
+  const funding = new bitcoin.Transaction();
+  funding.addInput(Buffer.from('00'.repeat(32), 'hex'), 0);
+  funding.addOutput(bitcoin.address.toOutputScript(address, bitcoin.networks.bitcoin), 100000);
+  const utxos = [{ txId: funding.getId(), txid: funding.getId(), vout: 0, value: 100000, address, txhex: funding.toHex() }];
+  const { psbt, tx } = w.createTransaction(
+    utxos,
+    [{ address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', value: 90000 }],
+    1,
+    w._getInternalAddressByIndex(0),
+    false,
+    false,
+  );
+  return { address, psbt, tx };
+}
+
+// 2-of-3 (the wallet's default policy) holding 2 seeds + 1 watch-only cosigner -> fully signs
+function buildSignedMultisig(kind) {
+  const w = new MultisigHDWallet();
+  setMultisigFormat(w, kind);
+  w.setDerivationPath(MULTISIG_PATHS[kind]); // must precede addCosigner() for seed cosigners
+  w.addCosigner(MULTISIG_SEED_1);
+  w.addCosigner(MULTISIG_SEED_2);
+  w.addCosigner(
+    MultisigHDWallet.seedToXpub(MULTISIG_SEED_3, MULTISIG_PATHS[kind]),
+    MultisigHDWallet.mnemonicToFingerprint(MULTISIG_SEED_3, ''),
+  );
+  w.setM(2);
+  return { wallet: w, ...fundAndSpendMultisig(w) };
 }
 
 function assertStrictEqual(actual, expected, message) {

--- a/screen/wallets/importMultisignature.tsx
+++ b/screen/wallets/importMultisignature.tsx
@@ -13,6 +13,7 @@ import { useWalletContext } from '../../contexts/wallet.context';
 import loc from '../../loc';
 import { ManualTextModal } from '../../components/ManualTextModal';
 import { MultisigHDWallet } from '../../class/wallets/multisig-hd-wallet';
+import { findCosignerIndexForSeed } from '../../class/multisig-cosigner-match';
 
 const ImportMultisignature: React.FC = () => {
   const { addWallet, saveToDisk, isElectrumDisabled } = useContext(BlueStorageContext);
@@ -46,16 +47,18 @@ const ImportMultisignature: React.FC = () => {
       setQuorum(multisigWallet.getN());
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      const derivationPath = multisigWallet.getDerivationPath();
-      const ownXpub = multisigWallet.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(mainWallet?.getSecret(), derivationPath));
-      const ownZpub = MultisigHDWallet.xpubToZpub(ownXpub);
-      const ownXpubFromZpub = MultisigHDWallet.zpubToXpub(ownZpub);
-      const isPartOfMultisig = multisigWallet.getCosigners().some(cosigner => cosigner === ownXpub || cosigner === ownZpub || cosigner === ownXpubFromZpub || cosigner === mainWallet?.getSecret());
-      if (!isPartOfMultisig) throw new Error(loc.multisig.not_part_of_multisig);
+      const ownSeed = mainWallet?.getSecret();
+      const ownPassphrase = (mainWallet as { getPassphrase?: () => string } | undefined)?.getPassphrase?.();
+      const ownCosignerIndex = findCosignerIndexForSeed(multisigWallet, ownSeed, ownPassphrase); // 1-based, or -1
+      if (ownCosignerIndex === -1) throw new Error(loc.multisig.not_part_of_multisig);
 
       multisigWallet.getCosigners().forEach((cosigner, index) => {
-        if (cosigner === mainWallet?.getSecret()) return;
-        if (cosigner === ownXpub || cosigner === ownZpub || cosigner === ownXpubFromZpub) return multisigWallet.replaceCosignerXpubWithSeed(index + 1, mainWallet?.getSecret() as string, '');
+        if (cosigner === ownSeed) return;
+        if (index + 1 === ownCosignerIndex) {
+          if (MultisigHDWallet.isXpubString(cosigner))
+            multisigWallet.replaceCosignerXpubWithSeed(ownCosignerIndex, ownSeed as string, ownPassphrase || '');
+          return;
+        }
         if (MultisigHDWallet.isXpubForMultisig(cosigner)) return;
         // Then it should be a seed? try to replace it
         multisigWallet.replaceCosignerSeedWithXpub(index + 1);

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { MultisigHDWallet } from '../../class/';
 import { BlueURDecoder, decodeUR, encodeUR } from '../../blue_modules/ur';
 import { MultisigCosigner } from '../../class/multisig-cosigner';
+import { findCosignerIndexForSeed } from '../../class/multisig-cosigner-match';
 const bitcoin = require('bitcoinjs-lib');
 const Base43 = require('../../blue_modules/base43');
 
@@ -2286,5 +2287,79 @@ describe('multisig-cosigner', () => {
     assert.deepStrictEqual(result, [
       'ur:crypto-account/oeadcywehhhpleaolytaadmhtaaddloxaxhdclaoamutctbahthnislelbwemnkeoefnhddienfetbpygrpaqdkemyrywyldaspyjkdtaahdcxhyneskwdhlehlfbwrpdnjlgsgakplkjtknvyttsgolnnlbwlcagoolcpfgsglkinamtaaddyotadlfcsdpykaocywehhhpleaxadaycywehhhplekpdwveih',
     ]);
+  });
+});
+
+describe('multisig cosigner matching for import (issue #176)', () => {
+  const path = "m/48'/0'/0'/2'";
+  const customPath = "m/48'/0'/1'/2'";
+  const seedA = 'salon smoke bubble dolphin powder govern rival sport better arrest certain manual';
+  const seedB = 'chaos word void picture gas update shop wave task blossom close inner';
+  const passA = '9WDdFSZX4d6mPxkr';
+  const strangerSeed = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+  // builds the public, xpub-only config a customer re-imports on a new phone
+  const buildConfig = ({ withPassphrase = false, derivation = path } = {}) => {
+    const source = new MultisigHDWallet();
+    source.setDerivationPath(derivation);
+    source.addCosigner(seedA, undefined, undefined, withPassphrase ? passA : undefined);
+    source.addCosigner(seedB);
+    source.setM(2);
+    const config = new MultisigHDWallet();
+    config.setSecret(source.getXpub()); // coordination setup contains only public keys
+    return config;
+  };
+
+  it('matches a standard cosigner seed and rejects a non-cosigner (scenario 1)', () => {
+    const w = buildConfig();
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedB, undefined), 2);
+    assert.strictEqual(findCosignerIndexForSeed(w, strangerSeed, undefined), -1);
+  });
+
+  it('matches a cosigner whose seed uses a BIP39 passphrase (scenario 2)', () => {
+    const w = buildConfig({ withPassphrase: true });
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, passA), 1);
+    // the historic bug: matching without (or with the wrong) passphrase must NOT succeed
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), -1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, 'wrong-passphrase'), -1);
+  });
+
+  it('matches cosigners registered at different per-cosigner derivation paths (scenario 3)', () => {
+    const w = new MultisigHDWallet();
+    w.setNativeSegwit();
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedA, customPath), MultisigHDWallet.mnemonicToFingerprint(seedA, ''), customPath);
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedB, path), MultisigHDWallet.mnemonicToFingerprint(seedB, ''), path);
+    w.setM(2);
+    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), customPath);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedB, undefined), 2);
+  });
+
+  it('falls back to per-cosigner xpub derivation when no fingerprint is available', () => {
+    // a config whose fingerprints are unknown ('00000000'): fingerprint match cannot work, so
+    // matching must rely on deriving the xpub at each cosigner's own path
+    const w = new MultisigHDWallet();
+    w.setNativeSegwit();
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedA, customPath), '00000000', customPath);
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedB, path), '00000000', path);
+    w.setM(2);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedB, undefined), 2);
+    assert.strictEqual(findCosignerIndexForSeed(w, strangerSeed, undefined), -1);
+  });
+
+  it('matches a cosigner from a sortedmulti() descriptor (empty global path, per-cosigner paths)', () => {
+    const config = buildConfig();
+    const x1 = config.getCosigner(1);
+    const x2 = config.getCosigner(2);
+    const f1 = config.getFingerprint(1);
+    const f2 = config.getFingerprint(2);
+    const descriptor = 'wsh(sortedmulti(2,[' + f1 + '/48h/0h/0h/2h]' + x1 + '/0/*,[' + f2 + '/48h/0h/0h/2h]' + x2 + '/0/*))';
+    const w = new MultisigHDWallet();
+    assert.doesNotThrow(() => w.setSecret(descriptor));
+    assert.strictEqual(w.getN(), 2);
+    assert.strictEqual(w.getDerivationPath(), ''); // descriptors keep an empty global path (as upstream); per-cosigner paths are authoritative
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
   });
 });


### PR DESCRIPTION
Addresses **issue #176 — bug 2** ("Wallet is not part of the multi-sig config").

## Problem

When a multi-sig customer re-imports their config on a new phone, the cosigner check rejects their seed with **"Your wallet is not part of this multisig setup"** (`loc.multisig.not_part_of_multisig`).

The check in `importMultisignature.tsx` recomputed the seed's xpub **one specific way** — at the wallet-global derivation path, **without the BIP39 passphrase** — then string-compared. It breaks whenever the real cosigner key was produced any other legitimate way.

Reproduced off-device against the repo's real bip32/bip39:

| Scenario | Old result |
|---|---|
| Standard seed, no passphrase, standard path | ✅ match |
| Seed uses a **BIP39 passphrase** (passphrase never passed) | ❌ "not part of" |
| Cosigner at a **per-cosigner / non-zero account path** (global path used) | ❌ "not part of" |
| `wsh(sortedmulti(...))` **descriptor** (global path stays `''`) | ❌ throws `Expected BIP32Path` |

This is a false rejection — the customer's backup is valid; nothing is lost. With the fix they re-import the same config and it works.

## Fix

- **`class/multisig-cosigner-match.ts`** (new, DFX-owned): `findCosignerIndexForSeed(wallet, mnemonic, passphrase)` matches by **master fingerprint** first (robust regardless of path/passphrase/encoding), then falls back to deriving the xpub at **each cosigner's own path** with the passphrase — the same derivation BlueWallet uses internally. Kept **out** of `MultisigHDWallet` so that BlueWallet-derived class stays byte-identical to upstream and doesn't conflict on fork sync.
- Import screen uses the helper and passes the wallet's **actual passphrase** into `replaceCosignerXpubWithSeed` (was hardcoded `''`).
- 5 regression tests covering all scenarios above.
- Add `__mocks__/react-native-config.js` — the `react-native-config` import added in #171 had no jest mock, which broke unit-suite loading.

## Why no change to `multisig-hd-wallet.js`

Checked the BlueWallet upstream source: it has **no** seed→cosigner matcher (this check is DFX-specific), and its `sortedmulti()` parser **intentionally** leaves the global derivation path empty — per-cosigner paths are authoritative everywhere downstream. So the descriptor "throw" only came from the DFX *screen* deriving at the bare global path; matching via per-cosigner paths (as upstream does) removes it **without** touching shared parsing. No back-fill, no shared-class edit.

## Tests

`multisig-hd-wallet` unit suite green (16/16, incl. 5 new). New helper has no tsc/eslint/prettier findings; no new errors vs. baseline elsewhere.
