### PR TITLE
Multisig: fix cosigner match on import (#176 bug 2) + self-test diagnostics

### DIFF
--- a/__mocks__/react-native-config.js
+++ b/__mocks__/react-native-config.js
@@ -1,0 +1,1 @@
+export default {};

--- a/class/multisig-cosigner-match.ts
+++ b/class/multisig-cosigner-match.ts
@@ -1,0 +1,44 @@
+import { MultisigHDWallet } from './wallets/multisig-hd-wallet';
+
+/**
+ * DFX-custom helper for the "import multisig" flow: determines whether a seed (mnemonic + optional
+ * BIP39 passphrase) belongs to one of `wallet`'s cosigners, returning its 1-based index, or -1.
+ *
+ * Kept out of MultisigHDWallet (BlueWallet-derived) so that class stays identical to upstream and
+ * doesn't conflict on fork sync. BlueWallet has no equivalent matcher; the check is DFX-specific.
+ *
+ * Matches by master fingerprint first (robust regardless of derivation path, passphrase or xpub
+ * encoding), then falls back to deriving the xpub at each cosigner's own path with the passphrase —
+ * the same derivation BlueWallet uses internally for cosigners.
+ */
+export function findCosignerIndexForSeed(wallet: MultisigHDWallet, mnemonic?: string, passphrase?: string): number {
+  if (!mnemonic) return -1;
+
+  let fingerprint: string | undefined;
+  try {
+    fingerprint = MultisigHDWallet.mnemonicToFingerprint(mnemonic, passphrase as string);
+  } catch {
+    fingerprint = undefined;
+  }
+
+  const cosigners = wallet.getCosigners();
+  for (let index = 1; index <= cosigners.length; index++) {
+    const cosigner = cosigners[index - 1];
+
+    if (fingerprint && wallet.getFingerprint(index) === fingerprint) return index;
+    if (cosigner === mnemonic) return index;
+    if (!MultisigHDWallet.isXpubString(cosigner)) continue;
+
+    const path = wallet.getCustomDerivationPathForCosigner(index);
+    if (!path) continue;
+
+    try {
+      const derivedXpub = MultisigHDWallet.seedToXpub(mnemonic, path, passphrase);
+      if (MultisigHDWallet.zpubToXpub(cosigner) === MultisigHDWallet.zpubToXpub(derivedXpub)) return index;
+    } catch {
+      // not derivable at this cosigner's path; keep looking
+    }
+  }
+
+  return -1;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "detox": "^20.25.0",
         "ecpair": "2.0.1",
         "ecurve": "1.0.6",
-        "electrum-client": "github:BtcTaroWallet/rn-electrum-client#3fd8ac4",
+        "electrum-client": "github:BtcTaroWallet/rn-electrum-client#cba3cc36f874899becfdaf319fd8684532204699",
         "electrum-mnemonic": "2.0.0",
         "events": "3.3.0",
         "junderw-crc32c": "1.2.0",
@@ -8375,7 +8375,8 @@
     },
     "node_modules/electrum-client": {
       "version": "3.1.1",
-      "resolved": "git+ssh://git@github.com/BtcTaroWallet/rn-electrum-client.git#3fd8ac4438d42a2e341f1da00578d8f426270a00",
+      "resolved": "git+ssh://git@github.com/BtcTaroWallet/rn-electrum-client.git#cba3cc36f874899becfdaf319fd8684532204699",
+      "integrity": "sha512-tQtTDbYKF/nlYDrHKf2phRQVazyUOohPIJDuCsJIWsVNRM/Edgi9bnC9bZuDEqvnEbP3VxPJd0a1M/LfYOQINg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
     "detox": "^20.25.0",
     "ecpair": "2.0.1",
     "ecurve": "1.0.6",
-    "electrum-client": "github:BtcTaroWallet/rn-electrum-client#3fd8ac4",
+    "electrum-client": "github:BtcTaroWallet/rn-electrum-client#cba3cc36f874899becfdaf319fd8684532204699",
     "electrum-mnemonic": "2.0.0",
     "events": "3.3.0",
     "junderw-crc32c": "1.2.0",

--- a/screen/selftest.js
+++ b/screen/selftest.js
@@ -473,6 +473,48 @@ export default class Selftest extends Component {
         );
       });
 
+      await step('Multisig real wallet: import coordination setup + reconstruct & sign the actual on-chain withdrawal', async () => {
+        const w = new MultisigHDWallet();
+        w.setSecret(REAL_MULTISIG_COORD);
+        assertStrictEqual(w.getM() + '/' + w.getN(), '2/3', 'real multisig policy');
+        // the throwaway seed is cosigner 3 of this vault
+        assertStrictEqual(findCosignerIndexForSeed(w, REAL_MULTISIG_SEED), 3, 'real wallet cosigner index');
+        assertStrictEqual(w.getFingerprint(3), '3D0C4290', 'real wallet cosigner fingerprint');
+        // the wallet derives the address the deposit actually paid to
+        assertStrictEqual(w._getExternalAddressByIndex(0), REAL_DEPOSIT.address, 'real wallet deposit address');
+
+        // load our seed and rebuild the exact withdrawal that was broadcast
+        w.replaceCosignerXpubWithSeed(3, REAL_MULTISIG_SEED, '');
+        const { psbt } = w.createTransaction(
+          [REAL_DEPOSIT],
+          [{ address: REAL_WITHDRAW_DEST, value: 43662 }],
+          2,
+          w._getInternalAddressByIndex(0),
+          0xffffffff,
+          true, // skip signing; we cosign below
+        );
+        const unsigned = bitcoin.Transaction.fromBuffer(psbt.data.globalMap.unsignedTx.toBuffer());
+        assertStrictEqual(unsigned.getId(), REAL_WITHDRAW_TXID, 'reconstructed withdrawal must match the broadcast txid');
+
+        // sign as cosigner 3 and confirm it reproduces the real on-chain signature
+        w.cosignPsbt(psbt);
+        const partialSig = psbt.data.inputs[0].partialSig || [];
+        assertStrictEqual(partialSig.length, 1, 'one signature (2-of-3, single device)');
+        assertStrictEqual(partialSig[0].signature.toString('hex'), REAL_WITHDRAW_SIG, 'reproduces the real cosigner-3 signature');
+      });
+
+      if (isRN) {
+        await step('Multisig real wallet: Electrum sees the on-chain withdrawal', async () => {
+          await BlueElectrum.waitTillConnected();
+          // confirmed tx -> stays in history forever even though the wallet is now empty (drift-proof)
+          const txs = await BlueElectrum.getTransactionsByAddress(REAL_DEPOSIT.address);
+          const found = txs.some(t => t.tx_hash === REAL_WITHDRAW_TXID);
+          if (!found) throw new Error('withdrawal tx not found in multisig address history');
+        });
+      } else {
+        log('- Multisig Electrum history: skipped (not RN)');
+      }
+
       log(`all tests passed in ${Date.now() - tStart}ms`);
     } catch (Err) {
       errorMessage += Err;
@@ -563,6 +605,27 @@ const MULTISIG_SEED_1 = 'abandon abandon abandon abandon abandon abandon abandon
 const MULTISIG_SEED_2 = 'chaos word void picture gas update shop wave task blossom close inner';
 const MULTISIG_SEED_3 = 'plate inform scissors pill asset scatter people emotion dose primary together expose';
 const MULTISIG_PATHS = { native: "m/48'/0'/0'/2'", wrapped: "m/48'/0'/0'/1'", legacy: "m/45'" };
+
+// --- Real (throwaway) multisig used by the on-chain diagnostics below. ---
+// These keys are committed ON PURPOSE: the wallet is a 2-of-3 burner that was funded once,
+// emptied, and must NEVER be funded again. Do not treat the seed below as a real secret.
+const REAL_MULTISIG_SEED = 'sand tone actor sell tone rough install divert decrease assist erode rice'; // cosigner 3 (fp 3D0C4290)
+const REAL_MULTISIG_COORD =
+  "# BlueWallet Multisig setup file\n# this file contains only public keys and is safe to\n# distribute among cosigners\n#\nName: Multisig Vault\nPolicy: 2 of 3\nDerivation: m/48'/0'/0'/2'\nFormat: P2WSH\n\nC20EF17C: xpub6EddsFof5PpmSjPrUkSBGPFD8JdFcLL5jV9J2TgRzHtdTFR47eZn4bAKUQviqZv2RqBKPyYX78zLXrWWE8UkGmL8UyZJS7rn2CGqViMjQQi\n\n426222B6: Zpub74dh4k2u2m27KG5x7Dw3KCJen7f1NRa4ikofK13u8k8Sos7pru1aZSkZSr7TyYQBHn6orV4cqvLbcQ7BQdFUJEKTsCYmoeb6uFc4sTeFgUY\n\n3D0C4290: Zpub74s3GBiqviXUzq2WFueBSVgWPLHNNvTbeed8rzwZMewpcvmUtAPNv84gMJPgGStCL3pyLGqoaH1CpbS4MhXNLNwTgEWPhgmryF1NQg3CJBn\n\n";
+const REAL_DEPOSIT = {
+  txId: 'a817cc0da4c0edce6c4fcdd7d94acf741aaa439dc5b54d1c84099c4ec0d9e1e9',
+  txid: 'a817cc0da4c0edce6c4fcdd7d94acf741aaa439dc5b54d1c84099c4ec0d9e1e9',
+  vout: 0,
+  value: 44112,
+  address: 'bc1qgv72gjdadr9rmf5fxwdagpqczxv089a8ykjy9tuuq40kc4x94w6s7d73am', // external[0]
+  txhex:
+    '02000000000101993fc3a83e6597b6c032ecc86e81d2c5edaec2d803b86c0fdbadc57e2341c6e20100000000fdffffff0150ac000000000000220020433ca449bd68ca3da689339bd404181198f397a725a442af9c055f6c54c5abb50140fb95c93998aeb9e85c86802d509799bac1fddf03f19c85d262a3883b2f61688b9b11e849f3410c324f96ad17f2195657dd66fae876fc76cb6bc471db0d1f70f900000000',
+};
+const REAL_WITHDRAW_DEST = 'bc1q00etgmkyxp4tvw7hham0hzh80hex2hyl2f5nv88hmffd0qx7lkjspm8aln';
+const REAL_WITHDRAW_TXID = '441f7d6d3c9dd71d5c005ccdf5bad272cd858bff63057b2f7985be3faf756575';
+// cosigner 3's real signature in the broadcast witness for the input above
+const REAL_WITHDRAW_SIG =
+  '3045022100f815bee168ad1407a7ec03bbcde53bbfbb0e92cc4b9f1fffb173266ebddd1da2022052f9fcd687dd71a234553bf20a287c263ce0ff9e1e957fc05a9374ee70d8fa5401';
 
 function setMultisigFormat(w, kind) {
   if (kind === 'native') w.setNativeSegwit();

--- a/screen/selftest.js
+++ b/screen/selftest.js
@@ -15,7 +15,9 @@ import {
   HDSegwitBech32Wallet,
   HDAezeedWallet,
   SLIP39LegacyP2PKHWallet,
+  MultisigHDWallet,
 } from '../class';
+import { findCosignerIndexForSeed } from '../class/multisig-cosigner-match';
 import ecc from '../blue_modules/noble_ecc';
 const bitcoin = require('bitcoinjs-lib');
 const BlueCrypto = require('react-native-blue-crypto');
@@ -186,7 +188,12 @@ export default class Selftest extends Component {
           },
         ];
 
-        const txNew2 = wallet.createTransaction(utxos2, [{ value: 90000, address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }], 1, wallet.getAddress());
+        const txNew2 = wallet.createTransaction(
+          utxos2,
+          [{ value: 90000, address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB' }],
+          1,
+          wallet.getAddress(),
+        );
         const tx = bitcoin.Transaction.fromHex(txNew2.tx.toHex());
         assertStrictEqual(
           txNew2.tx.toHex(),
@@ -308,15 +315,163 @@ export default class Selftest extends Component {
 
       if (isRN) {
         await step('Linking.canOpenURL(https)', async () => {
-          assertStrictEqual(
-            await Linking.canOpenURL('https://github.com/BlueWallet/BlueWallet/'),
-            true,
-            'Linking can not open https url',
-          );
+          assertStrictEqual(await Linking.canOpenURL('https://github.com/BlueWallet/BlueWallet/'), true, 'Linking can not open https url');
         });
       } else {
         log('- Linking: skipped (not RN)');
       }
+
+      await step('MultisigHDWallet P2WSH (native segwit) 2-of-3 create + fully sign tx', async () => {
+        const { wallet, address, psbt, tx } = buildSignedMultisig('native');
+        assertStrictEqual(address, 'bc1qqxuxfjvqcwyz3anmdptgj3rtas5c0w6h9p0yanqqx2yz0s25ceaqv9m44p', 'multisig native address');
+        assertStrictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2, 'multisig native sig count');
+        assertStrictEqual(!!tx, true, 'multisig native tx not finalized');
+        assertStrictEqual(
+          tx.toHex(),
+          '02000000000101674858a6180c3b8de3ff97c99118a43cc282d18d756b5b53aa8d70d673b52e9300000000000000008002905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac582600000000000022002035fa0b090f91f329cd5d96af493d593d0f454a8e8012526f8dcd5887e297ab0a0400483045022100b46ca1f3b336b0dcdd9304dbae7356de12b41ccd362206578e4fcbeb5976a2380220639b2de612084ca4880412452a8652e05070766b5884497e566b86cf85b98cbf0147304402205674ca71e69475a603b0470abd2b6e9b4715c28ddd44c93664adab033a1c49da022047aa6866fb08d6c68035b3e20d9f12453afaddd683ce3a8c72b02fb33801843001695221027ea237a4bcce5a375de67f7a094f5e9ab4fc466390e8f56658ed1c44488f84c82103d28f7015d5091c6a0dd4d84ff85c59eaf6d8d6795559da446eb2602fade078852103dc1953c2756c7c58d4f48ca1bbba767f414fd236bf4d662b67721ac626c514e053ae00000000',
+          'multisig native tx hex',
+        );
+        const parsed = bitcoin.Transaction.fromHex(tx.toHex());
+        assertStrictEqual(parsed.ins.length, 1, 'multisig native inputs');
+        assertStrictEqual(parsed.outs.length, 2, 'multisig native outputs');
+        assertStrictEqual(
+          bitcoin.address.fromOutputScript(parsed.outs[0].script),
+          '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB',
+          'multisig native recipient',
+        );
+      });
+
+      await step('MultisigHDWallet P2SH-P2WSH (wrapped segwit) 2-of-3 create + fully sign tx', async () => {
+        const { wallet, address, psbt, tx } = buildSignedMultisig('wrapped');
+        assertStrictEqual(address, '3HF9PMvQvRgcjN54XXdLAJf8BF34txtd3t', 'multisig wrapped address');
+        assertStrictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2, 'multisig wrapped sig count');
+        assertStrictEqual(!!tx, true, 'multisig wrapped tx not finalized');
+        assertStrictEqual(
+          tx.toHex(),
+          '02000000000101c1d353f3fd6ae4462a2a577c6a6727569d054d43c39e7ea71e4083d519160ccb00000000232200209ef56844d943322c25447dcfb149070a1b1973b323e75f4f2f386ca54aea5eb50000008002905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac352600000000000017a91415d70ea28b1cc1714e0e18731ce85ecd7e4d31cd870400483045022100896c0b63e70d0bfb5892a244cfb9f7d7d20afe6422cc1ed1bca842f0987f8e9a02207298445a94942fb0a78a9d9cb3c7bea782ce86e3c62da3b146d17064cd15eca4014730440220496cddc837802f1a5a2f22094822d1b90ce9d76b3687e8f325451fe8100204340220565c0d2ea63bfb8737e5d9cdbdb38bd331ec57f8ad05c17dc61bd2664f63f7b90169522102b373a8edcc14f4ba3276635e6c9ac782202aa327e8de8a4618f8063f569324152103abe5ccc0a6ddf20e02e27ca4829a4bcf288849f5d137db19559dd2ab23236dbe2103ad59934d6296d1041357fe385a82b0d55d50fbfd8fad4ea6729b583c9294a21253ae00000000',
+          'multisig wrapped tx hex',
+        );
+        const parsed = bitcoin.Transaction.fromHex(tx.toHex());
+        assertStrictEqual(parsed.ins.length, 1, 'multisig wrapped inputs');
+        assertStrictEqual(parsed.outs.length, 2, 'multisig wrapped outputs');
+        assertStrictEqual(
+          bitcoin.address.fromOutputScript(parsed.outs[0].script),
+          '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB',
+          'multisig wrapped recipient',
+        );
+      });
+
+      await step('MultisigHDWallet P2SH (legacy) 2-of-3 create + fully sign tx', async () => {
+        const { wallet, address, psbt, tx } = buildSignedMultisig('legacy');
+        assertStrictEqual(address, '37xAGrCeryNrNo6hSUxHQM6KqddrpY79vh', 'multisig legacy address');
+        assertStrictEqual(wallet.calculateHowManySignaturesWeHaveFromPsbt(psbt), 2, 'multisig legacy sig count');
+        assertStrictEqual(!!tx, true, 'multisig legacy tx not finalized');
+        assertStrictEqual(
+          tx.toHex(),
+          '0200000001244e9b60cd50fc2e3d5effa0928928500160eb41439006b7b2a58f7410c9e7b000000000fdfe0000483045022100fe90a753908be0664041f6d097ffae2a06b9fdd857ebc9e8d4265195beecb524022017129a95d83923b8af6554b736b1fd8df45223f31d47f1202541b7f2f483e3550148304502210085970b3703d1f85c1e91ed39040f2a13e9b75c1a3cbadaeaf5891af71dc5b23f022059ae19e8ee187329430664b6be2e69b799ece6cbe87ffe4bc85a2a1450708cf6014c69522102928ce56c258522767df7385d9a5f4beaf599d310f52b510a4cf01c762749bb7a21034c2273445591185bb37ebb08010d53e85c3791e3fa56c1756284fdf17206a0102103bf9331688d29fff59100b437d3bdf4f14a671b1da13ce57d01eb5d109ab5d1c053ae0000008002905f0100000000001976a914aa381cd428a4e91327fd4434aa0a08ff131f1a5a88ac962500000000000017a914d48975225be4992d7cb576744a72e64b7ad6713e8700000000',
+          'multisig legacy tx hex',
+        );
+        const parsed = bitcoin.Transaction.fromHex(tx.toHex());
+        assertStrictEqual(parsed.ins.length, 1, 'multisig legacy inputs');
+        assertStrictEqual(parsed.outs.length, 2, 'multisig legacy outputs');
+        assertStrictEqual(
+          bitcoin.address.fromOutputScript(parsed.outs[0].script),
+          '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB',
+          'multisig legacy recipient',
+        );
+      });
+
+      await step('MultisigHDWallet 2-of-3 single-device partial sign (1 of 2)', async () => {
+        // realistic case: this device holds only its own seed; the other two cosigners are xpubs.
+        // it can contribute one signature and must hand the PSBT to a second signer to finalize.
+        const w = new MultisigHDWallet();
+        w.setNativeSegwit();
+        w.setDerivationPath(MULTISIG_PATHS.native);
+        w.addCosigner(MULTISIG_SEED_1);
+        w.addCosigner(
+          MultisigHDWallet.seedToXpub(MULTISIG_SEED_2, MULTISIG_PATHS.native),
+          MultisigHDWallet.mnemonicToFingerprint(MULTISIG_SEED_2, ''),
+        );
+        w.addCosigner(
+          MultisigHDWallet.seedToXpub(MULTISIG_SEED_3, MULTISIG_PATHS.native),
+          MultisigHDWallet.mnemonicToFingerprint(MULTISIG_SEED_3, ''),
+        );
+        w.setM(2);
+        assertStrictEqual(
+          w._getExternalAddressByIndex(0),
+          'bc1qqxuxfjvqcwyz3anmdptgj3rtas5c0w6h9p0yanqqx2yz0s25ceaqv9m44p',
+          'multisig partial address',
+        );
+        const { psbt, tx } = fundAndSpendMultisig(w);
+        assertStrictEqual(w.calculateHowManySignaturesWeHaveFromPsbt(psbt), 1, 'multisig partial sig count');
+        assertStrictEqual(psbt.data.inputs[0].partialSig.length, 1, 'multisig partial partialSig');
+        assertStrictEqual(!!tx, false, 'multisig partial must not be finalized');
+        assertStrictEqual(typeof psbt.toBase64(), 'string', 'multisig partial PSBT serializable');
+      });
+
+      await step('MultisigHDWallet export/import round-trip preserves addresses', async () => {
+        const { wallet } = buildSignedMultisig('native');
+        const imported = new MultisigHDWallet();
+        imported.setSecret(wallet.getSecret());
+        assertStrictEqual(imported._getExternalAddressByIndex(0), wallet._getExternalAddressByIndex(0), 'multisig round-trip external');
+        assertStrictEqual(imported._getInternalAddressByIndex(0), wallet._getInternalAddressByIndex(0), 'multisig round-trip internal');
+      });
+
+      await step('MultisigHDWallet 2-of-3 cosigner with BIP39 passphrase -> address', async () => {
+        const w = new MultisigHDWallet();
+        w.setDerivationPath("m/48'/0'/0'/2'");
+        w.addCosigner(
+          'salon smoke bubble dolphin powder govern rival sport better arrest certain manual',
+          undefined,
+          undefined,
+          '9WDdFSZX4d6mPxkr',
+        );
+        w.addCosigner('chaos word void picture gas update shop wave task blossom close inner', undefined, undefined, 'E5jMAzsf464Hgwns');
+        w.addCosigner(
+          'plate inform scissors pill asset scatter people emotion dose primary together expose',
+          undefined,
+          undefined,
+          'RyBFfLr7weK3nDUG',
+        );
+        w.setM(2);
+        assertStrictEqual(
+          w._getExternalAddressByIndex(0),
+          'bc1q8rks34ypj5edxx82f7z7yzy4qy6dynfhcftjs9axzr2ml37p4pfs7j4uvm',
+          'multisig passphrase address',
+        );
+      });
+
+      await step('MultisigHDWallet custom per-cosigner derivation paths -> address', async () => {
+        const secret =
+          '# CoboVault Multisig setup file (created on D37EAD88)\n#\nName: CV_33B5B91A_2-2\nPolicy: 2 of 2\nFormat: P2WSH\n\n' +
+          "# derivation: m/47'/0'/0'/1'\n" +
+          'D37EAD88: Zpub74ijpfhERJNjhCKXRspTdLJV5eoEmSRZdHqDvp9kVtdVEyiXk7pXxRbfZzQvsDFpfDHEHVtVpx4Dz9DGUWGn2Xk5zG5u45QTMsYS2vjohNQ\n\n' +
+          "# derivation: m/46'/0'/0'/1'\n" +
+          '168DD603: Zpub75mAE8EjyxSzoyPmGnd5E6MyD7ALGNndruWv52xpzimZQKukwvEfXTHqmH8nbbc6ccP5t2aM3mws3pKYSnKpKMMytdbNEZFUxKzztYFM8Pn\n';
+        const w = new MultisigHDWallet();
+        w.setSecret(secret);
+        assertStrictEqual(w.getCustomDerivationPathForCosigner(1), "m/47'/0'/0'/1'", 'multisig custom path 1');
+        assertStrictEqual(w.getCustomDerivationPathForCosigner(2), "m/46'/0'/0'/1'", 'multisig custom path 2');
+        assertStrictEqual(
+          w._getExternalAddressByIndex(0),
+          'bc1qxzrzh4caw7e3genwtldtxntzj0ktfl7mhf2lh4fj8h7hnkvtvc4salvp85',
+          'multisig custom-path address',
+        );
+      });
+
+      await step('Multisig cosigner match: own seed recognised in xpub-only config', async () => {
+        const source = buildSignedMultisig('native').wallet;
+        const config = new MultisigHDWallet();
+        config.setSecret(source.getXpub()); // public coordination setup, no private keys
+        assertStrictEqual(findCosignerIndexForSeed(config, MULTISIG_SEED_1), 1, 'cosigner match seed 1');
+        assertStrictEqual(findCosignerIndexForSeed(config, MULTISIG_SEED_2), 2, 'cosigner match seed 2');
+        assertStrictEqual(findCosignerIndexForSeed(config, MULTISIG_SEED_3), 3, 'cosigner match seed 3');
+        assertStrictEqual(
+          findCosignerIndexForSeed(config, 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art'),
+          -1,
+          'cosigner match rejects stranger',
+        );
+      });
 
       log(`all tests passed in ${Date.now() - tStart}ms`);
     } catch (Err) {
@@ -402,6 +557,50 @@ export default class Selftest extends Component {
       </SafeBlueArea>
     );
   }
+}
+
+const MULTISIG_SEED_1 = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+const MULTISIG_SEED_2 = 'chaos word void picture gas update shop wave task blossom close inner';
+const MULTISIG_SEED_3 = 'plate inform scissors pill asset scatter people emotion dose primary together expose';
+const MULTISIG_PATHS = { native: "m/48'/0'/0'/2'", wrapped: "m/48'/0'/0'/1'", legacy: "m/45'" };
+
+function setMultisigFormat(w, kind) {
+  if (kind === 'native') w.setNativeSegwit();
+  else if (kind === 'wrapped') w.setWrappedSegwit();
+  else w.setLegacy();
+}
+
+// funds a multisig wallet with a synthetic prev-tx and spends it (so signing needs no network)
+function fundAndSpendMultisig(w) {
+  const address = w._getExternalAddressByIndex(0);
+  const funding = new bitcoin.Transaction();
+  funding.addInput(Buffer.from('00'.repeat(32), 'hex'), 0);
+  funding.addOutput(bitcoin.address.toOutputScript(address, bitcoin.networks.bitcoin), 100000);
+  const utxos = [{ txId: funding.getId(), txid: funding.getId(), vout: 0, value: 100000, address, txhex: funding.toHex() }];
+  const { psbt, tx } = w.createTransaction(
+    utxos,
+    [{ address: '1GX36PGBUrF8XahZEGQqHqnJGW2vCZteoB', value: 90000 }],
+    1,
+    w._getInternalAddressByIndex(0),
+    false,
+    false,
+  );
+  return { address, psbt, tx };
+}
+
+// 2-of-3 (the wallet's default policy) holding 2 seeds + 1 watch-only cosigner -> fully signs
+function buildSignedMultisig(kind) {
+  const w = new MultisigHDWallet();
+  setMultisigFormat(w, kind);
+  w.setDerivationPath(MULTISIG_PATHS[kind]); // must precede addCosigner() for seed cosigners
+  w.addCosigner(MULTISIG_SEED_1);
+  w.addCosigner(MULTISIG_SEED_2);
+  w.addCosigner(
+    MultisigHDWallet.seedToXpub(MULTISIG_SEED_3, MULTISIG_PATHS[kind]),
+    MultisigHDWallet.mnemonicToFingerprint(MULTISIG_SEED_3, ''),
+  );
+  w.setM(2);
+  return { wallet: w, ...fundAndSpendMultisig(w) };
 }
 
 function assertStrictEqual(actual, expected, message) {

--- a/screen/wallets/importMultisignature.tsx
+++ b/screen/wallets/importMultisignature.tsx
@@ -13,6 +13,7 @@ import { useWalletContext } from '../../contexts/wallet.context';
 import loc from '../../loc';
 import { ManualTextModal } from '../../components/ManualTextModal';
 import { MultisigHDWallet } from '../../class/wallets/multisig-hd-wallet';
+import { findCosignerIndexForSeed } from '../../class/multisig-cosigner-match';
 
 const ImportMultisignature: React.FC = () => {
   const { addWallet, saveToDisk, isElectrumDisabled } = useContext(BlueStorageContext);
@@ -46,16 +47,18 @@ const ImportMultisignature: React.FC = () => {
       setQuorum(multisigWallet.getN());
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      const derivationPath = multisigWallet.getDerivationPath();
-      const ownXpub = multisigWallet.convertXpubToMultisignatureXpub(MultisigHDWallet.seedToXpub(mainWallet?.getSecret(), derivationPath));
-      const ownZpub = MultisigHDWallet.xpubToZpub(ownXpub);
-      const ownXpubFromZpub = MultisigHDWallet.zpubToXpub(ownZpub);
-      const isPartOfMultisig = multisigWallet.getCosigners().some(cosigner => cosigner === ownXpub || cosigner === ownZpub || cosigner === ownXpubFromZpub || cosigner === mainWallet?.getSecret());
-      if (!isPartOfMultisig) throw new Error(loc.multisig.not_part_of_multisig);
+      const ownSeed = mainWallet?.getSecret();
+      const ownPassphrase = (mainWallet as { getPassphrase?: () => string } | undefined)?.getPassphrase?.();
+      const ownCosignerIndex = findCosignerIndexForSeed(multisigWallet, ownSeed, ownPassphrase); // 1-based, or -1
+      if (ownCosignerIndex === -1) throw new Error(loc.multisig.not_part_of_multisig);
 
       multisigWallet.getCosigners().forEach((cosigner, index) => {
-        if (cosigner === mainWallet?.getSecret()) return;
-        if (cosigner === ownXpub || cosigner === ownZpub || cosigner === ownXpubFromZpub) return multisigWallet.replaceCosignerXpubWithSeed(index + 1, mainWallet?.getSecret() as string, '');
+        if (cosigner === ownSeed) return;
+        if (index + 1 === ownCosignerIndex) {
+          if (MultisigHDWallet.isXpubString(cosigner))
+            multisigWallet.replaceCosignerXpubWithSeed(ownCosignerIndex, ownSeed as string, ownPassphrase || '');
+          return;
+        }
         if (MultisigHDWallet.isXpubForMultisig(cosigner)) return;
         // Then it should be a seed? try to replace it
         multisigWallet.replaceCosignerSeedWithXpub(index + 1);

--- a/tests/unit/multisig-hd-wallet.test.js
+++ b/tests/unit/multisig-hd-wallet.test.js
@@ -2,6 +2,7 @@ import assert from 'assert';
 import { MultisigHDWallet } from '../../class/';
 import { BlueURDecoder, decodeUR, encodeUR } from '../../blue_modules/ur';
 import { MultisigCosigner } from '../../class/multisig-cosigner';
+import { findCosignerIndexForSeed } from '../../class/multisig-cosigner-match';
 const bitcoin = require('bitcoinjs-lib');
 const Base43 = require('../../blue_modules/base43');
 
@@ -2286,5 +2287,79 @@ describe('multisig-cosigner', () => {
     assert.deepStrictEqual(result, [
       'ur:crypto-account/oeadcywehhhpleaolytaadmhtaaddloxaxhdclaoamutctbahthnislelbwemnkeoefnhddienfetbpygrpaqdkemyrywyldaspyjkdtaahdcxhyneskwdhlehlfbwrpdnjlgsgakplkjtknvyttsgolnnlbwlcagoolcpfgsglkinamtaaddyotadlfcsdpykaocywehhhpleaxadaycywehhhplekpdwveih',
     ]);
+  });
+});
+
+describe('multisig cosigner matching for import (issue #176)', () => {
+  const path = "m/48'/0'/0'/2'";
+  const customPath = "m/48'/0'/1'/2'";
+  const seedA = 'salon smoke bubble dolphin powder govern rival sport better arrest certain manual';
+  const seedB = 'chaos word void picture gas update shop wave task blossom close inner';
+  const passA = '9WDdFSZX4d6mPxkr';
+  const strangerSeed = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+  // builds the public, xpub-only config a customer re-imports on a new phone
+  const buildConfig = ({ withPassphrase = false, derivation = path } = {}) => {
+    const source = new MultisigHDWallet();
+    source.setDerivationPath(derivation);
+    source.addCosigner(seedA, undefined, undefined, withPassphrase ? passA : undefined);
+    source.addCosigner(seedB);
+    source.setM(2);
+    const config = new MultisigHDWallet();
+    config.setSecret(source.getXpub()); // coordination setup contains only public keys
+    return config;
+  };
+
+  it('matches a standard cosigner seed and rejects a non-cosigner (scenario 1)', () => {
+    const w = buildConfig();
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedB, undefined), 2);
+    assert.strictEqual(findCosignerIndexForSeed(w, strangerSeed, undefined), -1);
+  });
+
+  it('matches a cosigner whose seed uses a BIP39 passphrase (scenario 2)', () => {
+    const w = buildConfig({ withPassphrase: true });
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, passA), 1);
+    // the historic bug: matching without (or with the wrong) passphrase must NOT succeed
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), -1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, 'wrong-passphrase'), -1);
+  });
+
+  it('matches cosigners registered at different per-cosigner derivation paths (scenario 3)', () => {
+    const w = new MultisigHDWallet();
+    w.setNativeSegwit();
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedA, customPath), MultisigHDWallet.mnemonicToFingerprint(seedA, ''), customPath);
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedB, path), MultisigHDWallet.mnemonicToFingerprint(seedB, ''), path);
+    w.setM(2);
+    assert.strictEqual(w.getCustomDerivationPathForCosigner(1), customPath);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedB, undefined), 2);
+  });
+
+  it('falls back to per-cosigner xpub derivation when no fingerprint is available', () => {
+    // a config whose fingerprints are unknown ('00000000'): fingerprint match cannot work, so
+    // matching must rely on deriving the xpub at each cosigner's own path
+    const w = new MultisigHDWallet();
+    w.setNativeSegwit();
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedA, customPath), '00000000', customPath);
+    w.addCosigner(MultisigHDWallet.seedToXpub(seedB, path), '00000000', path);
+    w.setM(2);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
+    assert.strictEqual(findCosignerIndexForSeed(w, seedB, undefined), 2);
+    assert.strictEqual(findCosignerIndexForSeed(w, strangerSeed, undefined), -1);
+  });
+
+  it('matches a cosigner from a sortedmulti() descriptor (empty global path, per-cosigner paths)', () => {
+    const config = buildConfig();
+    const x1 = config.getCosigner(1);
+    const x2 = config.getCosigner(2);
+    const f1 = config.getFingerprint(1);
+    const f2 = config.getFingerprint(2);
+    const descriptor = 'wsh(sortedmulti(2,[' + f1 + '/48h/0h/0h/2h]' + x1 + '/0/*,[' + f2 + '/48h/0h/0h/2h]' + x2 + '/0/*))';
+    const w = new MultisigHDWallet();
+    assert.doesNotThrow(() => w.setSecret(descriptor));
+    assert.strictEqual(w.getN(), 2);
+    assert.strictEqual(w.getDerivationPath(), ''); // descriptors keep an empty global path (as upstream); per-cosigner paths are authoritative
+    assert.strictEqual(findCosignerIndexForSeed(w, seedA, undefined), 1);
   });
 });


### PR DESCRIPTION
Combines the multisig cosigner-match fix, new multisig self-test coverage, and a synced dependency bump.

## 1. Fix — cosigner match rejecting valid seeds on import

The import check (`importMultisignature.tsx`) recomputed the seed's xpub only at the wallet-global derivation path and **without the BIP39 passphrase**, then string-compared. It wrongly rejected legitimate cosigners with "not part of multisig" when the seed used a passphrase or sat at a per-cosigner/non-zero path, and threw `Expected BIP32Path` for `sortedmulti()` descriptors.

- **`class/multisig-cosigner-match.ts`** (new, DFX-owned): `findCosignerIndexForSeed()` — fingerprint-first, then xpub derived at each cosigner's own path with the passphrase. Kept out of the BlueWallet-derived `MultisigHDWallet` so that class stays identical to upstream.
- Import screen uses it and passes the real passphrase into `replaceCosignerXpubWithSeed`.
- Regression tests + `__mocks__/react-native-config.js` (the import added in #171 had no jest mock, which broke unit-suite loading).

## 2. Self-test multisig diagnostics (`screen/selftest.js`)

For the wallet's **default 2-of-3** policy: P2WSH/P2SH-P2WSH/P2SH create+sign+finalize, single-device partial sign, export/import round-trip, BIP39-passphrase + custom-path address derivation, cosigner-match, and a **real-wallet** path (throwaway vault) that reconstructs + cosigns an actual on-chain withdrawal (matching the broadcast signature) and confirms Electrum sees it.

## 3. Bump `electrum-client` to synced fork

`BtcTaroWallet/rn-electrum-client` was behind BlueWallet's fork. Synced it up (`cba3cc3`, byte-identical to BlueWallet `83420b8`): our prior DFX-only "don't hang on 'Batch limit exceeded'" patch is now identical to BlueWallet's, and we additionally pick up "perf: improve message parser". Pin + lockfile bumped; pure-JS dep, no native impact.

## Verification

`multisig-hd-wallet` unit suite green (16/16); real-withdrawal reconstruction matches the broadcast txid + signature; both phones run the build with prod env. electrum-client resolves + installs at the new sha.