### PR TITLE
CI: build APK + ship TestFlight on merge to develop

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,0 +1,111 @@
+name: Deploy (develop)
+
+# On every merge to develop: build a signed Android APK (uploaded as a workflow
+# artifact) and ship an iOS build to TestFlight. Versioned App Store / Play Store
+# releases stay on the existing v* tag flow (build-release-apk.yml).
+#
+# Required repository secrets:
+#   Android (already used by the v* release flow):
+#     KEYSTORE_FILE_HEX, KEYSTORE_PASSWORD, KEYSTORE_KEY_PASSWORD, KEYSTORE_ALIAS
+#   iOS (new — must be added):
+#     ASC_API_KEY_P8          App Store Connect API key (.p8 file contents)
+#     ASC_KEY_ID              ASC API key ID
+#     ASC_ISSUER_ID           ASC API key issuer ID
+#     IOS_DIST_CERT_P12       Apple Distribution cert + private key, base64 of a .p12
+#     IOS_DIST_CERT_PASSWORD  password for the .p12
+# Prerequisites: the app exists on App Store Connect under team Y4QBY6387T with
+# bundle id swiss.dfx.bitcoin, and the ASC API key has access to it.
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-develop
+  cancel-in-progress: false # never cancel an in-flight TestFlight upload
+
+permissions:
+  contents: read
+
+jobs:
+  android-apk:
+    name: Android APK
+    # Ubuntu: faster + cheaper than macOS for Android. The RN postinstall must
+    # run (JS-bundle shims + patch-package), but its pod-install step is
+    # Mac-guarded (scripts/podinstall.sh -> darwin* only), so it no-ops here.
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+      - name: Install node_modules
+        run: npm ci --omit=dev
+      - name: Build signed release APK (.env.prd)
+        env:
+          KEYSTORE_FILE_HEX: ${{ secrets.KEYSTORE_FILE_HEX }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          KS="$(mktemp /tmp/app-signing.XXXXXX.keystore)"; chmod 600 "$KS"
+          trap 'shred -u "$KS" 2>/dev/null || rm -f "$KS"' EXIT
+          printf '%s' "$KEYSTORE_FILE_HEX" | xxd -plain -revert > "$KS"
+          cd android
+          ./gradlew assembleRelease \
+            -PMYAPP_UPLOAD_STORE_FILE="$KS" \
+            -PMYAPP_UPLOAD_KEY_ALIAS="$KEYSTORE_ALIAS" \
+            -PMYAPP_UPLOAD_STORE_PASSWORD="$KEYSTORE_PASSWORD" \
+            -PMYAPP_UPLOAD_KEY_PASSWORD="$KEYSTORE_KEY_PASSWORD" \
+            -PMYAPP_VERSION_CODE="$BUILD_NUMBER"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dfx-bitcoin-develop-${{ github.run_number }}
+          path: android/app/build/outputs/apk/release/app-release.apk
+          if-no-files-found: error
+
+  ios-testflight:
+    name: iOS TestFlight
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: 'Install node_modules (runs RN postinstall: shims, pods, patches)'
+        run: npm ci
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: ios
+      - name: Select prod env for the build
+        run: echo ".env.prd" > /tmp/envfile
+      - name: Import Apple distribution certificate
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.IOS_DIST_CERT_P12 }}
+          p12-password: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+      - name: Write App Store Connect API key
+        run: |
+          echo "${{ secrets.ASC_API_KEY_P8 }}" > "$RUNNER_TEMP/AuthKey.p8"
+          echo "ASC_KEY_PATH=$RUNNER_TEMP/AuthKey.p8" >> "$GITHUB_ENV"
+      - name: Build + upload to TestFlight
+        working-directory: ios
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: bundle exec fastlane beta

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "fastlane"
+gem "cocoapods"

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,6 +1,2 @@
-# app_identifier("[[APP_IDENTIFIER]]") # The bundle identifier of your app
-# apple_id("[[APPLE_ID]]") # Your Apple email address
-
-
-# For more information about the Appfile, see:
-#     https://docs.fastlane.tools/advanced/#appfile
+app_identifier("swiss.dfx.bitcoin")
+team_id("Y4QBY6387T") # Apple Developer Portal team

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,23 +1,38 @@
-# This file contains the fastlane.tools configuration
-# You can find the documentation at https://docs.fastlane.tools
-#
-# For a list of all available actions, check out
-#
-#     https://docs.fastlane.tools/actions
-#
-# For a list of all available plugins, check out
-#
-#     https://docs.fastlane.tools/plugins/available-plugins
-#
-
-# Uncomment the line if you want fastlane to automatically update itself
-# update_fastlane
-
 default_platform(:ios)
 
 platform :ios do
-  desc "Description of what the lane does"
-  lane :custom_lane do
-    # add actions here: https://docs.fastlane.tools/actions
+  # Builds the prod (BlueWallet scheme -> .env.prd) app and uploads it to TestFlight.
+  # Auth + provisioning are handled by an App Store Connect API key; the distribution
+  # certificate is imported into the keychain by the CI workflow before this runs.
+  desc "Build and upload an internal build to TestFlight"
+  lane :beta do
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("ASC_KEY_ID"),
+      issuer_id: ENV.fetch("ASC_ISSUER_ID"),
+      key_filepath: ENV.fetch("ASC_KEY_PATH"),
+    )
+
+    # CI run number -> monotonic build number, so each develop merge uploads cleanly.
+    increment_build_number(
+      xcodeproj: "BlueWallet.xcodeproj",
+      build_number: ENV.fetch("BUILD_NUMBER"),
+    )
+
+    build_app(
+      workspace: "BlueWallet.xcworkspace",
+      scheme: "BlueWallet", # prod scheme; its pre-action selects .env.prd (CI also writes /tmp/envfile)
+      configuration: "Release",
+      export_method: "app-store",
+      # ASC API key authorises xcodebuild to fetch/create the App Store provisioning profile.
+      xcargs: "-allowProvisioningUpdates",
+      output_directory: "build",
+      output_name: "DFXBitcoin.ipa",
+      clean: true,
+    )
+
+    upload_to_testflight(
+      api_key: api_key,
+      skip_waiting_for_build_processing: true,
+    )
   end
 end


### PR DESCRIPTION
On every merge to `develop`: build a signed Android APK (workflow artifact) and ship an iOS build to TestFlight. The existing `v*` tag release flow is untouched — store releases stay there; this is for continuous internal testing builds.

## Files
- **`.github/workflows/deploy-develop.yml`** — `push: develop` (+ `workflow_dispatch`):
  - **android-apk** (ubuntu): decode `KEYSTORE_*` → `gradlew assembleRelease` (release config already maps to `.env.prd`), build number from `github.run_number`, upload `app-release.apk` artifact.
  - **ios-testflight** (macOS): `npm ci` (RN postinstall + pods) → import dist cert → ASC API key → `bundle exec fastlane beta`.
- **`ios/fastlane/Fastfile`** — `beta` lane: ASC API-key auth, CI build number, `gym` build of the **BlueWallet** prod scheme (`.env.prd`), `upload_to_testflight`; API key auto-manages the App Store profile (`-allowProvisioningUpdates`). Bundle id/team overridable via `IOS_BUNDLE_ID`/`IOS_TEAM_ID`.
- **`ios/fastlane/Appfile`** + **`ios/Gemfile`** — app id `swiss.dfx.bitcoin`, team `Y4QBY6387T`.

## New secrets to add (iOS)
- `ASC_API_KEY_P8` — App Store Connect API key (.p8 contents)
- `ASC_KEY_ID`, `ASC_ISSUER_ID`
- `IOS_DIST_CERT_P12` — base64 of an Apple Distribution cert+key .p12
- `IOS_DIST_CERT_PASSWORD`

Android reuses the existing `KEYSTORE_*` secrets.

## Prerequisite
App exists on App Store Connect under team `Y4QBY6387T`, bundle id `swiss.dfx.bitcoin`, and the ASC API key has access.

## Validation
The **Android job was run on a fork and produced a real signed APK** (~30 min on Ubuntu). The **iOS job hasn't run end-to-end yet** — it needs the secrets above + the App Store Connect app record, so the first TestFlight run on this repo will likely need a small signing tweak (normal for CI iOS). I can drive that once the secrets are in place.