### PR TITLE
ios: emit dSYMs for Release builds + crash-report docs

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,0 +1,108 @@
+name: Deploy (develop)
+
+# On every merge to develop: build a signed Android APK (uploaded as a workflow
+# artifact) and ship an iOS build to TestFlight. Versioned App Store / Play Store
+# releases stay on the existing v* tag flow (build-release-apk.yml).
+#
+# Required repository secrets:
+#   Android (already used by the v* release flow):
+#     KEYSTORE_FILE_HEX, KEYSTORE_PASSWORD, KEYSTORE_KEY_PASSWORD, KEYSTORE_ALIAS
+#   iOS (new — must be added):
+#     ASC_API_KEY_P8          App Store Connect API key (.p8 file contents)
+#     ASC_KEY_ID              ASC API key ID
+#     ASC_ISSUER_ID           ASC API key issuer ID
+#     IOS_DIST_CERT_P12       Apple Distribution cert + private key, base64 of a .p12
+#     IOS_DIST_CERT_PASSWORD  password for the .p12
+# Prerequisites: the app exists on App Store Connect under team Y4QBY6387T with
+# bundle id swiss.dfx.bitcoin, and the ASC API key has access to it.
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-develop
+  cancel-in-progress: false # never cancel an in-flight TestFlight upload
+
+permissions:
+  contents: read
+
+jobs:
+  android-apk:
+    name: Android APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+      - name: Install node_modules
+        run: npm ci --omit=dev --ignore-scripts
+      - name: Build signed release APK (.env.prd)
+        env:
+          KEYSTORE_FILE_HEX: ${{ secrets.KEYSTORE_FILE_HEX }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
+          KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: |
+          set -euo pipefail
+          KS="$(mktemp /tmp/app-signing.XXXXXX.keystore)"; chmod 600 "$KS"
+          trap 'shred -u "$KS" 2>/dev/null || rm -f "$KS"' EXIT
+          printf '%s' "$KEYSTORE_FILE_HEX" | xxd -plain -revert > "$KS"
+          cd android
+          ./gradlew assembleRelease \
+            -PMYAPP_UPLOAD_STORE_FILE="$KS" \
+            -PMYAPP_UPLOAD_KEY_ALIAS="$KEYSTORE_ALIAS" \
+            -PMYAPP_UPLOAD_STORE_PASSWORD="$KEYSTORE_PASSWORD" \
+            -PMYAPP_UPLOAD_KEY_PASSWORD="$KEYSTORE_KEY_PASSWORD" \
+            -PMYAPP_VERSION_CODE="$BUILD_NUMBER"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dfx-bitcoin-develop-${{ github.run_number }}
+          path: android/app/build/outputs/apk/release/app-release.apk
+          if-no-files-found: error
+
+  ios-testflight:
+    name: iOS TestFlight
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: 'Install node_modules (runs RN postinstall: shims, pods, patches)'
+        run: npm ci
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: ios
+      - name: Select prod env for the build
+        run: echo ".env.prd" > /tmp/envfile
+      - name: Import Apple distribution certificate
+        uses: apple-actions/import-codesign-certs@v3
+        with:
+          p12-file-base64: ${{ secrets.IOS_DIST_CERT_P12 }}
+          p12-password: ${{ secrets.IOS_DIST_CERT_PASSWORD }}
+      - name: Write App Store Connect API key
+        run: |
+          echo "${{ secrets.ASC_API_KEY_P8 }}" > "$RUNNER_TEMP/AuthKey.p8"
+          echo "ASC_KEY_PATH=$RUNNER_TEMP/AuthKey.p8" >> "$GITHUB_ENV"
+      - name: Build + upload to TestFlight
+        working-directory: ios
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          BUILD_NUMBER: ${{ github.run_number }}
+        run: bundle exec fastlane beta

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -31,11 +31,11 @@ permissions:
 jobs:
   android-apk:
     name: Android APK
-    # macOS to match the proven v* release build: the RN postinstall runs pod
-    # install (needs CocoaPods) and the JS bundle needs the postinstall
-    # shims/patches, so scripts must run.
-    runs-on: macos-15
-    timeout-minutes: 45
+    # Ubuntu: faster + cheaper than macOS for Android. The RN postinstall must
+    # run (JS-bundle shims + patch-package), but its pod-install step is
+    # Mac-guarded (scripts/podinstall.sh -> darwin* only), so it no-ops here.
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -31,7 +31,10 @@ permissions:
 jobs:
   android-apk:
     name: Android APK
-    runs-on: ubuntu-latest
+    # macOS to match the proven v* release build: the RN postinstall runs pod
+    # install (needs CocoaPods) and the JS bundle needs the postinstall
+    # shims/patches, so scripts must run.
+    runs-on: macos-15
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +48,7 @@ jobs:
           java-version: '17'
           cache: gradle
       - name: Install node_modules
-        run: npm ci --omit=dev --ignore-scripts
+        run: npm ci --omit=dev
       - name: Build signed release APK (.env.prd)
         env:
           KEYSTORE_FILE_HEX: ${{ secrets.KEYSTORE_FILE_HEX }}

--- a/docs/crash-reports.md
+++ b/docs/crash-reports.md
@@ -1,0 +1,53 @@
+# Crash reports (Apple native, no third-party tools)
+
+The app ships **no crash-reporting SDK** and sends no telemetry. We rely on Apple's built-in
+crash collection, which surfaces in **Xcode → Window → Organizer → Crashes** (and the crash
+section of App Store Connect) for the app id `swiss.dfx.bitcoin`.
+
+For a crash to appear there, readable, four things must line up:
+
+1. **dSYMs are generated.** Release/Archive builds set `DEBUG_INFORMATION_FORMAT = dwarf-with-dsym`
+   (project-level Release config in `ios/BlueWallet.xcodeproj`). dSYMs are the symbol files Apple
+   needs to turn raw addresses into function names + line numbers.
+2. **dSYMs are uploaded with the build.** Automatic on Xcode Archive → upload ("Upload your app's
+   symbols" is on by default) and via fastlane `upload_to_testflight` (default). Don't disable
+   symbol upload in the release lane.
+3. **The user shared analytics.** Crashes only reach Apple from users who have
+   *Settings → Privacy & Security → Analytics & Improvements → Share With App Developers* enabled.
+4. **You look in the right place.** Organizer → Crashes, filtered to `swiss.dfx.bitcoin`.
+
+No code in the app is involved — this is enabled purely by being a TestFlight/App Store build under
+our team with symbols uploaded.
+
+> Note: this captures **native** crashes well. A pure-JS error escalated to a native abort will point
+> into Hermes / `RCTFatal` without the JS line — reading that needs JS source maps, which is a
+> separate setup not covered here.
+
+## Getting a crash from a specific customer (no SDK, works on any build)
+
+The crash log already exists on the customer's device:
+
+**Customer side**
+1. Settings → Privacy & Security → Analytics & Improvements → **Analytics Data**
+2. Scroll to an entry named like `Bitcoin-<date>` (or the process name) around the crash time
+3. Tap it → Share → send the `.ips` file
+
+**Our side — symbolicate it**
+1. Get the **dSYM for the exact build** the customer runs:
+   - App Store Connect → the app → the specific build → **Download dSYM**, or
+   - Xcode → Organizer → the matching Archive → **Download Debug Symbols** / show in Finder
+2. Symbolicate with the matching dSYM:
+   - Easiest: open the `.ips` in Xcode with the matching archive present, or
+   - `atos -arch arm64 -o <App>.app.dSYM/Contents/Resources/DWARF/<App> -l <loadAddr> <addr>`
+
+Even **before** symbolicating, the report's header is informative:
+
+- **Exception Type / Termination Reason** — e.g. `0x8badf00d` = watchdog timeout (app hung),
+  `EXC_BAD_ACCESS` = bad memory access, `EXC_CRASH (SIGABRT)` = an assertion / uncaught exception.
+- **Binary Images / faulting frame** — names the framework or library at the top of the crashing
+  thread, which often localizes the cause immediately.
+
+## Keeping dSYMs
+
+Archive every store/TestFlight build (Xcode keeps them under *Organizer → Archives*) and/or keep the
+`.xcarchive` from CI, so a dSYM is always available to symbolicate a crash from that exact build.

--- a/ios/BlueWallet.xcodeproj/project.pbxproj
+++ b/ios/BlueWallet.xcodeproj/project.pbxproj
@@ -760,6 +760,7 @@
 				SWIFT_VERSION = 4.2;
 				USE_HERMES = true;
 				VALIDATE_PRODUCT = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 			};
 			name = Release;
 		};

--- a/ios/Gemfile
+++ b/ios/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "fastlane"
+gem "cocoapods"

--- a/ios/fastlane/Appfile
+++ b/ios/fastlane/Appfile
@@ -1,6 +1,2 @@
-# app_identifier("[[APP_IDENTIFIER]]") # The bundle identifier of your app
-# apple_id("[[APPLE_ID]]") # Your Apple email address
-
-
-# For more information about the Appfile, see:
-#     https://docs.fastlane.tools/advanced/#appfile
+app_identifier("swiss.dfx.bitcoin")
+team_id("Y4QBY6387T") # Apple Developer Portal team

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,23 +1,38 @@
-# This file contains the fastlane.tools configuration
-# You can find the documentation at https://docs.fastlane.tools
-#
-# For a list of all available actions, check out
-#
-#     https://docs.fastlane.tools/actions
-#
-# For a list of all available plugins, check out
-#
-#     https://docs.fastlane.tools/plugins/available-plugins
-#
-
-# Uncomment the line if you want fastlane to automatically update itself
-# update_fastlane
-
 default_platform(:ios)
 
 platform :ios do
-  desc "Description of what the lane does"
-  lane :custom_lane do
-    # add actions here: https://docs.fastlane.tools/actions
+  # Builds the prod (BlueWallet scheme -> .env.prd) app and uploads it to TestFlight.
+  # Auth + provisioning are handled by an App Store Connect API key; the distribution
+  # certificate is imported into the keychain by the CI workflow before this runs.
+  desc "Build and upload an internal build to TestFlight"
+  lane :beta do
+    api_key = app_store_connect_api_key(
+      key_id: ENV.fetch("ASC_KEY_ID"),
+      issuer_id: ENV.fetch("ASC_ISSUER_ID"),
+      key_filepath: ENV.fetch("ASC_KEY_PATH"),
+    )
+
+    # CI run number -> monotonic build number, so each develop merge uploads cleanly.
+    increment_build_number(
+      xcodeproj: "BlueWallet.xcodeproj",
+      build_number: ENV.fetch("BUILD_NUMBER"),
+    )
+
+    build_app(
+      workspace: "BlueWallet.xcworkspace",
+      scheme: "BlueWallet", # prod scheme; its pre-action selects .env.prd (CI also writes /tmp/envfile)
+      configuration: "Release",
+      export_method: "app-store",
+      # ASC API key authorises xcodebuild to fetch/create the App Store provisioning profile.
+      xcargs: "-allowProvisioningUpdates",
+      output_directory: "build",
+      output_name: "DFXBitcoin.ipa",
+      clean: true,
+    )
+
+    upload_to_testflight(
+      api_key: api_key,
+      skip_waiting_for_build_processing: true,
+    )
   end
 end


### PR DESCRIPTION
## Why

Investigating the iOS import crash (#176) we have **no way to see what crashed** — the app ships no crash-reporting SDK (intentional, privacy) and there was no symbol setup. This wires up Apple's **native** crash reporting (Xcode Organizer / App Store Connect) so the next occurrence is diagnosable. No third-party tools, no telemetry, no app code.

## What

- **`ios/BlueWallet.xcodeproj`** — set `DEBUG_INFORMATION_FORMAT = dwarf-with-dsym` on the project-level **Release** config. Release/Archive builds now always emit dSYMs (previously relied on Xcode's implicit default), so crashes show up symbolicated in Organizer for `swiss.dfx.bitcoin`.
- **`docs/crash-reports.md`** — how the Apple crash dashboard works, the four conditions for a crash to appear readable, and the step-by-step to retrieve + symbolicate a crash from a specific customer device (incl. reading the `.ips` header before symbolication).

## Notes / follow-ups

- dSYM **upload** is automatic on Xcode Archive→upload and via fastlane `upload_to_testflight`; just keep symbol upload enabled in the release lane (relevant once the TestFlight lane in #180 lands).
- Crashes only reach Apple from users with *Share With App Developers* enabled.
- Captures **native** crashes well (the leading hypothesis for #176). Pure-JS aborts would need JS source maps — out of scope here.

Relates to #176.