### PR TITLE
fix(android): Transparent-AAB nach add-transparency signieren

### DIFF
--- a/scripts/build-release-apk.sh
+++ b/scripts/build-release-apk.sh
@@ -76,6 +76,22 @@ bundletool add-transparency \
   --ks-key-alias="$TRANSPARENCY_ALIAS" \
   --ks-pass=pass:"$TRANSPARENCY_PASSWORD"
 
+# `bundletool add-transparency` only signs the code-transparency block and emits an
+# otherwise UNsigned bundle, so re-sign the output with the upload key. Google Play
+# rejects unsigned uploads ("All uploaded bundles must be signed"); the GitHub-release
+# flow never caught this because it only attests the AAB, never uploads it to Play.
+jarsigner \
+  -keystore "$KEYSTORE" \
+  -storepass "$KEYSTORE_PASSWORD" \
+  -keypass "$KEYSTORE_KEY_PASSWORD" \
+  -sigalg SHA256withRSA -digestalg SHA-256 \
+  "$TRANSPARENT_AAB" "$KEYSTORE_ALIAS"
+
+# Fail loudly if the bundle is somehow still unsigned before it ever reaches Play.
+# `jarsigner -verify` exits 0 even for unsigned jars, so assert on its output text.
+jarsigner -verify "$TRANSPARENT_AAB" | grep -q 'jar verified\.' \
+  || { echo "Transparent AAB is not signed after jarsigner — refusing to continue" >&2; exit 1; }
+
 keytool -exportcert \
   -alias "$TRANSPARENCY_ALIAS" \
   -keystore "$TRANSPARENCY_KEYSTORE" \


### PR DESCRIPTION
Beim Test der Release-Pipeline (Tag `v2.0.5`) scheiterte der Android-Job beim Play-Upload an:

> `Google Api Error: Invalid request - All uploaded bundles must be signed. Please sign the bundle using jarsigner.`

**Root Cause:** `bundletool add-transparency` signiert nur den Code-Transparency-Block und gibt ein ansonsten **unsigniertes** Bundle aus. `scripts/build-release-apk.sh` lädt genau dieses `app-release-transparent.aab` zu Play hoch, ohne es vorher neu zu signieren. Der bestehende GitHub-Release-Flow hat das nie bemerkt, weil er das AAB nur **attestiert**, aber nie zu Play hochlädt.

**Fix:** Nach `add-transparency` wird das Transparent-AAB mit dem Upload-Key (`KEYSTORE_*`) per `jarsigner` neu signiert (Googles dokumentierter Code-Transparency-Flow). Ein `jarsigner -verify`-Guard bricht den Build ab, falls das Bundle wider Erwarten unsigniert bleibt (da `-verify` allein bei unsigniert exit 0 liefert, wird auf den Ausgabetext geprüft).

**Validierung:** `jarsigner`-Sign+Verify lokal gegen Wegwerf-Keystore/Dummy-AAB geprüft — signiert → `jar verified.` (PASS), unsigniert → Guard greift (FAIL). Voller End-to-End-Beweis folgt mit dem nächsten Tag-Run nach Merge.

Hinweis: Selbst mit diesem Fix bleibt der Android-Listing-Schritt durch die offene Play-Deklaration „Financial features" (Krypto-Lizenzdoku pro Land) blockiert — das ist eine separate Compliance-Aufgabe.