### PR TITLE
ci: automatischer develop→main Release-PR

### DIFF
--- a/.github/workflows/auto-release-pr.yml
+++ b/.github/workflows/auto-release-pr.yml
@@ -1,0 +1,76 @@
+name: Auto Release PR
+
+# Opens (and keeps open) a single develop -> main "release" PR whenever develop
+# moves ahead of main, so promoting a verified develop to the released line is a
+# one-click merge. Store delivery itself stays tag-driven (auto-tag + release.yml);
+# main is the human-approved release marker. Mirrors DFXswiss/api's auto-release-pr.
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: auto-release-pr
+  cancel-in-progress: false
+
+jobs:
+  create-release-pr:
+    name: Create Release PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch main branch
+        run: git fetch origin main
+
+      - name: Check for existing PR
+        id: check-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_COUNT=$(gh pr list --base main --head develop --state open --json number --jq 'length')
+          echo "pr_exists=$([[ $PR_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+          echo "::notice::Open PRs from develop to main: $PR_COUNT"
+
+      - name: Check for differences
+        id: check-diff
+        if: steps.check-pr.outputs.pr_exists == 'false'
+        run: |
+          DIFF_COUNT=$(git rev-list --count origin/main..origin/develop)
+          echo "has_changes=$([[ $DIFF_COUNT -gt 0 ]] && echo 'true' || echo 'false')" >> "$GITHUB_OUTPUT"
+          echo "commit_count=$DIFF_COUNT" >> "$GITHUB_OUTPUT"
+          echo "::notice::Commits ahead of main: $DIFF_COUNT"
+
+      - name: Create Release PR
+        if: steps.check-pr.outputs.pr_exists == 'false' && steps.check-diff.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_COUNT: ${{ steps.check-diff.outputs.commit_count }}
+        run: |
+          printf '%s\n' \
+            "## Automatic Release PR" \
+            "" \
+            "This PR was automatically created after changes were pushed to develop." \
+            "" \
+            "**Commits:** ${COMMIT_COUNT} new commit(s)" \
+            "" \
+            "### Checklist" \
+            "- [ ] Review all changes" \
+            "- [ ] Verify CI passes" \
+            "- [ ] Approve and merge when ready for production" \
+            > /tmp/pr-body.md
+
+          gh pr create \
+            --base main \
+            --head develop \
+            --title "Release: develop -> main" \
+            --body-file /tmp/pr-body.md


### PR DESCRIPTION
Ergänzt einen Release-PR-Workflow analog zu `DFXswiss/api` (`auto-release-pr.yaml`).

**Kontext:** btc-wallet hatte bisher keinen develop→main-Gate. `master` wurde nach `main` umbenannt; dieser Workflow öffnet bei jedem develop-Push automatisch einen develop→main-PR „Release: develop -> main" (sofern noch keiner offen ist und develop main voraus ist).

**Semantik:** `main` ist der menschlich freigegebene Release-Marker (Ein-Klick-Merge zum Freigeben eines verifizierten develop-Stands). Die eigentliche Store-Auslieferung bleibt **tag-getrieben** (`auto-tag` → `release.yml`); `main` deployt (noch) nichts.

**Hinweis:** Wie im api-Repo wird der PR via `GITHUB_TOKEN` erstellt — solche PRs lösen keine weiteren Workflow-Runs aus (CI startet auf dem develop→main-PR nicht automatisch). Falls CI auf Release-PRs erwünscht ist, müsste ein PAT/Deploy-Key verwendet werden — bewusst weggelassen, um 1:1 dem api-Muster zu folgen.