### PR TITLE
Pre-release fixes: multisig delete crash, send scroll, Face ID splash, import freeze, scanner alert burst, app-state guard, CI dedupe

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,20 +1,12 @@
 name: Deploy (develop)
 
-# On every merge to develop: build a signed Android APK (uploaded as a workflow
-# artifact) and ship an iOS build to TestFlight. Versioned App Store / Play Store
-# releases stay on the existing v* tag flow (build-release-apk.yml).
+# On every merge to develop: build a signed Android APK and upload it as a
+# workflow artifact for quick install/testing. iOS TestFlight and the versioned
+# store releases are owned by the tag flow (auto-tag.yml -> release.yml); this
+# workflow intentionally does not build iOS to avoid a duplicate TestFlight upload.
 #
 # Required repository secrets:
-#   Android (already used by the v* release flow):
-#     KEYSTORE_FILE_HEX, KEYSTORE_PASSWORD, KEYSTORE_KEY_PASSWORD, KEYSTORE_ALIAS
-#   iOS (App Store Connect API key + fastlane match):
-#     APP_STORE_CONNECT_KEY        App Store Connect API key (.p8 file contents)
-#     APP_STORE_CONNECT_KEY_ID     ASC API key ID
-#     APP_STORE_CONNECT_ISSUER_ID  ASC API key issuer ID
-#     MATCH_SSH_KEY                deploy key for the certs repo (DFXswiss/btc-wallet-certificates)
-#     MATCH_PASSWORD               match encryption passphrase
-# Prerequisites: the app exists on App Store Connect under team Y4QBY6387T with
-# bundle id swiss.dfx.bitcoin; signing assets live (encrypted) in the match certs repo.
+#   KEYSTORE_FILE_HEX, KEYSTORE_PASSWORD, KEYSTORE_KEY_PASSWORD, KEYSTORE_ALIAS
 
 on:
   push:
@@ -23,7 +15,7 @@ on:
 
 concurrency:
   group: deploy-develop
-  cancel-in-progress: false # never cancel an in-flight TestFlight upload
+  cancel-in-progress: false # let each merge's APK build finish
 
 permissions:
   contents: read
@@ -73,39 +65,3 @@ jobs:
           name: dfx-bitcoin-develop-${{ github.run_number }}
           path: android/app/build/outputs/apk/release/app-release.apk
           if-no-files-found: error
-
-  ios-testflight:
-    name: iOS TestFlight
-    runs-on: macos-26
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - name: 'Install node_modules (runs RN postinstall: shims, pods, patches)'
-        run: npm ci
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.3'
-          bundler-cache: true
-          working-directory: ios
-      - name: Select prod env for the build
-        run: echo ".env.prd" > /tmp/envfile
-      - name: SSH access for fastlane match
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.MATCH_SSH_KEY }}
-      - name: Write App Store Connect API key
-        run: |
-          echo "${{ secrets.APP_STORE_CONNECT_KEY }}" > "$RUNNER_TEMP/AuthKey.p8"
-          echo "ASC_KEY_PATH=$RUNNER_TEMP/AuthKey.p8" >> "$GITHUB_ENV"
-      - name: Build + upload to TestFlight
-        working-directory: ios
-        env:
-          ASC_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          ASC_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
-          BUILD_NUMBER: ${{ github.run_number }}
-        run: bundle exec fastlane beta

--- a/App.js
+++ b/App.js
@@ -187,7 +187,7 @@ const App = () => {
       currency.updateExchangeRate();
       setBalanceRefreshInterval();
     }
-    if (appState.current === 'active' && nextAppState.match(/background/)) clearBalanceRefreshInterval();
+    if (appState.current === 'active' && nextAppState?.match(/background/)) clearBalanceRefreshInterval();
     if (nextAppState) {
       appState.current = nextAppState;
     }

--- a/UnlockWith.js
+++ b/UnlockWith.js
@@ -10,6 +10,7 @@ import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 const styles = StyleSheet.create({
   root: {
     flex: 1,
+    backgroundColor: '#072440',
   },
   container: {
     flex: 1,
@@ -29,6 +30,11 @@ const styles = StyleSheet.create({
   },
   splashContainer: {
     flex: 0,
+  },
+  splash: {
+    width: 220,
+    height: 70,
+    resizeMode: 'contain',
   },
 });
 

--- a/blue_modules/Privacy.tsx
+++ b/blue_modules/Privacy.tsx
@@ -1,5 +1,5 @@
 import { useContext, useEffect } from 'react';
-import { CaptureProtection } from 'react-native-capture-protection';
+import { CaptureProtection, ContentMode } from 'react-native-capture-protection';
 import { BlueStorageContext } from './storage-context';
 
 interface PrivacyComponent extends React.FC {
@@ -28,7 +28,11 @@ const Privacy: PrivacyComponent = () => {
 
 Privacy.enableBlur = () => {
   if (!isPrivacyBlurEnabledRef) return;
-  CaptureProtection.prevent().catch(() => {});
+  // Show the branded splash (matching the native LaunchScreen) instead of the library's default
+  // white cover. screenshot/record are passed explicitly because prevent() only defaults them to
+  // true when called with NO argument — with a partial option they default to false.
+  const cover = { image: require('../img/dfx/splash.png'), backgroundColor: '#072440' as const, contentMode: ContentMode.center };
+  CaptureProtection.prevent({ screenshot: true, record: cover, appSwitcher: cover }).catch(() => {});
 };
 
 Privacy.disableBlur = () => {

--- a/blue_modules/storage-context.js
+++ b/blue_modules/storage-context.js
@@ -273,8 +273,11 @@ export const BlueStorageProvider = ({ children }) => {
     await saveToDisk();
     A(A.ENUM.CREATED_WALLET);
     majorTomToGroundControl(w.getAllExternalAddresses(), [], []);
-    // start balance fetching at the background
-    await w.fetchBalance();
+    // Background (don't await) so import/add flows navigate immediately instead of freezing on a
+    // slow/unreachable Electrum call; refresh the list again once the balance lands.
+    w.fetchBalance()
+      .then(() => setWallets([...BlueApp.getWallets()]))
+      .catch(e => console.warn('addAndSaveWallet: fetchBalance failed', e));
     w.fetchTransactions();
     setWallets([...BlueApp.getWallets()]);
   };

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -955,7 +955,8 @@ const styles = StyleSheet.create({
     paddingTop: 20,
   },
   root: {
-    flex: 1,
+    // flexGrow (not flex:1) so tall content can exceed the viewport and scroll when the keyboard is up
+    flexGrow: 1,
     justifyContent: 'space-between',
   },
   scrollViewContent: {

--- a/screen/wallets/addMultisigStep2.js
+++ b/screen/wallets/addMultisigStep2.js
@@ -1,5 +1,5 @@
 import React, { useContext, useRef, useState, useEffect, useMemo } from 'react';
-import { FlatList, LayoutAnimation, Platform, StyleSheet, Text, View } from 'react-native';
+import { Alert, FlatList, LayoutAnimation, Platform, StyleSheet, Text, View } from 'react-native';
 import { Icon } from 'react-native-elements';
 import { useNavigation, useRoute, useTheme } from '@react-navigation/native';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
@@ -32,7 +32,8 @@ const WalletsAddMultisigStep2 = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [cosignerXpubURv2, setCosignerXpubURv2] = useState(''); // string displayed in renderCosignersXpubModal()
   const [ownXpub, setOwnXpub] = useState('');
-  const scannedCache = {};
+  const [isError, setIsError] = useState(false);
+  const scannedCache = useRef({}).current; // ref so the scan-dedup cache survives re-renders
   const quorum = useRef(new Array(n));
 
   useEffect(() => {
@@ -211,7 +212,15 @@ const WalletsAddMultisigStep2 = () => {
     } catch (error) {}
   };
 
+  // Pause the scanner while a validation-error alert is open so an animated/repeated QR can't
+  // enqueue a burst of alerts that keep draining after the user navigates away.
+  const presentScanError = message => {
+    setIsError(true);
+    Alert.alert(loc.alert.default, message, [{ text: loc._.ok, onPress: () => setIsError(false) }]);
+  };
+
   const onBarCodeRead = ret => {
+    if (isError) return;
     const h = HashIt(ret.data);
     if (scannedCache[h]) {
       // this QR was already scanned by this ScanQRCode, lets prevent firing duplicate callbacks
@@ -260,21 +269,21 @@ const WalletsAddMultisigStep2 = () => {
     } catch (_) {}
 
     if (!new MultisigCosigner(ret.data).isValid()) {
-      return alert(loc.multisig.not_a_multisignature_xpub);
+      return presentScanError(loc.multisig.not_a_multisignature_xpub);
     }
 
     if (ret.data.toUpperCase().startsWith('UR')) {
-      alert('BC-UR not decoded. This should never happen');
+      presentScanError('BC-UR not decoded. This should never happen');
     } else {
       if (MultisigHDWallet.isXpubValid(ret.data) && !MultisigHDWallet.isXpubForMultisig(ret.data)) {
-        return alert(loc.multisig.not_a_multisignature_xpub);
+        return presentScanError(loc.multisig.not_a_multisignature_xpub);
       }
       if (MultisigHDWallet.isXpubValid(ret.data)) {
         return tryUsingXpub(ret.data);
       }
 
       let cosigner = new MultisigCosigner(ret.data);
-      if (!cosigner.isValid()) return alert(loc.multisig.invalid_cosigner);
+      if (!cosigner.isValid()) return presentScanError(loc.multisig.invalid_cosigner);
       if (cosigner.howManyCosignersWeHave() > 1) {
         // lets look for the correct cosigner. thats probably gona be the one with specific corresponding path,
         // for example m/48'/0'/0'/2' if user chose to setup native segwit in BW
@@ -342,7 +351,7 @@ const WalletsAddMultisigStep2 = () => {
           throw new Error('This should never happen');
       }
 
-      if (!correctFormat) return alert(loc.formatString(loc.multisig.invalid_cosigner_format, { format }));
+      if (!correctFormat) return presentScanError(loc.formatString(loc.multisig.invalid_cosigner_format, { format }));
 
       const cosignersCopy = [...cosigners];
       cosignersCopy.push([cosigner.getXpub(), cosigner.getFp(), cosigner.getPath()]);
@@ -387,7 +396,7 @@ const WalletsAddMultisigStep2 = () => {
       </View>
       <View style={styles.cameraContainer}>
         <Camera
-          scanBarcode
+          scanBarcode={!isError}
           scanThrottleDelay={0}
           onReadCode={event => onBarCodeRead({ data: event?.nativeEvent?.codeStringValue })}
           style={styles.camera}

--- a/screen/wallets/asset.js
+++ b/screen/wallets/asset.js
@@ -55,8 +55,8 @@ const Asset = ({ navigation }) => {
   const [isLoading, setIsLoading] = useState(false);
   const multisigWallet = useMemo(() => wallets.find(w => w.type === MultisigHDWallet.type), [wallets]);
   const wallet = useMemo(() => wallets.find(w => w.getID() === walletID), [wallets, walletID]);
-  const [itemPriceUnit, setItemPriceUnit] = useState(wallet.getPreferredBalanceUnit());
-  const [dataSource, setDataSource] = useState(wallet.getTransactions(15));
+  const [itemPriceUnit, setItemPriceUnit] = useState(() => wallet?.getPreferredBalanceUnit());
+  const [dataSource, setDataSource] = useState(() => wallet?.getTransactions(15) ?? []);
   const [timeElapsed, setTimeElapsed] = useState(0);
   const [limit, setLimit] = useState(15);
   const [pageSize, setPageSize] = useState(20);
@@ -84,6 +84,7 @@ const Asset = ({ navigation }) => {
    * @returns {Array}
    */
   const getTransactionsSliced = (lmt = Infinity) => {
+    if (!wallet) return [];
     let txs = wallet.getTransactions();
     for (const tx of txs) {
       tx.sort_ts = +new Date(tx.received);
@@ -129,6 +130,7 @@ const Asset = ({ navigation }) => {
   }, [walletTransactionUpdateStatus]);
 
   useEffect(() => {
+    if (!wallet) return;
     setIsLoading(true);
     setLimit(15);
     setPageSize(20);
@@ -138,7 +140,7 @@ const Asset = ({ navigation }) => {
     setSelectedWallet(wallet.getID());
     setDataSource(wallet.getTransactions(15));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [walletID]);
+  }, [walletID, wallet]);
 
   useEffect(() => {
     const newWallet = wallets.find(w => w.getID() === walletID);
@@ -373,6 +375,9 @@ const Asset = ({ navigation }) => {
         return null;
     }
   };
+
+  // Wallet can become undefined mid-render when it is deleted while this screen is still mounted.
+  if (!wallet) return null;
 
   return (
     <View style={styles.flex}>

--- a/screen/wallets/details.js
+++ b/screen/wallets/details.js
@@ -167,10 +167,15 @@ const WalletDetails = () => {
     reset();
   };
 
-  const deleteCurrentWallet = () => {
-    navigate('WalletTransactions');
+  const deleteCurrentWallet = async () => {
     deleteWallet(wallet);
-    saveToDisk();
+    // Await the Realm-backed save (which opens + closes a Realm) BEFORE navigating away, so the
+    // save's microtask can't race the navigation teardown — that race is what crashes the release
+    // build (use-after-close of a Realm collection Proxy).
+    await saveToDisk();
+    // popToTop tears down WalletDetails/Settings/WalletAsset for the deleted wallet deterministically
+    // and lands on the home root, instead of relying on a navigate-to-root pop to reconcile.
+    dispatch(StackActions.popToTop());
   };
 
   const navigateToOverviewAndDeleteWallet = () => {

--- a/screen/wallets/home.js
+++ b/screen/wallets/home.js
@@ -61,8 +61,8 @@ const WalletHome = ({ navigation }) => {
     const total = new WatchOnlyWallet();
     total.setLabel(loc.wallets.total);
     total.balance = wallets.reduce((prev, curr) => prev + (curr.isDummy ? 0 : curr.getBalance()), 0);
-    total.hideBalance = wallet.hideBalance;
-    total.preferredBalanceUnit = wallet.preferredBalanceUnit;
+    total.hideBalance = wallet?.hideBalance;
+    total.preferredBalanceUnit = wallet?.preferredBalanceUnit;
     return total;
   }, [wallets, wallet]);
 
@@ -81,7 +81,7 @@ const WalletHome = ({ navigation }) => {
   useEffect(() => {
     setIsLoading(true);
     setIsLoading(false);
-    setSelectedWallet(wallet.getID());
+    if (wallet) setSelectedWallet(wallet.getID());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [walletID]);
 


### PR DESCRIPTION
## Summary

Seven focused fixes found while testing the `develop` build on a physical iPhone (iOS 26) and Android (Android 14). Each is a single, self-contained commit so they can be reviewed — or cherry-picked — independently.

## Fixes

- **Multisig delete crash** (`0bceca7c`) — deleting the multisig wallet removes it from the shared wallets context, so still-mounted screens (`asset.js`, `home.js`) re-render referencing the just-deleted wallet (`getPreferredBalanceUnit`/`hideBalance`/`getID`) with no guard → JS redbox; and `deleteCurrentWallet` navigated *before* the un-awaited `saveToDisk()` finished, so a Realm collection Proxy was accessed after `realm.close()` during teardown → native Hermes `SIGSEGV` in release builds (matches the App Store Connect crash: `EXC_BAD_ACCESS` in hermes `Reflect.get` ← Realm `OrderedCollection`). Guard the post-delete renders; in `deleteCurrentWallet` `await saveToDisk()` then `StackActions.popToTop()`.

- **Send screen won't scroll** (`b7d17745`) — the content `View` used `flex: 1` inside the ScrollView, collapsing it to exactly viewport height so there was no overflow to scroll to the Create button with the keyboard up. Use `flexGrow: 1`.

- **Face ID / lock screen shows white** (`244dcf60`) — `UnlockWith` root had no `backgroundColor` and referenced an undefined `styles.splash`, so the (white) logo sat on a white background; the app-switcher privacy cover used the library's default white. Add the brand background (`#072440`, matching `LaunchScreen`) + the splash style, and pass a branded capture-protection cover.

- **CI: duplicate iOS TestFlight upload per develop merge** (`10b2bc0e`) — every merge to `develop` built iOS twice: `deploy-develop.yml`'s `ios-testflight` job (`fastlane beta`) **and** `auto-tag` → `release.yml` (`fastlane release`), both calling `upload_to_testflight`. Remove the redundant `ios-testflight` job; the tag flow owns iOS TestFlight. (Addresses the review note on #190.)

- **Unhandled rejection on app-state change** (`1ed5b4d9`) — `handleAppStateChange` dereferenced `nextAppState.match()` without guarding `undefined` (which it already handles two lines above/below); being `async`, the throw surfaced as an unhandled promise rejection on startup. Optional-chain the access.

- **Multisig cosigner scanner fires a runaway alert burst** (`bd5a16a1`) — the cosigner scanner ran with `scanThrottleDelay={0}` and no gate while a validation alert was open, and its dedup cache was a plain object re-created every render. An invalid / animated-UR QR therefore fired a burst of native alerts; iOS queues these, so they keep draining one-by-one even after navigating to another screen. Gate `onBarCodeRead` with an `isError` flag (mirroring `importMultisignature`) and make the dedup cache a `useRef`.

- **Import screen freezes; "Import" does nothing** (`3db63f2d`) — `addAndSaveWallet` `await`ed `w.fetchBalance()` (a blocking Electrum call) before the import flow navigates, despite the adjacent comment saying balance should load in the background (the wallet is already persisted by the preceding `saveToDisk()`). On a slow/unreachable server the button looked dead. Run the balance fetch in the background (matching `fetchTransactions`) and refresh the list once it lands. Affects all add/import flows.

## Testing

Built and run on a physical iPhone (iOS 26.5) and Android device (Android 14) against `develop`. Verified on-device: Send-screen scroll, Face-ID lock-screen splash, and multisig-delete (no crash). The multisig-alert burst was intermittent/unreproducible, so that fix is based on code analysis of the scan path; the import, app-state, and CI fixes are likewise targeted code fixes.

Base: `develop`.
