### PR TITLE
fix(release): ship Android to Play internal track, not open testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Release
 # Triggers on every vX.Y.Z tag and routes by PATCH:
 #   PATCH == 0 (vX.Y.0) -> production-candidate (GitHub release, prerelease: false)
 #   PATCH >= 1 (vX.Y.Z) -> internal release (auto-tag output, prerelease: true)
-# Both lanes ship to the test tracks (TestFlight + Play beta); production
+# Both lanes ship to the test tracks (TestFlight + Play internal); production
 # promotion stays a manual console action.
 #
 # Required secrets:
@@ -113,7 +113,7 @@ jobs:
         run: bundle exec fastlane release
 
   android-deploy:
-    name: Android -> Play beta + listing
+    name: Android -> Play internal + listing
     needs: [guard, preflight]
     if: needs.guard.outputs.proceed == 'true'
     runs-on: ubuntu-latest
@@ -148,7 +148,7 @@ jobs:
           working-directory: android
       - name: Write Play service account
         run: echo "${{ secrets.PLAY_STORE_JSON_BASE64 }}" | base64 -d > android/credentials.json
-      - name: Build attested AAB + upload to Play beta + stage listing
+      - name: Build attested AAB + upload to Play internal + stage listing
         working-directory: android
         env:
           NEW_VERSION: ${{ github.ref_name }}

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -18,9 +18,9 @@ def resolve_release_info(raw_tag)
 end
 
 platform :android do
-  # Open Testing ("beta"): public, link-shareable track.
+  # Internal Testing: private track for the team's testers.
   def release_track
-    "beta"
+    "internal"
   end
 
   # The attested AAB produced by scripts/build-release-apk.sh (relative to android/).
@@ -28,7 +28,7 @@ platform :android do
     "app/build/outputs/bundle/release/app-release-transparent.aab"
   end
 
-  desc "Build the attested AAB and upload to Play Store beta + stage the listing"
+  desc "Build the attested AAB and upload to Play Store internal + stage the listing"
   lane :release do
     info = resolve_release_info(ENV["NEW_VERSION"] || "dev")
 

--- a/docs/release-pipeline-setup.md
+++ b/docs/release-pipeline-setup.md
@@ -2,7 +2,7 @@
 
 One-time provisioning for the tag-driven store-release pipeline (see
 `docs/release-pipeline.md` for how it works). Do these once on the **`DFXswiss/btc-wallet`**
-repo; afterwards every `vX.Y.Z` tag ships to TestFlight + Play beta automatically.
+repo; afterwards every `vX.Y.Z` tag ships to TestFlight + Play internal automatically.
 
 > No secret *values* belong in this file or the repo — this only says **where to get each key**.
 > Add every secret under: GitHub repo → **Settings → Secrets and variables → Actions → New repository secret**
@@ -85,7 +85,7 @@ capability"* — the same error class we hit signing on a device. Enabling them 
 ### 3. Google Play Console
 - Ensure the `swiss.dfx.bitcoin` app exists.
 - Create the **service account** + grant release permissions (see `PLAY_STORE_JSON_BASE64`).
-- Make sure an **Open Testing ("beta")** track exists.
+- Make sure an **Internal Testing ("internal")** track exists.
 
 ### 4. Store listing content (unblocks the preflight)
 The preflight (`scripts/check-store-metadata.sh`) blocks a release while any `FIXME-` remains. Fill these for **both** `de-DE` and `en-US`:
@@ -99,5 +99,5 @@ Limits enforced: iOS name/subtitle 30, keywords 100, promo 170, description 4000
 ## First run / dry run
 1. Add all secrets; complete steps 1–4.
 2. Push a test tag (e.g. `v0.0.1`) or merge to `develop` (auto-tag creates the next tag).
-3. The `release` workflow runs: guard → preflight → iOS (TestFlight) + Android (Play beta) → GitHub release.
+3. The `release` workflow runs: guard → preflight → iOS (TestFlight) + Android (Play internal) → GitHub release.
 4. Expect the **iOS signing step may need a small first-run tweak** (normal for CI iOS). Promotion to production stays a manual click in each console.

--- a/docs/release-pipeline.md
+++ b/docs/release-pipeline.md
@@ -27,7 +27,7 @@ All implemented in one PR ([#181](https://github.com/DFXswiss/btc-wallet/pull/18
 | ----- | -------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | 1     | Versioning generator + `auto-tag` + `release` skeleton (guard + version + concurrency) | ✅ done, validated (`v9.9.9` test tag)                                  |
 | 2     | iOS lane: `match` + `gym` + `upload_to_testflight` + staged `deliver`                  | ✅ implemented (needs certs repo + ASC)                                 |
-| 3     | Android lane: `supply` → Play `beta`, on the attested AAB                              | ✅ implemented (needs Play service account)                             |
+| 3     | Android lane: `supply` → Play `internal`, on the attested AAB                              | ✅ implemented (needs Play service account)                             |
 | 4     | metadata (de-DE/en-US) + `check-store-metadata.sh` + `store-metadata.yml`              | ✅ scaffolded (real copy + legal URLs are `FIXME-`, gated by preflight) |
 | 5     | Cleanup: remove placeholder `custom_lane`; remove legacy CircleCI / App Center         | ✅ done (both deleted; BlueWallet upstream had already removed them)    |
 
@@ -54,7 +54,7 @@ All implemented in one PR ([#181](https://github.com/DFXswiss/btc-wallet/pull/18
 - Manual **`vX.Y.0`** tag (MAJOR/MINOR) = **production candidate**.
 - **`release.yml`** — on `push: tags: v*`:
   - **guard** validates the strict `vX.Y.Z` shape and routes the lane: `PATCH==0` → production candidate (GitHub release, `prerelease: false`); `PATCH>=1` → internal release (`prerelease: true`).
-  - both lanes ship to the **test tracks** (TestFlight + Play `beta`); production promotion stays a manual console action.
+  - both lanes ship to the **test tracks** (TestFlight + Play `internal`); production promotion stays a manual console action.
   - `concurrency: store-release`, `cancel-in-progress: false` — serialises store uploads so back-to-back tags can't race the same slot.
 
 ### Day-to-day: how to ship a version
@@ -81,7 +81,7 @@ All implemented in one PR ([#181](https://github.com/DFXswiss/btc-wallet/pull/18
 `android/fastlane/` (`Fastfile` + `Appfile` + `credentials.json` from a base64 secret) `beta` lane, on top of the existing signed/attested AAB:
 
 1. Build the signed AAB (reuse `build-release-apk.sh` + `KEYSTORE_*` / `TRANSPARENCY_*`).
-2. **`upload_to_play_store`** track `beta` (Open Testing) — AAB **+ changelog**, `skip_upload_metadata/images/screenshots: true`.
+2. **`upload_to_play_store`** track `internal` (Internal Testing) — AAB **+ changelog**, `skip_upload_metadata/images/screenshots: true`.
 3. A **second** `upload_to_play_store` pushing **only** metadata + images + screenshots (no changelog).
 
 - `Appfile`: `package_name("swiss.dfx.bitcoin")`, `json_key_file("./credentials.json")` (Play service account).
@@ -128,7 +128,7 @@ No secret **values** live in this repo — only names. Provision them in repo/or
 
 1. **`match` certs repo:** dedicated private repo `DFXswiss/btc-wallet-certificates`.
 2. **Languages:** trim to `de-DE` + `en-US`; drop unmaintained inherited locales.
-3. **Android track:** `beta` (Open Testing) for the automated lane; production promotion manual.
+3. **Android track:** `internal` (Internal Testing) for the automated lane; production promotion manual.
 4. **Screenshots:** committed/versioned set in-repo for the first cut; automated capture deferred.
 
 ## RN ≠ Flutter deltas (don't blindly copy RealUnit's Flutter commands)
@@ -144,7 +144,7 @@ No secret **values** live in this repo — only names. Provision them in repo/or
 
 - [x] Single-source version generator drives both platforms from the Git tag; tagless build hard-fails. _(phase 1)_
 - [x] `auto-tag` on `develop` produces internal-release tags; `vX.Y.0` = production candidate. _(phase 1)_
-- [ ] One `release` workflow on `v*` builds **and uploads** iOS (TestFlight) **and** Android (Play `beta`) from a single tag.
+- [ ] One `release` workflow on `v*` builds **and uploads** iOS (TestFlight) **and** Android (Play `internal`) from a single tag.
 - [ ] iOS listing (texts + screenshots) staged via `deliver` (never auto-submitted).
 - [ ] Android listing (texts + images + screenshots) via `supply`, separate from the binary/changelog upload.
 - [ ] `store-metadata.yml` syncs listing-only changes on demand and on metadata changes.


### PR DESCRIPTION
## What
Point the Android release lane's `release_track` at **`internal`** (Internal Testing) instead of **`beta`** (Open Testing), and update the now-stale "beta" labels/docs.

## Why
The team only uses the **Internal Testing** track. Open Testing is currently paused on the Play Console, so tagged releases built the AAB but never reached testers. The `store_metadata` lane was already hard-pinned to `internal`; this aligns the `release` lane with it.

## Changes
- `android/fastlane/Fastfile` — `release_track` `beta` → `internal` (single source of truth for the AAB+changelog and listing uploads).
- `.github/workflows/release.yml` — header comment + job/step names ("Play beta" → "Play internal").
- `docs/release-pipeline.md`, `docs/release-pipeline-setup.md` — Android-track references updated.

iOS `beta` lane name (TestFlight) is intentionally untouched — unrelated to the Play track. Production promotion stays a manual console action.

## Setup note
The Play service account needs release permission on the **Internal Testing** track (Open Testing is no longer used by the automated lane).