### PR TITLE
fix(android): drop READ_MEDIA_IMAGES merged by capture-protection

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" tools:node="remove"/>
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
     <uses-permission android:name="android.permission.NFC" />


### PR DESCRIPTION
The `Android -> Play internal` release job fails at `upload_to_play_store`:

```
Google Api Error: Invalid request - All developers requesting access to the
photo and video permissions are required to tell Google Play about the core
functionality of their app
```

### Cause
`react-native-capture-protection` declares `READ_MEDIA_IMAGES` (Android 13/14) in its manifest, which merges into the app manifest. The app has no photo/video feature that uses it, but its mere presence makes Google Play require a Photo & Video Permissions declaration, blocking the AAB upload.

### Fix
Remove the permission at manifest-merge time:

```xml
<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" tools:node="remove"/>
```

The final AAB no longer requests photo/video access, so Play stops requiring the declaration. Screen-capture protection does not depend on media-read and is unaffected.