### PR TITLE
fix(store): match App Store + Play listing metadata to the live values

### DIFF
--- a/ios/fastlane/metadata/de-DE/name.txt
+++ b/ios/fastlane/metadata/de-DE/name.txt
@@ -1,1 +1,1 @@
-DFX Bitcoin
+DFX BTC Taro Wallet

--- a/ios/fastlane/metadata/de-DE/subtitle.txt
+++ b/ios/fastlane/metadata/de-DE/subtitle.txt
@@ -1,1 +1,1 @@
-Selbstverwahrte Bitcoin-Wallet
+Bitcoin & Lightning

--- a/ios/fastlane/metadata/en-US/name.txt
+++ b/ios/fastlane/metadata/en-US/name.txt
@@ -1,1 +1,1 @@
-DFX Bitcoin
+DFX BTC Taro Wallet

--- a/ios/fastlane/metadata/en-US/subtitle.txt
+++ b/ios/fastlane/metadata/en-US/subtitle.txt
@@ -1,1 +1,1 @@
-Self-custodial Bitcoin wallet
+Bitcoin & Lightning


### PR DESCRIPTION
## What

Align the iOS **and** Android fastlane store metadata with the **live store listings** so a release no longer changes the published name/subtitle.

When the release pipeline (#181) was wired up, the metadata was authored fresh rather than copied from the live listings, so it diverged. On iOS, App Store Connect flags Name + Subtitle (EN + DE) on submit. On Android the divergence is worse: the release lane uploads listing text (`skip_upload_metadata: false`), so it would silently overwrite the live Play listing on the next release — no manual diff to catch it.

### iOS (`ios/fastlane/metadata/`)
| File | Before | After (live) |
|---|---|---|
| `en-US/name.txt`, `de-DE/name.txt` | DFX Bitcoin | DFX BTC Taro Wallet |
| `en-US/subtitle.txt`, `de-DE/subtitle.txt` | Self-custodial Bitcoin wallet / Selbstverwahrte Bitcoin-Wallet | Bitcoin & Lightning |

### Android (`android/fastlane/metadata/android/`)
| File | Before | After (live) |
|---|---|---|
| `en-US/title.txt`, `de-DE/title.txt` | DFX Bitcoin | DFX BTC Taro Wallet |
| `en-US/short_description.txt`, `de-DE/short_description.txt` | Self-custodial Bitcoin wallet / Selbstverwahrende Bitcoin-Wallet | Bitcoin & Lightning |

Privacy URLs (both platforms) and the long descriptions (`full_description` already identical to the iOS `description`) already matched live and are unchanged.

## Why

So the pipeline's metadata upload stops altering the live store listings on every release. No app/binary changes.