### PR TITLE
fix(android): match Play Store listing metadata to the live values

### DIFF
--- a/android/fastlane/metadata/android/de-DE/short_description.txt
+++ b/android/fastlane/metadata/android/de-DE/short_description.txt
@@ -1,1 +1,1 @@
-Selbstverwahrende Bitcoin-Wallet
+Bitcoin & Lightning

--- a/android/fastlane/metadata/android/de-DE/title.txt
+++ b/android/fastlane/metadata/android/de-DE/title.txt
@@ -1,1 +1,1 @@
-DFX Bitcoin
+DFX BTC Taro Wallet

--- a/android/fastlane/metadata/android/en-US/short_description.txt
+++ b/android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,1 +1,1 @@
-Self-custodial Bitcoin wallet
+Bitcoin & Lightning

--- a/android/fastlane/metadata/android/en-US/title.txt
+++ b/android/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-DFX Bitcoin
+DFX BTC Taro Wallet


### PR DESCRIPTION
## What

Follow-up to #195 (which fixed the iOS side). Align the Android fastlane metadata with the live Play listing so a release no longer changes the published title/short description.

The Android release lane uploads listing text on every release (`skip_upload_metadata: false`), so the authored-divergent values would **silently overwrite the live Play listing** — there's no manual submit diff like App Store Connect, so this is the more important half to land.

| File | Before | After (live) |
|---|---|---|
| `en-US/title.txt`, `de-DE/title.txt` | DFX Bitcoin | DFX BTC Taro Wallet |
| `en-US/short_description.txt`, `de-DE/short_description.txt` | Self-custodial Bitcoin wallet / Selbstverwahrende Bitcoin-Wallet | Bitcoin & Lightning |

`full_description` already matches the iOS `description` in both locales, and the Play graphics/screenshots are untouched. No app/binary changes.

## Why

So the pipeline's metadata upload stops altering the live Play listing on every release.