### PR TITLE
fix: privateNegate in noble_ecc shim; rework wallet header for Android edge-to-edge

### DIFF
--- a/blue_modules/noble_ecc.ts
+++ b/blue_modules/noble_ecc.ts
@@ -20,6 +20,8 @@ export interface TinySecp256k1InterfaceExtended {
   isXOnlyPoint(p: Uint8Array): boolean;
 
   xOnlyPointAddTweak(p: Uint8Array, tweak: Uint8Array): XOnlyPointAddTweakResult | null;
+
+  privateNegate(d: Uint8Array): Uint8Array;
 }
 
 necc.utils.sha256Sync = (...messages: Uint8Array[]): Uint8Array => {
@@ -119,7 +121,7 @@ const ecc: TinySecp256k1InterfaceExtended & TinySecp256k1Interface & TinySecp256
       return ret;
     }),
 
-  // privateNegate: (d: Uint8Array): Uint8Array => necc.utils.privateNegate(d),
+  privateNegate: (d: Uint8Array): Uint8Array => necc.utils.privateNegate(d),
 
   sign: (h: Uint8Array, d: Uint8Array, e?: Uint8Array): Uint8Array => {
     return necc.signSync(h, d, { der: false, extraEntropy: e });

--- a/components/DfxServicesButtons.tsx
+++ b/components/DfxServicesButtons.tsx
@@ -218,7 +218,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'center',
     alignItems: 'center',
-    marginVertical: 10,
+    marginVertical: 6,
     gap: 10,
   },
 });

--- a/components/FloatButtons.js
+++ b/components/FloatButtons.js
@@ -1,6 +1,6 @@
 import React, { useState, useRef, forwardRef } from 'react';
 import PropTypes from 'prop-types';
-import { View, Text, TouchableOpacity, StyleSheet, Dimensions, PixelRatio } from 'react-native';
+import { View, Text, TouchableOpacity, StyleSheet, Dimensions, PixelRatio, Platform } from 'react-native';
 import { useTheme } from '@react-navigation/native';
 
 const BORDER_RADIUS = 30;
@@ -15,7 +15,7 @@ const cStyles = StyleSheet.create({
   },
   rootAbsolute: {
     position: 'absolute',
-    bottom: 30,
+    bottom: Platform.OS === 'android' ? 20 : 30,
   },
   rootInline: {},
   rootPre: {

--- a/components/TransactionsNavigationHeader.js
+++ b/components/TransactionsNavigationHeader.js
@@ -19,10 +19,12 @@ export default class TransactionsNavigationHeader extends Component {
     width: PropTypes.number,
     showRBFWarning: PropTypes.bool,
     rightHeaderComponent: PropTypes.element,
+    headerOverlayHeight: PropTypes.number,
   };
 
   static defaultProps = {
     showRBFWarning: false,
+    headerOverlayHeight: 0,
   };
 
   static actionKeys = {
@@ -182,7 +184,8 @@ export default class TransactionsNavigationHeader extends Component {
 
     const stylesHook = StyleSheet.create({
       lineaderGradient: {
-        minHeight: this.props.showRBFWarning ? 100 : 140,
+        minHeight: (this.props.showRBFWarning ? 85 : 120) + this.props.headerOverlayHeight,
+        paddingTop: this.props.headerOverlayHeight > 0 ? this.props.headerOverlayHeight : 15,
       },
     });
 

--- a/screen/wallets/asset.js
+++ b/screen/wallets/asset.js
@@ -19,6 +19,7 @@ import {
 } from 'react-native';
 import { Icon } from 'react-native-elements';
 import { useRoute, useNavigation, useTheme, useFocusEffect } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Chain } from '../../models/bitcoinUnits';
 import navigationStyle from '../../components/navigationStyle';
 import { MultisigHDWallet, WatchOnlyWallet } from '../../class';
@@ -60,10 +61,12 @@ const Asset = ({ navigation }) => {
   const [timeElapsed, setTimeElapsed] = useState(0);
   const [limit, setLimit] = useState(15);
   const [pageSize, setPageSize] = useState(20);
-  const { setParams, setOptions, navigate } = useNavigation();
+  const { setParams, setOptions, navigate, goBack } = useNavigation();
   const { colors, scanImage } = useTheme();
   const walletActionButtonsRef = useRef();
   const { width } = useWindowDimensions();
+  const insets = useSafeAreaInsets();
+  const headerOverlayHeight = insets.top + 44;
   const [fContainerHeight, setFContainerHeight] = useState(0);
   const elapsedTimeInterval = useRef(null);
 
@@ -386,6 +389,7 @@ const Asset = ({ navigation }) => {
         navigation={navigation}
         wallet={wallet}
         width={width}
+        headerOverlayHeight={headerOverlayHeight}
         onWalletChange={passedWallet =>
           InteractionManager.runAfterInteractions(async () => {
             setItemPriceUnit(passedWallet.getPreferredBalanceUnit());
@@ -394,6 +398,22 @@ const Asset = ({ navigation }) => {
         }
         rightHeaderComponent={renderRightHeaderComponent()}
       />
+      {Platform.OS === 'android' && (
+        <View style={[styles.navHeader, { top: insets.top }]}>
+          <TouchableOpacity accessibilityRole="button" testID="NavigationGoBack" style={styles.walletDetails} onPress={() => goBack()}>
+            <Icon name="arrow-back" type="material" size={22} color="#FFFFFF" />
+          </TouchableOpacity>
+          <Text style={styles.navHeaderTitle}>{walletTransactionUpdateStatus === walletID ? loc.transactions.updating : ''}</Text>
+          <TouchableOpacity
+            accessibilityRole="button"
+            testID="Settings"
+            style={styles.walletDetails}
+            onPress={() => walletID && navigate('Settings', { walletID })}
+          >
+            <Icon name="more-horiz" type="material" size={22} color="#FFFFFF" />
+          </TouchableOpacity>
+        </View>
+      )}
       {!isMultiSig() && <DfxServicesButtons walletID={wallet.getID()} />}
       {isLightningTestnet() && (
         <View style={styles.testnetBanner}>
@@ -476,36 +496,58 @@ const Asset = ({ navigation }) => {
 
 export default Asset;
 
-Asset.navigationOptions = navigationStyle({}, (options, { navigation, route }) => ({
-  ...options,
-  headerStyle: {
-    backgroundColor: 'transparent',
-    borderBottomWidth: 0,
-    elevation: 0,
-    shadowOffset: { height: 0, width: 0 },
-  },
-  headerRight: () => (
-    <TouchableOpacity
-      accessibilityRole="button"
-      testID="Settings"
-      style={styles.walletDetails}
-      onPress={() => {
-        route?.params?.walletID &&
-          navigation.navigate('Settings', {
-            walletID: route?.params?.walletID,
-          });
-      }}
-    >
-      <Icon name="more-horiz" type="material" size={22} color="#FFFFFF" />
-    </TouchableOpacity>
-  ),
-}));
+Asset.navigationOptions = navigationStyle({}, (options, { navigation, route }) => {
+  if (Platform.OS === 'android') {
+    return {
+      ...options,
+      headerShown: false,
+    };
+  }
+
+  return {
+    ...options,
+    headerTransparent: true,
+    headerStyle: {
+      backgroundColor: 'transparent',
+    },
+    headerRight: () => (
+      <TouchableOpacity
+        accessibilityRole="button"
+        testID="Settings"
+        style={styles.walletDetails}
+        onPress={() => {
+          route?.params?.walletID &&
+            navigation.navigate('Settings', {
+              walletID: route?.params?.walletID,
+            });
+        }}
+      >
+        <Icon name="more-horiz" type="material" size={22} color="#FFFFFF" />
+      </TouchableOpacity>
+    ),
+  };
+});
 
 Asset.propTypes = {
   navigation: PropTypes.shape(),
 };
 
 const styles = StyleSheet.create({
+  navHeader: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    height: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    zIndex: 1,
+  },
+  navHeaderTitle: {
+    color: '#FFFFFF',
+    fontWeight: '600',
+  },
   payCardImage: {
     width: 1.3 * 30,
     height: 30,

--- a/screen/wallets/home.js
+++ b/screen/wallets/home.js
@@ -16,6 +16,7 @@ import {
 } from 'react-native';
 import { Icon } from 'react-native-elements';
 import { useRoute, useNavigation, useTheme, useIsFocused } from '@react-navigation/native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as bitcoin from 'bitcoinjs-lib';
 import { BlueListItem, SecondButton } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
@@ -48,13 +49,15 @@ const WalletHome = ({ navigation }) => {
   const multisigWallet = useMemo(() => wallets.find(w => w.type === MultisigHDWallet.type), [wallets]);
   const lnWallet = useMemo(() => wallets.find(w => w.type === LightningLdsWallet.type), [wallets]);
   const [, setIsLoading] = useState(false);
-  const { name } = useRoute();
+  const { name, params } = useRoute();
   const { setParams, navigate } = useNavigation();
   const { colors, scanImage } = useTheme();
   const walletActionButtonsRef = useRef();
   const { width } = useWindowDimensions();
   const isFocused = useIsFocused();
   const getPrivateText = usePrivateText();
+  const insets = useSafeAreaInsets();
+  const headerOverlayHeight = insets.top + 44;
 
   const wallet = useMemo(() => wallets.find(w => w.getID() === walletID), [wallets, walletID]);
   const totalWallet = useMemo(() => {
@@ -75,6 +78,15 @@ const WalletHome = ({ navigation }) => {
     },
     comingSoon: {
       color: colors.alternativeTextColor,
+    },
+    backupSeed: {
+      backgroundColor: params?.backupWarning ? '#FFF389' : colors.buttonBackgroundColor,
+    },
+    backupSeedText: {
+      marginLeft: 4,
+      color: colors.buttonAlternativeTextColor,
+      fontWeight: '600',
+      fontSize: 14,
     },
   });
 
@@ -300,6 +312,7 @@ const WalletHome = ({ navigation }) => {
         navigation={navigation}
         wallet={totalWallet}
         width={width}
+        headerOverlayHeight={headerOverlayHeight}
         showRBFWarning={!wallet.allowRBF()}
         onWalletChange={total =>
           InteractionManager.runAfterInteractions(async () => {
@@ -311,6 +324,30 @@ const WalletHome = ({ navigation }) => {
           })
         }
       />
+      {Platform.OS === 'android' && (
+        <View style={[styles.navHeader, { top: insets.top }]}>
+          {params?.showsBackupSeed ? (
+            <TouchableOpacity
+              accessibilityRole="button"
+              testID="backupSeed"
+              style={[styles.backupSeedButton, stylesHook.backupSeed]}
+              onPress={() => navigate('BackupSeedRoot', { screenName: 'BackupExplanation' })}
+            >
+              <View style={styles.backupSeedContainer}>
+                {params?.backupWarning && <Icon name="warning-outline" type="ionicon" size={18} color="#FFFFFF" />}
+                <Text style={stylesHook.backupSeedText}>
+                  {params?.backupWarning ? loc.wallets.backupSeedWarning : loc.wallets.backupSeed}
+                </Text>
+              </View>
+            </TouchableOpacity>
+          ) : (
+            <View />
+          )}
+          <TouchableOpacity accessibilityRole="button" testID="Settings" style={styles.walletDetails} onPress={() => navigate('Settings')}>
+            <Icon name="more-horiz" type="material" size={22} color="#FFFFFF" />
+          </TouchableOpacity>
+        </View>
+      )}
       <DfxServicesButtons />
       <View style={[styles.list, stylesHook.list]}>
         {displayWallets.map((item, i) => (
@@ -399,12 +436,19 @@ const WalletHome = ({ navigation }) => {
 export default WalletHome;
 
 WalletHome.navigationOptions = navigationStyle({}, (options, { theme, navigation, route }) => {
+  if (Platform.OS === 'android') {
+    return {
+      ...options,
+      headerShown: false,
+      gestureEnabled: false,
+    };
+  }
+
   const stylesHook = StyleSheet.create({
     backupSeed: {
       height: 34,
       padding: 8,
       borderRadius: 8,
-      backgroundColor: Platform.OS === 'ios' ? undefined : route?.params?.backupWarning ? '#FFF389' : theme.colors.buttonBackgroundColor,
     },
     backupSeedText: {
       marginLeft: 4,
@@ -415,6 +459,7 @@ WalletHome.navigationOptions = navigationStyle({}, (options, { theme, navigation
   });
 
   return {
+    ...options,
     headerLeft: () =>
       route?.params?.showsBackupSeed ? (
         <TouchableOpacity
@@ -444,15 +489,11 @@ WalletHome.navigationOptions = navigationStyle({}, (options, { theme, navigation
       </TouchableOpacity>
     ),
     title: '',
+    headerTransparent: true,
     headerStyle: {
       backgroundColor: 'transparent',
-      borderBottomWidth: 0,
-      elevation: 0,
-      // shadowRadius: 0,
-      shadowOffset: { height: 0, width: 0 },
     },
     headerTintColor: '#FFFFFF',
-    headerBackTitleVisible: false,
     headerBackVisible: false,
     gestureEnabled: false,
   };
@@ -473,6 +514,22 @@ const styles = StyleSheet.create({
   walletDetails: {
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  navHeader: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    height: 44,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    zIndex: 1,
+  },
+  backupSeedButton: {
+    height: 34,
+    padding: 8,
+    borderRadius: 8,
   },
   backupSeedContainer: {
     flex: 1,


### PR DESCRIPTION
Two fixes: a startup crash in the noble_ecc shim, and a rework of the wallet header for Android 15 edge-to-edge.

## 1. Startup crash: `ecc.privateNegate is not a function`

### Problem

The app can crash at module load with:

```
Uncaught Error: ecc.privateNegate is not a function (it is undefined)
  at testecc.js:23
```

Call chain: `HDSegwitP2SHWallet` → `BIP47Factory(ecc)` → `bip32` → `testEcc(ecc)` → `ecc.privateNegate()`.

`@spsina/bip47` declares `bip32: ^3.0.1`. `bip32@3.1.0` added `privateNegate` assertions to its init-time `testEcc` (testecc.js:23-25), so any install where bip47's range resolves to 3.1.0 (instead of deduping to the top-level 3.0.1 pin) crashes on startup, because `privateNegate` is commented out in `blue_modules/noble_ecc.ts`.

Reproduced on a Pixel 7 / API 36 emulator; whether a given environment crashes depends solely on which bip32 the install resolved, which is why it doesn't surface everywhere.

### Fix

Enable `privateNegate` in the noble_ecc shim, delegating to `necc.utils.privateNegate` (available in the installed `@noble/secp256k1@1.6.3`), and declare it on `TinySecp256k1InterfaceExtended`. Upstream BlueWallet master ships the same function.

### Verification

- All 3 `bip32@3.1.0` `testecc.js` privateNegate vectors pass against `necc.utils.privateNegate`
- `tsc --noEmit` clean, eslint clean

### Upstream provenance

This is the exact change BlueWallet shipped in [BlueWallet/BlueWallet@47acf76ef](https://github.com/BlueWallet/BlueWallet/commit/47acf76ef) (Aug 2024, #6867) — same interface member, same `necc.utils.privateNegate` delegation — so it closes a drift gap with upstream rather than introducing one. BlueWallet's current master has since rewritten the shim, but that version is coupled to `@noble/secp256k1` v3 / `@noble/hashes` / bitcoinjs v7 and isn't cherry-pickable onto our 1.6.3 stack.

## 2. Android edge-to-edge header rework (home & asset screens)

### Problem

Since the Android 15 upgrade (targetSdk 36), edge-to-edge is enforced and react-native-screens bakes the status-bar inset into the native-stack header unconditionally (`topInsetEnabled` is deprecated and a no-op). On the wallet home and asset screens this produced a tall empty band between the status bar and the wallet card, with the header buttons sitting too low (natively centered in a 56dp toolbar zone that isn't exposed to JS).

### Fix

Follows the approach upstream BlueWallet uses for its WalletTransactions hero header (`getWalletTransactionsOptions.tsx`):

- **Android**: hide the native header (`headerShown: false`) and render the nav buttons in JS, absolutely positioned over the hero — backup button/back arrow on the left, settings on the right, and the "updating…" status title on the asset screen (previously a native `headerTitle`, which would otherwise be lost)
- **iOS**: keep the native header with `headerTransparent: true`, preserving the native bar-button (liquid glass) styling
- **TransactionsNavigationHeader**: new optional `headerOverlayHeight` prop (`insets.top + 44`); the hero pads by it and grows its min-height so the wallet-card background extends behind the status bar and nav buttons on both platforms (third consumer `lndViewInvoice.js` is unaffected, prop defaults to 0)
- **Spacing**: hero body min-height 140→120 (RBF variant 100→85), DFX tile row `marginVertical` 10→6, Android float buttons `bottom` 30→20

### Verification

Checked on 3 API 36 emulators (5"/320dpi, Pixel 7/420dpi, 6.7"/480dpi) and iOS. The Pixel 7 shows a slightly larger top gap than the other two — that's its emulated display cutout inflating the safe-area inset, i.e. correct behavior, matching physical hardware.
