### PR TITLE
fix(android): support 16 KB page sizes (react-native-keychain 10, NDK r28)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         googlePlayServicesVersion = "16.+"
         googlePlayServicesIidVersion = "16.0.1"
         firebaseVersion = "21.1.0"
-        ndkVersion = "27.1.12297006"
+        ndkVersion = "28.2.13676358"
         kotlinVersion = '2.1.20'
         // Legacy alias consumed by some community libraries (e.g. react-native-camera-kit) that
         // still reference $kotlin_version in their build.gradle.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2908,7 +2908,7 @@ PODS:
     - Yoga
   - RNHandoff (0.0.3):
     - React
-  - RNKeychain (9.2.3):
+  - RNKeychain (10.0.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -3892,7 +3892,7 @@ SPEC CHECKSUMS:
   RNFS: 89de7d7f4c0f6bafa05343c578f61118c8282ed8
   RNGestureHandler: 884f03ad24511911552480eb2058266db0b177ce
   RNHandoff: bc8af5a86853ff13b033e7ba1114c3c5b38e6385
-  RNKeychain: 483402cf2b90647eb0cf569cebbc069d32addea4
+  RNKeychain: a2c134ab796272c3d605e035ab727591000b30f3
   RNLocalize: 1aedbc2c15073861a364174919d23c31c5924b16
   RNPermissions: 29cfd9c9bbb7f0bd35e702dc849e33b294feac52
   RNQrGenerator: 3318e98283e861e9d93e58111fc4de8e03e2ddb3
@@ -3910,6 +3910,6 @@ SPEC CHECKSUMS:
   Yoga: 5456bb010373068fc92221140921b09d126b116e
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 
-PODFILE CHECKSUM: 391bd443a99dadf42e4d20131d7fa4690f0db61e
+PODFILE CHECKSUM: a92df18318be23818a3e971cce0991f61d44fdb1
 
 COCOAPODS: 1.16.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "react-native-handoff": "github:BlueWallet/react-native-handoff#v0.0.4",
         "react-native-haptic-feedback": "2.3.4",
         "react-native-image-picker": "8.2.1",
-        "react-native-keychain": "9.2.3",
+        "react-native-keychain": "10.0.0",
         "react-native-linear-gradient": "2.8.3",
         "react-native-localize": "3.7.0",
         "react-native-nfc-manager": "^3.14.14",
@@ -17349,9 +17349,9 @@
       }
     },
     "node_modules/react-native-keychain": {
-      "version": "9.2.3",
-      "resolved": "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-9.2.3.tgz",
-      "integrity": "sha512-dbn50fk4HLr4JQ71X3j6ZSTbKv+G9s85Zv9cE2na7k7KGn1j+wxjqGTE3wG+WKB3nNEylgu/KXR99mtsC/hpRQ==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/react-native-keychain/-/react-native-keychain-10.0.0.tgz",
+      "integrity": "sha512-YzPKSAnSzGEJ12IK6CctNLU79T1W15WDrElRQ+1/FsOazGX9ucFPTQwgYe8Dy8jiSEDJKM4wkVa3g4lD2Z+Pnw==",
       "license": "MIT",
       "workspaces": [
         "KeychainExample",

--- a/package.json
+++ b/package.json
@@ -177,7 +177,7 @@
     "react-native-handoff": "github:BlueWallet/react-native-handoff#v0.0.4",
     "react-native-haptic-feedback": "2.3.4",
     "react-native-image-picker": "8.2.1",
-    "react-native-keychain": "9.2.3",
+    "react-native-keychain": "10.0.0",
     "react-native-linear-gradient": "2.8.3",
     "react-native-localize": "3.7.0",
     "react-native-nfc-manager": "^3.14.14",


### PR DESCRIPTION
## Problem

v2.0.15 artifacts still fail Google Play's 16 KB page-size check. The sole offender is `lib/x86_64/libconceal.so`, whose ELF LOAD segments are 4 KB-aligned (`2**12`). It is bundled by `react-native-keychain` ≤ 9.x via `com.facebook.conceal:conceal:1.1.3@aar`, a 2016 prebuilt that will never be rebuilt.

The check covers **both** 64-bit ABIs. The arm64 copy of the same lib happens to be 64 KB-aligned (old linker defaults differ per arch), which is why arm64-only checks pass while the app as a whole stays non-compliant.

## Fix (ports upstream BlueWallet/BlueWallet#8488)

- `react-native-keychain` 9.2.3 → **10.0.0** — removes the FacebookConceal dependency (and `libconceal.so`) entirely
- `ndkVersion` 27.1.12297006 → **28.2.13676358** — NDK r28+ emits 16 KB-aligned code by default, keeping locally-compiled libs (`libappmodules.so`) safe going forward

Also included: `ios/Podfile.lock` regenerated (RNKeychain pod 10.0.0; the `PODFILE CHECKSUM` update corrects a stale value — the committed checksum did not match the committed `Podfile`).

## Why the v10 breaking changes don't affect us

- **FacebookConceal cipher removal**: react-native-keychain only ever writes with Conceal on API < 23 devices. This app's minSdk was already 28 when the keychain dependency was introduced (2021), so no install has ever stored data with that cipher. Our single usage (Realm encryption key in `BlueApp.js`) is unaffected.
- **minSdk 23+ required**: we're at 28.
- **Library warmup removed**: not used.

BlueWallet upstream has shipped this combination since April 2026.

## Verification

- Built an APK from this branch and swept every 64-bit lib: `libconceal.so` is gone (22 libs per ABI, was 23) and all 131 ELF LOAD segments across arm64-v8a + x86_64 are `2**14` — fully compliant. Check per lib: `objdump -p <lib.so> | grep LOAD` (needs `align 2**14`+), plus `zipalign -c -P 16 -v 4 <apk>`.
- `npm run lint` and `npm run unit` pass locally (27/27 suites).