### PR TITLE
Stability fixes: tcp-socket connect crash, amount-input ref, multisig guards, Electrum connect resilience

### DIFF
--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -151,8 +151,8 @@ async function _initConnection() {
     usingPeer = savedPeer;
   }
 
-  await DefaultPreference.setName('group.swiss.dfx.bitcoin');
   try {
+    await DefaultPreference.setName('group.swiss.dfx.bitcoin');
     if (usingPeer.host.endsWith('onion')) {
       const randomPeer = await getCurrentPeer();
       await DefaultPreference.set(ELECTRUM_HOST, randomPeer.host);

--- a/class/wallets/multisig-hd-wallet.js
+++ b/class/wallets/multisig-hd-wallet.js
@@ -245,6 +245,9 @@ export class MultisigHDWallet extends AbstractHDElectrumWallet {
    */
   _getXpubFromCosigner(cosigner) {
     const index = this._cosigners.indexOf(cosigner);
+    if (!cosigner || index === -1) {
+      throw new Error('Invalid cosigner or cosigners not initialized');
+    }
     if (this._cosignersXpubs[index]) return this._cosignersXpubs[index];
 
     if (MultisigHDWallet.isXprvString(cosigner)) cosigner = MultisigHDWallet.convertXprvToXpub(cosigner);

--- a/components/AmountInput.js
+++ b/components/AmountInput.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import BigNumber from 'bignumber.js';
 import { Badge, Icon, Text } from 'react-native-elements';
-import { Image, LayoutAnimation, StyleSheet, TextInput, TouchableOpacity, TouchableWithoutFeedback, View } from 'react-native';
+import { Image, StyleSheet, TextInput, TouchableOpacity, TouchableWithoutFeedback, View } from 'react-native';
 import { useTheme } from '@react-navigation/native';
 import confirm from '../helpers/confirm';
 import { BitcoinUnit } from '../models/bitcoinUnits';
@@ -203,16 +203,13 @@ class AmountInput extends Component {
   };
 
   updateRate = () => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     this.setState({ isRateBeingUpdated: true }, async () => {
       try {
         await currency.updateExchangeRate();
         currency.mostRecentFetchedRate().then(mostRecentFetchedRate => {
-          LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
           this.setState({ mostRecentFetchedRate });
         });
       } finally {
-        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
         this.setState({ isRateBeingUpdated: false, isRateOutdated: await currency.isRateOutdated() });
       }
     });

--- a/components/AmountInput.js
+++ b/components/AmountInput.js
@@ -152,7 +152,7 @@ class AmountInput extends Component {
   textInput = React.createRef();
 
   handleTextInputOnPress = () => {
-    this.textInput.current.focus();
+    this.textInput.current?.focus();
   };
 
   handleChangeText = text => {
@@ -269,7 +269,7 @@ class AmountInput extends Component {
         accessibilityRole="button"
         accessibilityLabel={loc._.enter_amount}
         disabled={this.props.pointerEvents === 'none'}
-        onPress={() => this.textInput.focus()}
+        onPress={() => this.textInput.current?.focus()}
       >
         <>
           <View style={styles.root}>
@@ -303,7 +303,7 @@ class AmountInput extends Component {
                     placeholder="0"
                     textAlign="center"
                     maxLength={this.maxLength()}
-                    ref={textInput => (this.textInput = textInput)}
+                    ref={this.textInput}
                     editable={!this.props.isLoading && !disabled}
                     value={parseFloat(amount) >= 0 ? String(amount) : undefined}
                     placeholderTextColor={disabled ? colors.buttonDisabledTextColor : colors.alternativeTextColor2}

--- a/components/DynamicQRCode.js
+++ b/components/DynamicQRCode.js
@@ -1,7 +1,7 @@
 /* eslint react/prop-types: "off", react-native/no-inline-styles: "off" */
 import React, { Component } from 'react';
 import { Text } from 'react-native-elements';
-import { Dimensions, LayoutAnimation, StyleSheet, TouchableOpacity, View } from 'react-native';
+import { Dimensions, StyleSheet, TouchableOpacity, View } from 'react-native';
 import { encodeUR } from '../blue_modules/ur';
 import QRCodeComponent from './QRCodeComponent';
 import { BlueCurrentTheme } from '../components/themes';
@@ -108,7 +108,6 @@ export class DynamicQRCode extends Component {
           accessibilityRole="button"
           testID="DynamicCode"
           onPress={() => {
-            LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
             this.setState(prevState => ({ hideControls: !prevState.hideControls }));
           }}
         >

--- a/patches/react-native-tcp-socket+6.4.1.patch
+++ b/patches/react-native-tcp-socket+6.4.1.patch
@@ -1,0 +1,54 @@
+diff --git a/node_modules/react-native-tcp-socket/ios/TcpSockets.m b/node_modules/react-native-tcp-socket/ios/TcpSockets.m
+index 0fe15d2..a5553c6 100644
+--- a/node_modules/react-native-tcp-socket/ios/TcpSockets.m
++++ b/node_modules/react-native-tcp-socket/ios/TcpSockets.m
+@@ -219,20 +219,35 @@ - (void)onWrittenData:(TcpSocketClient *)client msgId:(NSNumber *)msgId {
+ 
+ - (void)onConnect:(TcpSocketClient *)client {
+     GCDAsyncSocket *socket = [client getSocket];
+-    [self sendEventWithName:@"connect"
+-                       body:@{
+-                           @"id" : client.id,
+-                           @"connection" : @{
+-                               @"localAddress" : [socket localHost],
+-                               @"localPort" :
+-                                   [NSNumber numberWithInt:[socket localPort]],
+-                               @"remoteAddress" : [socket connectedHost],
+-                               @"remotePort" : [NSNumber
+-                                   numberWithInt:[socket connectedPort]],
+-                               @"remoteFamily" : [socket isIPv4] ? @"IPv4"
+-                                                                 : @"IPv6"
+-                           }
+-                       }];
++    NSString *localAddress = [socket localHost];
++    NSString *remoteAddress = [socket connectedHost];
++    // The socket can disconnect between this callback being queued and run,
++    // in which case the address getters return nil. Building the connection
++    // dictionary with a nil value throws NSInvalidArgumentException and
++    // crashes the app, so emit an error instead of the connect event -
++    // skipping silently would hang the JS side waiting for a callback.
++    if (localAddress != nil && remoteAddress != nil) {
++        [self sendEventWithName:@"connect"
++                           body:@{
++                               @"id" : client.id,
++                               @"connection" : @{
++                                   @"localAddress" : localAddress,
++                                   @"localPort" :
++                                       [NSNumber numberWithInt:[socket localPort]],
++                                   @"remoteAddress" : remoteAddress,
++                                   @"remotePort" : [NSNumber
++                                       numberWithInt:[socket connectedPort]],
++                                   @"remoteFamily" : [socket isIPv4] ? @"IPv4"
++                                                                     : @"IPv6"
++                               }
++                           }];
++    } else {
++        [self sendEventWithName:@"error"
++                           body:@{
++                               @"id" : client.id,
++                               @"error" : @"Socket disconnected before connect could be reported"
++                           }];
++    }
+ }
+ 
+ - (void)onListen:(TcpSocketClient *)server {

--- a/screen/receive/details.js
+++ b/screen/receive/details.js
@@ -60,7 +60,7 @@ const ReceiveDetails = () => {
   const [initialUnconfirmed, setInitialUnconfirmed] = useState(0);
   const [displayBalance, setDisplayBalance] = useState('');
   const fetchAddressInterval = useRef();
-  const { inputProps, amountSats, formattedUnit, changeToNextUnit } = useInputAmount();
+  const { inputProps, amountSats, formattedUnit, changeToNextUnit, resetInput } = useInputAmount();
 
   const stylesHook = StyleSheet.create({
     customAmount: {
@@ -386,6 +386,8 @@ const ReceiveDetails = () => {
     setInitialUnconfirmed(0);
     setIntervalMs(5000);
     setBip21encoded(undefined);
+    setCustomLabel('');
+    resetInput();
     setParams({ walletID: id, address: null });
   };
 

--- a/screen/receive/details.js
+++ b/screen/receive/details.js
@@ -377,6 +377,15 @@ const ReceiveDetails = () => {
       return { name: newWallet.isPosMode ? 'PosReceive' : 'LNDReceive', params: { walletID: id } };
     }
 
+    setShowAddress(false);
+    setShowPendingBalance(false);
+    setShowConfirmedBalance(false);
+    setDisplayBalance('');
+    setEta('');
+    setInitialConfirmed(0);
+    setInitialUnconfirmed(0);
+    setIntervalMs(5000);
+    setBip21encoded(undefined);
     setParams({ walletID: id, address: null });
   };
 

--- a/screen/send/coinControl.js
+++ b/screen/send/coinControl.js
@@ -6,7 +6,6 @@ import {
   FlatList,
   Keyboard,
   KeyboardAvoidingView,
-  LayoutAnimation,
   PixelRatio,
   Platform,
   StyleSheet,
@@ -359,11 +358,9 @@ const CoinControl = () => {
         selected={selected.includes(`${p.item.txid}:${p.item.vout}`)}
         selectionStarted={selectionStarted}
         onSelect={() => {
-          LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut); // animate buttons show
           setSelected(s => [...s, `${p.item.txid}:${p.item.vout}`]);
         }}
         onDeSelect={() => {
-          LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut); // animate buttons show
           setSelected(s => s.filter(i => i !== `${p.item.txid}:${p.item.vout}`));
         }}
       />

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -6,7 +6,6 @@ import {
   FlatList,
   Keyboard,
   KeyboardAvoidingView,
-  LayoutAnimation,
   Platform,
   ScrollView,
   StatusBar,
@@ -213,7 +212,6 @@ const SendDetails = () => {
       })
       .catch(e => console.log('loading recommendedFees error', e))
       .finally(() => {
-        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
         setNetworkTransactionFeesIsLoading(false);
       });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
@@ -323,7 +321,6 @@ const SendDetails = () => {
   // we need to re-calculate fees if user opens-closes coin control
   useFocusEffect(
     useCallback(() => {
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
       setDumb(v => !v);
     }, []),
   );
@@ -384,7 +381,6 @@ const SendDetails = () => {
 
     return change;
   };
-
 
   const createTransaction = async () => {
     Keyboard.dismiss();

--- a/screen/wallets/addMultisigStep2.js
+++ b/screen/wallets/addMultisigStep2.js
@@ -1,7 +1,7 @@
 import React, { useContext, useRef, useState, useEffect, useMemo } from 'react';
 import { Alert, FlatList, LayoutAnimation, Platform, StyleSheet, Text, View } from 'react-native';
 import { Icon } from 'react-native-elements';
-import { useNavigation, useRoute, useTheme } from '@react-navigation/native';
+import { useIsFocused, useNavigation, useRoute, useTheme } from '@react-navigation/native';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import PropTypes from 'prop-types';
 
@@ -35,6 +35,7 @@ const WalletsAddMultisigStep2 = () => {
   const [isError, setIsError] = useState(false);
   const scannedCache = useRef({}).current; // ref so the scan-dedup cache survives re-renders
   const quorum = useRef(new Array(n));
+  const isFocused = useIsFocused();
 
   useEffect(() => {
     if (cosigners.length === 0) {
@@ -395,12 +396,14 @@ const WalletsAddMultisigStep2 = () => {
         <QRCodeComponent value={cosignerXpubURv2} size={290} />
       </View>
       <View style={styles.cameraContainer}>
-        <Camera
-          scanBarcode={!isError}
-          scanThrottleDelay={0}
-          onReadCode={event => onBarCodeRead({ data: event?.nativeEvent?.codeStringValue })}
-          style={styles.camera}
-        />
+        {isFocused && (
+          <Camera
+            scanBarcode={!isError}
+            scanThrottleDelay={0}
+            onReadCode={event => onBarCodeRead({ data: event?.nativeEvent?.codeStringValue })}
+            style={styles.camera}
+          />
+        )}
       </View>
       <View style={styles.buttonContainer}>
         <BlueButton isLoading={isLoading} title={loc.multisig.create} onPress={onCreate} disabled={cosigners.length !== n} />

--- a/screen/wallets/addMultisigStep2.js
+++ b/screen/wallets/addMultisigStep2.js
@@ -1,5 +1,5 @@
 import React, { useContext, useRef, useState, useEffect, useMemo } from 'react';
-import { Alert, FlatList, LayoutAnimation, Platform, StyleSheet, Text, View } from 'react-native';
+import { Alert, FlatList, Platform, StyleSheet, Text, View } from 'react-native';
 import { Icon } from 'react-native-elements';
 import { useIsFocused, useNavigation, useRoute, useTheme } from '@react-navigation/native';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
@@ -193,7 +193,6 @@ const WalletsAddMultisigStep2 = () => {
 
     const cosignersCopy = [...cosigners];
     cosignersCopy.push([xpub, fp, path]);
-    if (Platform.OS !== 'android') LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setCosigners(cosignersCopy);
   };
 
@@ -356,7 +355,6 @@ const WalletsAddMultisigStep2 = () => {
 
       const cosignersCopy = [...cosigners];
       cosignersCopy.push([cosigner.getXpub(), cosigner.getFp(), cosigner.getPath()]);
-      if (Platform.OS !== 'android') LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
       ReactNativeHapticFeedback.trigger('notificationSuccess', { ignoreAndroidSystemSettings: false });
       setCosigners(cosignersCopy);
     }

--- a/screen/wallets/addresses.js
+++ b/screen/wallets/addresses.js
@@ -108,15 +108,19 @@ const WalletAddresses = () => {
     const newAddresses = [];
 
     for (let index = 0; index <= walletInstance.next_free_change_address_index; index++) {
-      const address = getAddress(walletInstance, index, true);
-
-      newAddresses.push(address);
+      try {
+        newAddresses.push(getAddress(walletInstance, index, true));
+      } catch (error) {
+        console.error('error', error);
+      }
     }
 
     for (let index = 0; index < walletInstance.next_free_address_index + walletInstance.gap_limit; index++) {
-      const address = getAddress(walletInstance, index, false);
-
-      newAddresses.push(address);
+      try {
+        newAddresses.push(getAddress(walletInstance, index, false));
+      } catch (error) {
+        console.error('error', error);
+      }
     }
 
     setAddresses(newAddresses);

--- a/screen/wallets/importDiscovery.js
+++ b/screen/wallets/importDiscovery.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState, useRef, useMemo } from 'react';
-import { ActivityIndicator, Alert, FlatList, LayoutAnimation, StyleSheet, View } from 'react-native';
+import { ActivityIndicator, Alert, FlatList, StyleSheet, View } from 'react-native';
 import { StackActions, useNavigation, useRoute, useTheme } from '@react-navigation/native';
 import ReactNativeHapticFeedback from 'react-native-haptic-feedback';
 import { BlueButton, BlueButtonLink, BlueFormLabel, BlueSpacing10, BlueSpacing20, SafeBlueArea } from '../../BlueComponents';
@@ -75,7 +75,6 @@ const ImportWalletDiscovery = () => {
     const onWallet = wallet => {
       if (wallet.type === WatchOnlyWallet.type) return;
 
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
       const id = wallet.getID();
       let subtitle;
       try {
@@ -121,7 +120,6 @@ const ImportWalletDiscovery = () => {
         Alert.alert('import error', e.message);
       })
       .finally(() => {
-        LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
         setLoading(false);
       });
 

--- a/screen/wallets/signVerify.js
+++ b/screen/wallets/signVerify.js
@@ -4,7 +4,6 @@ import {
   Alert,
   Keyboard,
   KeyboardAvoidingView,
-  LayoutAnimation,
   Platform,
   StatusBar,
   StyleSheet,
@@ -102,7 +101,6 @@ const SignVerify = () => {
   };
 
   const handleFocus = value => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setMessageHasFocus(value);
   };
 

--- a/screen/wallets/viewEditMultisigCosigners.js
+++ b/screen/wallets/viewEditMultisigCosigners.js
@@ -5,7 +5,6 @@ import {
   InteractionManager,
   Keyboard,
   KeyboardAvoidingView,
-  LayoutAnimation,
   Platform,
   StatusBar,
   StyleSheet,
@@ -326,7 +325,6 @@ const ViewEditMultisigCosigners = () => {
       return alert(e.message);
     }
 
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut);
     setWallet(wallet);
     setIsProvideMnemonicsModalVisible(false);
     setImportText('');


### PR DESCRIPTION
Field-crash fix plus three stability fixes ported/adapted from upstream BlueWallet.

## fix(ios): react-native-tcp-socket onConnect nil-address crash

Top field crash group in Xcode Organizer (8 devices in the last year, present since at least 2.0.3 — the unguarded code exists in 5.6.2 through 6.4.1):

```
-[TcpSockets onConnect:] + 384
*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[0]
```

GCDAsyncSocket's `localHost`/`connectedHost` return nil once a socket has disconnected. If the connection drops between the TLS handshake completing and the connect event being built, `onConnect:` inserts nil into the event dictionary → uncaught `NSInvalidArgumentException` → SIGABRT. Electrum connections during import/discovery are the main trigger. Ports BlueWallet's patch-package fix 1:1 (BlueWallet/BlueWallet#8576) against the same pinned 6.4.1; upstream library bug still open (Rapsssito/react-native-tcp-socket#197).

## fix: crash focusing amount input via stale ref access

`AmountInput` mixed a `createRef` object with a callback ref that replaced it with the raw node on mount — one of the two focus paths always dereferenced the wrong shape and threw (fatal in release). Now uses the ref object consistently with `.current?.focus()`. Same defect class as BlueWallet/BlueWallet#7572, adapted to this component's class-based shape.

## fix: guard multisig xpub lookup and address-list derivation

An undefined/unregistered cosigner entry reached `isXprvString(undefined)` inside address derivation (cryptic TypeError), and on the addresses screen a single failing derivation killed the whole list. Clear error from `_getXpubFromCosigner` + per-address try/catch in the list. Equivalent of BlueWallet/BlueWallet#7893 adapted to this fork's value-based cosigner lookup.

## fix: keep Electrum connect alive when app-group preferences fail

`DefaultPreference.setName` was the one call in `_initConnection` outside the try/catch guarding the other preference writes; a rejection killed the connection attempt before reaching the Electrum client, surfacing as an unhandled rejection in fire-and-forget callers. Scoped equivalent of BlueWallet/BlueWallet#7594. Their #8597 (optional confirmations on mempool txs) needs no port — this code base already normalizes confirmations at ingestion.

## Verification

- `npx patch-package` applies both repo patches cleanly
- `tests/unit/multisig-hd-wallet.test.js`: 16/16 pass (includes the issue #176 cosigner-matching scenarios)
- Changed files pass prettier

## fix: reset pending-payment state when switching wallets on receive screen

Repro: open Receive for an onchain wallet, receive a payment (pending widget with amount/ETA appears), then switch to another onchain wallet via the selector. The new wallet's address rendered together with the previous wallet's pending widget, because the view flags render stacked and the watcher state (flags, balance baselines, ETA, poll cadence, stale bip21 string) survived the switch. The stale baselines could also make the poller misreport a received amount for the new wallet. The custom amount and label inputs are also cleared on switch (via the hook's existing resetInput, as the boltcard and cashier screens already do) — previously they kept the old wallet's values while the QR encoded the plain new address. The wallet selector on this screen is fork-specific — no upstream counterpart.


## fix: release camera when leaving the multisig cosigner-scan screen

Add-multisig step 2 rendered its cosigner-scanning Camera unconditionally. After Create navigates to the new wallet, the screen stays mounted in the stack underneath — the camera session stayed open (camera-in-use indicator visible) and the scan callback kept firing, so scanning any QR from an unrelated screen popped the not-a-cosigner validation alert. Now gated on `useIsFocused`, matching every other scanner screen in the repo (ScanQRCode, ScanCodeSend, importMultisignature).


## fix: remove LayoutAnimation (deprecated and unreliable on the new architecture)

`LayoutAnimation.configureNext` arms a global animation for whatever layout commit happens next; several call sites fired at network-dependent moments (send-screen fee fetch, exchange-rate refresh), so the armed animation can collide with unrelated commits — on Fabric this intermittently leaves views with a layout frame but no drawing. Prime suspect for a field report of the send screen's amount/recipient inputs rendering as blank space (width, scroll-offset, and empty-data explanations were each ruled out by on-device injection tests). Ports BlueWallet/BlueWallet#8541, which removed every LayoutAnimation call after their RN 83 upgrade for the same reason. Only cosmetic easing on unit switches and fee/discovery loads is lost.

