### PR TITLE
TST: test coverage for #200 stability fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -124,6 +124,7 @@
         "@react-native/js-polyfills": "^0.83.1",
         "@react-native/metro-babel-transformer": "^0.83.1",
         "@react-native/typescript-config": "^0.83.1",
+        "@testing-library/react-native": "^13.2.0",
         "@tsconfig/react-native": "^3.0.2",
         "@types/bs58check": "^2.1.0",
         "@types/create-hash": "^1.2.2",
@@ -2870,6 +2871,16 @@
         "@types/yargs-parser": "*"
       }
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -3016,6 +3027,16 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
@@ -4847,6 +4868,114 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.3.3.tgz",
+      "integrity": "sha512-k6Mjsd9dbZgvY4Bl7P1NIpePQNi+dfYtlJ5voi9KQlynxSyQkfOgJmYGCYmw/aSgH/rUcFvG8u5gd4npzgRDyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.0.5",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.0.5",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.50",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.50.tgz",
+      "integrity": "sha512-ydBWw0G6WFwWHzh9RK4B5c690UkreOG0llq0r+DaI7LgKgxigf8mhHzIPI3S0850g1BPkq/zpuCfrq4QFgUlTQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@tsconfig/react-native": {
@@ -11093,6 +11222,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -15270,6 +15409,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -17000,6 +17149,22 @@
       "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
       "license": "MIT"
     },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-localization": {
       "version": "1.0.19",
       "resolved": "git+ssh://git@github.com/BlueWallet/react-localization.git#ae7969a8998128aebf1169f931fb22587dc5f874",
@@ -17982,6 +18147,20 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -19241,6 +19420,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@react-native/js-polyfills": "^0.83.1",
     "@react-native/metro-babel-transformer": "^0.83.1",
     "@react-native/typescript-config": "^0.83.1",
+    "@testing-library/react-native": "^13.2.0",
     "@tsconfig/react-native": "^3.0.2",
     "@types/bs58check": "^2.1.0",
     "@types/create-hash": "^1.2.2",

--- a/screen/receive/details.js
+++ b/screen/receive/details.js
@@ -41,6 +41,38 @@ import useInputAmount from '../../hooks/useInputAmount';
 import NetworkTransactionFees from '../../models/networkTransactionFees';
 const currency = require('../../blue_modules/currency');
 
+// Pure decision for a wallet switch on the receive screen. Kept at module
+// scope (no component state) so it is unit-testable without rendering.
+// Returns { action: 'none' | 'navigate' | 'reset', target? }.
+export const resolveWalletChange = (newWallet, currentWalletId) => {
+  if (!newWallet || newWallet.getID() === currentWalletId) return { action: 'none' };
+  if (newWallet.chain !== Chain.ONCHAIN) {
+    return {
+      action: 'navigate',
+      target: { name: newWallet.isPosMode ? 'PosReceive' : 'LNDReceive', params: { walletID: newWallet.getID() } },
+    };
+  }
+  return { action: 'reset' };
+};
+
+// Resets the whole pending-payment watcher + input state so nothing (view
+// flags, balance baselines, eta, poll cadence, stale bip21 string, custom
+// amount/label) leaks across wallets. Setters are injected so it can be
+// unit-tested in isolation.
+export const resetReceiveState = setters => {
+  setters.setShowAddress(false);
+  setters.setShowPendingBalance(false);
+  setters.setShowConfirmedBalance(false);
+  setters.setDisplayBalance('');
+  setters.setEta('');
+  setters.setInitialConfirmed(0);
+  setters.setInitialUnconfirmed(0);
+  setters.setIntervalMs(5000);
+  setters.setBip21encoded(undefined);
+  setters.setCustomLabel('');
+  setters.resetInput();
+};
+
 const ReceiveDetails = () => {
   const { walletID, address } = useRoute().params;
   const { wallets, saveToDisk, sleep, isElectrumDisabled, refreshAllWalletTransactions, revalidateBalancesInterval } =
@@ -368,26 +400,24 @@ const ReceiveDetails = () => {
   };
 
   const onWalletChange = id => {
-    if (id === wallet?.getID()) return;
-
     const newWallet = wallets.find(w => w.getID() === id);
-    if (!newWallet) return;
+    const decision = resolveWalletChange(newWallet, wallet?.getID());
+    if (decision.action === 'none') return;
+    if (decision.action === 'navigate') return decision.target;
 
-    if (newWallet.chain !== Chain.ONCHAIN) {
-      return { name: newWallet.isPosMode ? 'PosReceive' : 'LNDReceive', params: { walletID: id } };
-    }
-
-    setShowAddress(false);
-    setShowPendingBalance(false);
-    setShowConfirmedBalance(false);
-    setDisplayBalance('');
-    setEta('');
-    setInitialConfirmed(0);
-    setInitialUnconfirmed(0);
-    setIntervalMs(5000);
-    setBip21encoded(undefined);
-    setCustomLabel('');
-    resetInput();
+    resetReceiveState({
+      setShowAddress,
+      setShowPendingBalance,
+      setShowConfirmedBalance,
+      setDisplayBalance,
+      setEta,
+      setInitialConfirmed,
+      setInitialUnconfirmed,
+      setIntervalMs,
+      setBip21encoded,
+      setCustomLabel,
+      resetInput,
+    });
     setParams({ walletID: id, address: null });
   };
 

--- a/screen/wallets/CosignerCamera.js
+++ b/screen/wallets/CosignerCamera.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Camera } from 'react-native-camera-kit-no-google';
+
+// Renders the cosigner-scanning camera only while the screen is focused, so the
+// camera session is released (and its scan callback stops firing) once the user
+// navigates away from add-multisig step 2. Mirrors every other scanner screen
+// in the repo (ScanQRCode, ScanCodeSend, importMultisignature).
+export const CosignerCamera = ({ isFocused, scanBarcode, onReadCode, style }) => {
+  if (!isFocused) return null;
+  return <Camera scanBarcode={scanBarcode} scanThrottleDelay={0} onReadCode={onReadCode} style={style} />;
+};
+
+CosignerCamera.propTypes = {
+  isFocused: PropTypes.bool,
+  scanBarcode: PropTypes.bool,
+  onReadCode: PropTypes.func,
+  style: PropTypes.any,
+};

--- a/screen/wallets/addMultisigStep2.js
+++ b/screen/wallets/addMultisigStep2.js
@@ -13,7 +13,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { BlueURDecoder, encodeUR } from '../../blue_modules/ur';
 import QRCodeComponent from '../../components/QRCodeComponent';
 import alert from '../../components/Alert';
-import { Camera } from 'react-native-camera-kit-no-google';
+import { CosignerCamera } from './CosignerCamera';
 import { ScrollView } from 'react-native-gesture-handler';
 const createHash = require('create-hash');
 
@@ -394,14 +394,12 @@ const WalletsAddMultisigStep2 = () => {
         <QRCodeComponent value={cosignerXpubURv2} size={290} />
       </View>
       <View style={styles.cameraContainer}>
-        {isFocused && (
-          <Camera
-            scanBarcode={!isError}
-            scanThrottleDelay={0}
-            onReadCode={event => onBarCodeRead({ data: event?.nativeEvent?.codeStringValue })}
-            style={styles.camera}
-          />
-        )}
+        <CosignerCamera
+          isFocused={isFocused}
+          scanBarcode={!isError}
+          onReadCode={event => onBarCodeRead({ data: event?.nativeEvent?.codeStringValue })}
+          style={styles.camera}
+        />
       </View>
       <View style={styles.buttonContainer}>
         <BlueButton isLoading={isLoading} title={loc.multisig.create} onPress={onCreate} disabled={cosigners.length !== n} />

--- a/screen/wallets/addresses.js
+++ b/screen/wallets/addresses.js
@@ -50,6 +50,31 @@ export const filterByAddressType = (type, isInternal, currentType) => {
   return isInternal === false;
 };
 
+// Derives the full internal+external address list for a wallet, tolerating a
+// single failing derivation (e.g. an unregistered multisig cosigner throwing)
+// so one bad entry degrades gracefully instead of killing the whole list.
+export const buildWalletAddresses = walletInstance => {
+  const addresses = [];
+
+  for (let index = 0; index <= walletInstance.next_free_change_address_index; index++) {
+    try {
+      addresses.push(getAddress(walletInstance, index, true));
+    } catch (error) {
+      console.error('error', error);
+    }
+  }
+
+  for (let index = 0; index < walletInstance.next_free_address_index + walletInstance.gap_limit; index++) {
+    try {
+      addresses.push(getAddress(walletInstance, index, false));
+    } catch (error) {
+      console.error('error', error);
+    }
+  }
+
+  return addresses;
+};
+
 const WalletAddresses = () => {
   const [showAddresses, setShowAddresses] = useState(false);
 
@@ -105,25 +130,7 @@ const WalletAddresses = () => {
   }, [setOptions]);
 
   const getAddresses = () => {
-    const newAddresses = [];
-
-    for (let index = 0; index <= walletInstance.next_free_change_address_index; index++) {
-      try {
-        newAddresses.push(getAddress(walletInstance, index, true));
-      } catch (error) {
-        console.error('error', error);
-      }
-    }
-
-    for (let index = 0; index < walletInstance.next_free_address_index + walletInstance.gap_limit; index++) {
-      try {
-        newAddresses.push(getAddress(walletInstance, index, false));
-      } catch (error) {
-        console.error('error', error);
-      }
-    }
-
-    setAddresses(newAddresses);
+    setAddresses(buildWalletAddresses(walletInstance));
     setShowAddresses(true);
   };
 

--- a/tests/unit/AmountInput.test.js
+++ b/tests/unit/AmountInput.test.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { TouchableWithoutFeedback } from 'react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
+import AmountInput from '../../components/AmountInput';
+import { BitcoinUnit } from '../../models/bitcoinUnits';
+
+const mockFocus = jest.fn();
+
+jest.mock('../../blue_modules/currency', () => ({
+  mostRecentFetchedRate: jest.fn(() => Promise.resolve({})),
+  isRateOutdated: jest.fn(() => Promise.resolve(false)),
+  updateExchangeRate: jest.fn(() => Promise.resolve()),
+  fiatToBTC: jest.fn(() => '0'),
+  satoshiToBTC: jest.fn(() => '0'),
+  satoshiToLocalCurrency: jest.fn(() => '$0.00'),
+  getCurrencySymbol: jest.fn(() => '$'),
+}));
+
+// The wrapper reads colors from the navigation theme; provide one so the
+// component can render outside a NavigationContainer.
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useTheme: () => ({
+      colors: {
+        alternativeTextColor2: '#0070ff',
+        buttonDisabledTextColor: '#999999',
+        buttonAlternativeTextColor: '#ffffff',
+        mainColor: '#ff0000',
+      },
+    }),
+  };
+});
+
+// Expose a focus() on the TextInput's ref so we can assert the press path
+// (this.textInput.current?.focus()) actually reaches the input. react-test-renderer
+// gives composite refs a no-op focus, which is why a plain "does not throw" assertion
+// would stay green even if the #200 ref fix were reverted.
+jest.mock('react-native/Libraries/Components/TextInput/TextInput', () => {
+  const react = require('react');
+  const TextInputMock = react.forwardRef((props, ref) => {
+    react.useImperativeHandle(ref, () => ({ focus: mockFocus }));
+    return react.createElement('TextInput', { testID: props.testID });
+  });
+  return { __esModule: true, default: TextInputMock };
+});
+
+describe('AmountInput focus (ref fix, PR #200)', () => {
+  beforeEach(() => mockFocus.mockClear());
+
+  it('renders the amount input', async () => {
+    const screen = render(<AmountInput unit={BitcoinUnit.BTC} amount="0" onChangeText={jest.fn()} onAmountUnitChange={jest.fn()} />);
+    await act(async () => {}); // flush the async rate fetch started in componentDidMount
+    expect(screen.getByTestId('BitcoinAmountInput')).toBeTruthy();
+  });
+
+  it('focuses the amount input when the surrounding press target is tapped', async () => {
+    const screen = render(<AmountInput unit={BitcoinUnit.BTC} amount="0" onChangeText={jest.fn()} onAmountUnitChange={jest.fn()} />);
+    await act(async () => {});
+
+    // outer TouchableWithoutFeedback onPress -> this.textInput.current?.focus()
+    // (the createRef object #200 switched to)
+    fireEvent.press(screen.UNSAFE_getAllByType(TouchableWithoutFeedback)[0]);
+    expect(mockFocus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/CosignerCamera.test.js
+++ b/tests/unit/CosignerCamera.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { CosignerCamera } from '../../screen/wallets/CosignerCamera';
+
+jest.mock('react-native-camera-kit-no-google', () => {
+  const react = require('react');
+  const { View } = require('react-native');
+  return { Camera: props => react.createElement(View, { testID: 'cosigner-camera', ...props }) };
+});
+
+// PR #200 gated the cosigner scanner's camera on useIsFocused so the session is
+// released once the user navigates away from add-multisig step 2.
+describe('CosignerCamera focus gating (PR #200)', () => {
+  it('renders the camera while the screen is focused', () => {
+    const screen = render(<CosignerCamera isFocused scanBarcode onReadCode={jest.fn()} />);
+    expect(screen.queryByTestId('cosigner-camera')).toBeTruthy();
+  });
+
+  it('renders nothing (releases the camera) when the screen is not focused', () => {
+    const screen = render(<CosignerCamera isFocused={false} scanBarcode onReadCode={jest.fn()} />);
+    expect(screen.queryByTestId('cosigner-camera')).toBeNull();
+  });
+});

--- a/tests/unit/addresses.test.js
+++ b/tests/unit/addresses.test.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { getAddress, sortByAddressIndex, totalBalance, filterByAddressType } from '../../screen/wallets/addresses';
+import { getAddress, sortByAddressIndex, totalBalance, filterByAddressType, buildWalletAddresses } from '../../screen/wallets/addresses';
 import { TABS } from '../../components/addresses/AddressTypeTabs';
 
 jest.mock('../../blue_modules/currency', () => {
@@ -66,6 +66,61 @@ describe('Addresses', () => {
     assert.strictEqual(totalBalance(wallet1Balance), 0);
     assert.strictEqual(totalBalance(wallet2Balance), 10);
     assert.strictEqual(totalBalance(wallet3Balance), 10);
+  });
+
+  it('buildWalletAddresses derives internal + external and tolerates a throwing derivation', () => {
+    const wallet = {
+      next_free_change_address_index: 1, // internal loop index 0..1 => 2 internal
+      next_free_address_index: 1,
+      gap_limit: 2, // external loop index 0..2 => 3 external (index 1 throws)
+      _getInternalAddressByIndex: index => `internal_${index}`,
+      _getExternalAddressByIndex: index => {
+        if (index === 1) throw new Error('boom');
+        return `external_${index}`;
+      },
+      _balances_by_internal_index: {},
+      _balances_by_external_index: {},
+      _txs_by_internal_index: {},
+      _txs_by_external_index: {},
+    };
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const result = buildWalletAddresses(wallet);
+    const errorCalls = errorSpy.mock.calls.length;
+    errorSpy.mockRestore();
+
+    // the throwing external index 1 is skipped, everything else survives with its index intact
+    assert.deepStrictEqual(
+      result.map(a => a.address),
+      ['internal_0', 'internal_1', 'external_0', 'external_2'],
+    );
+    assert.deepStrictEqual(
+      result.filter(a => !a.isInternal).map(a => a.index),
+      [0, 2],
+    );
+    assert.strictEqual(errorCalls, 1); // the failing derivation was caught, not rethrown
+  });
+
+  it('buildWalletAddresses returns an empty list when every derivation throws', () => {
+    const wallet = {
+      next_free_change_address_index: 0,
+      next_free_address_index: 0,
+      gap_limit: 1,
+      _getInternalAddressByIndex: () => {
+        throw new Error('bad');
+      },
+      _getExternalAddressByIndex: () => {
+        throw new Error('bad');
+      },
+      _balances_by_internal_index: {},
+      _balances_by_external_index: {},
+      _txs_by_internal_index: {},
+      _txs_by_external_index: {},
+    };
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    assert.deepStrictEqual(buildWalletAddresses(wallet), []);
+    errorSpy.mockRestore();
   });
 
   it('Returns AddressItem object', () => {

--- a/tests/unit/multisig-hd-wallet-guard.test.js
+++ b/tests/unit/multisig-hd-wallet-guard.test.js
@@ -1,0 +1,31 @@
+import assert from 'assert';
+import { MultisigHDWallet } from '../../class/';
+
+// Guard added in PR #200: _getXpubFromCosigner now throws a clear error for an
+// undefined / unregistered cosigner instead of letting isXprvString(undefined)
+// blow up with a cryptic TypeError deep inside address derivation.
+const XPUB1 = 'xpub69SfFhG5eA9cqxHKM6b1HhXMpDzipUPDBNMBrjNgWWbbzKqnqwx2mvMyB5bRgmLAi7cBgr8euuz4Lvz3maWxpfUmdM71dyQuvq68mTAG4Cp';
+const XPUB2 = 'xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj';
+const FP1 = 'D37EAD88';
+
+describe('MultisigHDWallet._getXpubFromCosigner guard', () => {
+  it('throws a clear error for an undefined cosigner instead of a cryptic TypeError', () => {
+    const w = new MultisigHDWallet();
+    w.addCosigner(XPUB1, FP1);
+    assert.throws(() => w._getXpubFromCosigner(undefined), /Invalid cosigner or cosigners not initialized/);
+  });
+
+  it('throws for a cosigner that is not registered on the wallet', () => {
+    const w = new MultisigHDWallet();
+    w.addCosigner(XPUB1, FP1);
+    assert.throws(() => w._getXpubFromCosigner(XPUB2), /Invalid cosigner or cosigners not initialized/);
+  });
+
+  it('still returns the xpub for a registered cosigner (happy path preserved)', () => {
+    const w = new MultisigHDWallet();
+    w.addCosigner(XPUB1, FP1);
+    const xpub = w._getXpubFromCosigner(XPUB1);
+    assert.strictEqual(typeof xpub, 'string');
+    assert.ok(xpub.startsWith('xpub'));
+  });
+});

--- a/tests/unit/receive-details.test.js
+++ b/tests/unit/receive-details.test.js
@@ -1,0 +1,76 @@
+import assert from 'assert';
+import { resolveWalletChange, resetReceiveState } from '../../screen/receive/details';
+import { Chain } from '../../models/bitcoinUnits';
+
+// details.js pulls in BlueElectrum (which otherwise opens a long-lived
+// peer-rotation timer and keeps jest from exiting) and currency; mock them the
+// same way addresses.test.js does, since these pure helpers use neither.
+jest.mock('../../blue_modules/BlueElectrum', () => ({ connectMain: jest.fn() }));
+jest.mock('../../blue_modules/currency', () => ({ init: jest.fn() }));
+
+const fakeWallet = (id, chain, isPosMode = false) => ({ getID: () => id, chain, isPosMode });
+
+// Logic behind the receive screen's wallet selector (PR #200): switching wallets
+// must reset the pending-payment watcher for onchain wallets and hand off to the
+// LN/POS screens for offchain ones.
+describe('ReceiveDetails wallet switch', () => {
+  describe('resolveWalletChange', () => {
+    it('is a no-op when the picked wallet is the current one', () => {
+      assert.deepStrictEqual(resolveWalletChange(fakeWallet('a', Chain.ONCHAIN), 'a'), { action: 'none' });
+    });
+
+    it('is a no-op when the picked wallet cannot be found', () => {
+      assert.deepStrictEqual(resolveWalletChange(undefined, 'a'), { action: 'none' });
+    });
+
+    it('resets when switching to another onchain wallet', () => {
+      assert.deepStrictEqual(resolveWalletChange(fakeWallet('b', Chain.ONCHAIN), 'a'), { action: 'reset' });
+    });
+
+    it('hands off to LNDReceive for a lightning wallet', () => {
+      assert.deepStrictEqual(resolveWalletChange(fakeWallet('b', Chain.OFFCHAIN), 'a'), {
+        action: 'navigate',
+        target: { name: 'LNDReceive', params: { walletID: 'b' } },
+      });
+    });
+
+    it('hands off to PosReceive for a POS-mode wallet', () => {
+      assert.deepStrictEqual(resolveWalletChange(fakeWallet('b', Chain.OFFCHAIN, true), 'a'), {
+        action: 'navigate',
+        target: { name: 'PosReceive', params: { walletID: 'b' } },
+      });
+    });
+  });
+
+  describe('resetReceiveState', () => {
+    it('clears every watcher flag, baseline and input field', () => {
+      const setters = {
+        setShowAddress: jest.fn(),
+        setShowPendingBalance: jest.fn(),
+        setShowConfirmedBalance: jest.fn(),
+        setDisplayBalance: jest.fn(),
+        setEta: jest.fn(),
+        setInitialConfirmed: jest.fn(),
+        setInitialUnconfirmed: jest.fn(),
+        setIntervalMs: jest.fn(),
+        setBip21encoded: jest.fn(),
+        setCustomLabel: jest.fn(),
+        resetInput: jest.fn(),
+      };
+
+      resetReceiveState(setters);
+
+      expect(setters.setShowAddress).toHaveBeenCalledWith(false);
+      expect(setters.setShowPendingBalance).toHaveBeenCalledWith(false);
+      expect(setters.setShowConfirmedBalance).toHaveBeenCalledWith(false);
+      expect(setters.setDisplayBalance).toHaveBeenCalledWith('');
+      expect(setters.setEta).toHaveBeenCalledWith('');
+      expect(setters.setInitialConfirmed).toHaveBeenCalledWith(0);
+      expect(setters.setInitialUnconfirmed).toHaveBeenCalledWith(0);
+      expect(setters.setIntervalMs).toHaveBeenCalledWith(5000);
+      expect(setters.setBip21encoded).toHaveBeenCalledWith(undefined);
+      expect(setters.setCustomLabel).toHaveBeenCalledWith('');
+      expect(setters.resetInput).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/tests/unit/useInputAmount.test.js
+++ b/tests/unit/useInputAmount.test.js
@@ -1,0 +1,31 @@
+import { renderHook, act } from '@testing-library/react-native';
+import useInputAmount from '../../hooks/useInputAmount';
+import { BitcoinUnit } from '../../models/bitcoinUnits';
+
+jest.mock('../../blue_modules/currency', () => ({
+  mostRecentFetchedRate: jest.fn(() => Promise.resolve({})),
+  fiatToBTC: jest.fn(() => 0),
+  satoshiToBTC: jest.fn(() => 0),
+  getCurrencySymbol: jest.fn(() => '$'),
+}));
+
+// resetInput is what the receive screen calls on wallet switch (PR #200) to
+// clear the custom amount. It must wipe the typed amount, the sats value and
+// restore the initial unit.
+describe('useInputAmount resetInput', () => {
+  it('clears amount + sats and restores the initial unit', () => {
+    const { result } = renderHook(() => useInputAmount(BitcoinUnit.BTC));
+
+    act(() => result.current.inputProps.onChangeText('1'));
+    act(() => result.current.changeToNextUnit()); // BTC -> SATS
+
+    expect(result.current.amountSats).toBe(100000000);
+    expect(result.current.unit).toBe(BitcoinUnit.SATS);
+
+    act(() => result.current.resetInput());
+
+    expect(result.current.inputAmount).toBe('');
+    expect(result.current.amountSats).toBe(0);
+    expect(result.current.unit).toBe(BitcoinUnit.BTC);
+  });
+});


### PR DESCRIPTION
Adds regression coverage for the behaviour changed by the stability-fix PR #200. Where the affected logic lived inside a component, it is extracted into a small, behaviour-preserving helper so it can be unit-tested without a full render tree.

## Coverage of #200's changes

| Change in #200 | Test |
|---|---|
| `_getXpubFromCosigner` now throws on an undefined/unregistered cosigner | `multisig-hd-wallet-guard.test.js` — throws a clear error; still returns the xpub for a registered cosigner |
| `addresses`: per-address `try/catch` tolerance | `addresses.test.js` — one throwing derivation is skipped (indices intact); all-throwing returns `[]` |
| `receive/details`: pending-watcher + input reset on wallet switch | `receive-details.test.js` — `resolveWalletChange` branches (none/navigate/reset) and `resetReceiveState` clears every flag/baseline/input |
| `useInputAmount.resetInput` used by the receive reset | `useInputAmount.test.js` — clears amount/sats, restores the unit |
| `AmountInput` ref fix (focus no longer crashes) | `AmountInput.test.js` — renders and focusing via press does not throw |
| `addMultisigStep2` camera gated on `useIsFocused` | `CosignerCamera.test.js` — renders the camera only while focused |

## Refactors (behaviour-preserving)

- `addresses`: extract `buildWalletAddresses()` from `WalletAddresses`.
- `receive/details`: extract `resolveWalletChange()` + `resetReceiveState()` to module scope.
- `addMultisigStep2`: extract the focus-gated cosigner `Camera` into a `CosignerCamera` component.

## Tooling

- Adds `@testing-library/react-native` as a **dev** dependency (test tooling only; reuses the already-present `react-test-renderer`). No runtime dependency is added.

## Not unit-tested (by design)

- The Objective-C `react-native-tcp-socket` patch and the Electrum connect-resilience reorder are native / network concerns, not reachable from Jest.
- The pure `LayoutAnimation` removals have no observable behaviour to assert (only cosmetic easing was dropped).

## Verification

- Full unit suite: **32 suites, 223 passed / 1 skipped**.
- Lint (`tsc` + unused-loc + eslint): **0 errors**, no new warnings.
- Node 20 (matches CI).
