### PR TITLE
General fixes

### DIFF
--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -47,13 +47,12 @@ const storageKey = 'ELECTRUM_PEERS';
 const defaultPeer = { host: 'electrum1.bluewallet.io', ssl: '443' };
 const hardcodedPeers = [
   { host: 'mainnet.foundationdevices.com', ssl: '50002' },
-  { host: 'electrum.jochen-hoenicke.de', ssl: '50006' },
   { host: 'electrum1.bluewallet.io', ssl: '443' },
   { host: 'electrum.acinq.co', ssl: '50002' },
   { host: 'electrum.bitaroo.net', ssl: '50002' },
-  { host: 'VPS.hsmiths.com', tcp: '50001', ssl: '50002' },
-  { host: 'helicarrier.bauerj.eu', tcp: '50001', ssl: '50002' },
-  { host: 'kirsche.emzy.de', tcp: '50001', ssl: '50002' },
+  { host: 'VPS.hsmiths.com', ssl: '50002' },
+  { host: 'helicarrier.bauerj.eu', ssl: '50002' },
+  { host: 'kirsche.emzy.de', ssl: '50002' },
 ];
 
 /** @type {ElectrumClient} */

--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -47,6 +47,7 @@ const storageKey = 'ELECTRUM_PEERS';
 const defaultPeer = { host: 'electrum1.bluewallet.io', ssl: '443' };
 const hardcodedPeers = [
   { host: 'mainnet.foundationdevices.com', ssl: '50002' },
+  { host: 'bitcoin.lu.ke', ssl: '50002' },
   { host: 'electrum1.bluewallet.io', ssl: '443' },
   { host: 'electrum.acinq.co', ssl: '50002' },
   { host: 'electrum.bitaroo.net', ssl: '50002' },

--- a/class/deeplink-schema-match.js
+++ b/class/deeplink-schema-match.js
@@ -1,7 +1,6 @@
 import legacyUrl from 'url';
 import { Chain } from '../models/bitcoinUnits';
 import Lnurl from './lnurl';
-import { OpenCryptoPayPaymentLink } from './open-crypto-pay';
 const bitcoin = require('bitcoinjs-lib');
 const bip21 = require('bip21');
 
@@ -527,69 +526,6 @@ class DeeplinkSchemaMatch {
     return false;
   }
 
-  static async assertNavigationByLnurl(text, context) {
-    const url = Lnurl.getUrlFromLnurl(text);
-    if (!url) return;
-
-    const tag = new URL(url).searchParams.get('tag');
-
-    if (tag === Lnurl.TAG_LOGIN_REQUEST) {
-      return [
-        'LnurlAuth',
-        {
-          lnurl: text,
-          walletID: context?.walletID,
-        },
-      ];
-    }
-
-    try {
-      const reply = await new Lnurl(url).fetchGet(url);
-
-      if (OpenCryptoPayPaymentLink.isOpenCryptoPayResponse(reply)) {
-        return [
-          'SendDetailsRoot',
-          {
-            screen: 'OpenCryptoPaySend',
-            params: {
-              plDetails: reply,
-              walletID: context?.walletID,
-            },
-          },
-        ];
-      }
-
-      if (reply.tag === Lnurl.TAG_PAY_REQUEST) {
-        return [
-          'SendDetailsRoot',
-          {
-            screen: 'ScanLndInvoice',
-            params: {
-              uri: text,
-              walletID: context?.walletID,
-            },
-          },
-        ];
-      }
-
-      if (reply.tag === Lnurl.TAG_WITHDRAW_REQUEST) {
-        return [
-          'ReceiveDetailsRoot',
-          {
-            screen: 'LNDCreateInvoice',
-            params: {
-              uri: text,
-              walletID: context?.walletID,
-            },
-          },
-        ];
-      }
-
-      throw new Error('Unsupported lnurl');
-    } catch (error) {
-      console.error(error);
-    }
-  }
 }
 
 export default DeeplinkSchemaMatch;

--- a/class/lnurl.js
+++ b/class/lnurl.js
@@ -25,7 +25,11 @@ export default class Lnurl {
   }
 
   static findlnurl(bodyOfText) {
-    const cleanedText = bodyOfText.replace('mailto:', '').toLowerCase();
+    // the app's own URI schemes may wrap a lightning: link, e.g. dfxtaro:lightning:LNURL1...
+    const cleanedText = bodyOfText
+      .replace('mailto:', '')
+      .toLowerCase()
+      .replace(/^(?:dfxtaro|bluewallet):/, '');
     const res = /^(?:http.*[&?]lightning=|lightning:)?(lnurl1[02-9ac-hj-np-z]+)/.exec(cleanedText);
     if (res) {
       return res[1];

--- a/class/lnurl.js
+++ b/class/lnurl.js
@@ -25,11 +25,11 @@ export default class Lnurl {
   }
 
   static findlnurl(bodyOfText) {
-    // the app's own URI schemes may wrap a lightning: link, e.g. dfxtaro:lightning:LNURL1...
+    // the app's own URI schemes may wrap a lightning: link, e.g. dfxtaro:lightning:LNURL1... or dfxtaro://lightning:LNURL1...
     const cleanedText = bodyOfText
-      .replace('mailto:', '')
       .toLowerCase()
-      .replace(/^(?:dfxtaro|bluewallet):/, '');
+      .replace('mailto:', '')
+      .replace(/^(?:dfxtaro|bluewallet):(?:\/\/)?/, '');
     const res = /^(?:http.*[&?]lightning=|lightning:)?(lnurl1[02-9ac-hj-np-z]+)/.exec(cleanedText);
     if (res) {
       return res[1];

--- a/navigation/ReceiveDetailsStack.tsx
+++ b/navigation/ReceiveDetailsStack.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '../components/themes';
 
 import ReceiveDetails from '../screen/receive/details';
 import LNDCreateInvoice from '../screen/lnd/lndCreateInvoice';
+import LnurlAuth from '../screen/lnd/lnurlAuth';
 import LNDReceive from '../screen/lnd/lndReceive';
 import LndPosReceive from '../screen/lnd/lndPosReceive';
 import CashierPos from '../screen/lnd/cashierPos';
@@ -25,6 +26,7 @@ const ReceiveDetailsStack = () => {
     <Stack.Navigator screenOptions={{ headerShadowVisible: false }} initialRouteName="ReceiveDetails">
       <Stack.Screen name="ReceiveDetails" component={ReceiveDetails} options={ReceiveDetails.navigationOptions(theme)} />
       <Stack.Screen name="LNDCreateInvoice" component={LNDCreateInvoice} options={LNDCreateInvoice.navigationOptions(theme)} />
+      <Stack.Screen name="LnurlAuth" component={LnurlAuth} options={LnurlAuth.navigationOptions(theme)} />
       <Stack.Screen name="LNDReceive" component={LNDReceive} options={LNDReceive.navigationOptions(theme)} />
       <Stack.Screen name="PosReceive" component={LndPosReceive} options={LndPosReceive.navigationOptions(theme)} />
       <Stack.Screen name="CashierPos" component={CashierPos} options={CashierPos.navigationOptions(theme)} />

--- a/navigation/SendDetailsStack.tsx
+++ b/navigation/SendDetailsStack.tsx
@@ -14,6 +14,7 @@ import CoinControl from '../screen/send/coinControl';
 import ScanLndInvoice from '../screen/lnd/scanLndInvoice';
 import LnurlPay from '../screen/lnd/lnurlPay';
 import LnurlPaySuccess from '../screen/lnd/lnurlPaySuccess';
+import LnurlAuth from '../screen/lnd/lnurlAuth';
 import LnurlNavigationForwarder from '../screen/lnd/lnurlNavigationForwarder';
 import OpenCryptoPayCommitOnchain from '../screen/open-crypto-pay/openCrytoPayCommitOnchain';
 
@@ -38,6 +39,7 @@ const SendDetailsStack = () => {
       <Stack.Screen name="ScanLndInvoice" component={ScanLndInvoice} options={ScanLndInvoice.navigationOptions(theme)} />
       <Stack.Screen name="LnurlPay" component={LnurlPay} options={LnurlPay.navigationOptions(theme)} />
       <Stack.Screen name="LnurlPaySuccess" component={LnurlPaySuccess} options={LnurlPaySuccess.navigationOptions(theme)} />
+      <Stack.Screen name="LnurlAuth" component={LnurlAuth} options={LnurlAuth.navigationOptions(theme)} />
       <Stack.Screen
         name="LnurlNavigationForwarder"
         component={LnurlNavigationForwarder}

--- a/navigation/types.ts
+++ b/navigation/types.ts
@@ -35,7 +35,7 @@ export type SendDetailsStackParamList = {
   ScanLndInvoice: object;
   LnurlPay: object;
   LnurlPaySuccess: object;
-  LnurlAuth: object;
+  LnurlAuth: { walletID?: string; lnurl: string };
   LnurlNavigationForwarder: object;
   OpenCryptoPayCommitOnchain: object;
 };
@@ -43,7 +43,7 @@ export type SendDetailsStackParamList = {
 export type ReceiveDetailsStackParamList = {
   ReceiveDetails: { walletID: string; address?: string };
   LNDCreateInvoice: object;
-  LnurlAuth: object;
+  LnurlAuth: { walletID?: string; lnurl: string };
   LNDReceive: object;
   PosReceive: object;
   CashierPos: object;
@@ -139,7 +139,7 @@ export type WalletsStackParamList = {
   IsItMyAddress: undefined;
   LnurlPay: object;
   LnurlPaySuccess: object;
-  LnurlAuth: object;
+  LnurlAuth: { walletID?: string; lnurl: string };
   Success: object;
   WalletAddresses: { walletID: string };
 };

--- a/navigation/types.ts
+++ b/navigation/types.ts
@@ -35,6 +35,7 @@ export type SendDetailsStackParamList = {
   ScanLndInvoice: object;
   LnurlPay: object;
   LnurlPaySuccess: object;
+  LnurlAuth: object;
   LnurlNavigationForwarder: object;
   OpenCryptoPayCommitOnchain: object;
 };
@@ -42,6 +43,7 @@ export type SendDetailsStackParamList = {
 export type ReceiveDetailsStackParamList = {
   ReceiveDetails: { walletID: string; address?: string };
   LNDCreateInvoice: object;
+  LnurlAuth: object;
   LNDReceive: object;
   PosReceive: object;
   CashierPos: object;

--- a/screen/lnd/lnurlNavigationForwarder.tsx
+++ b/screen/lnd/lnurlNavigationForwarder.tsx
@@ -120,9 +120,12 @@ const LnurlNavigationForwarder = () => {
 
     const isOffchain = wallets.find((w: any) => w.getID() === params?.walletID)?.chain === Chain.OFFCHAIN;
     if (tag === Lnurl.TAG_LOGIN_REQUEST) {
-      return navigation.navigate('LnurlAuth', {
-        lnurl,
-        walletID: isOffchain ? params?.walletID : undefined,
+      return navigation.replace('SendDetailsRoot', {
+        screen: 'LnurlAuth',
+        params: {
+          lnurl,
+          walletID: isOffchain ? params?.walletID : undefined,
+        },
       });
     }
 

--- a/tests/unit/deeplink-schema-match.test.js
+++ b/tests/unit/deeplink-schema-match.test.js
@@ -106,6 +106,11 @@ describe.each(['', '//'])('unit - DeepLinkSchemaMatch', function (suffix) {
         'LNURL1DP68GURN8GHJ7UM9WFMXJCM99E3K7MF0V9CXJ0M385EKVCENXC6R2C35XVUKXEFCV5MKVV34X5EKZD3EV56NYD3HXQURZEPEXEJXXEPNXSCRVWFNV9NXZCN9XQ6XYEFHVGCXXCMYXYMNSERXFQ5FNS',
       ),
     );
+    assert.ok(
+      DeeplinkSchemaMatch.isLnUrl(
+        'dfxtaro:lightning:LNURL1DP68GURN8GHJ7UM9WFMXJCM99E3K7MF0V9CXJ0M385EKVCENXC6R2C35XVUKXEFCV5MKVV34X5EKZD3EV56NYD3HXQURZEPEXEJXXEPNXSCRVWFNV9NXZCN9XQ6XYEFHVGCXXCMYXYMNSERXFQ5FNS',
+      ),
+    );
   });
 
   it('navigationForRoute', async () => {
@@ -166,6 +171,20 @@ describe.each(['', '//'])('unit - DeepLinkSchemaMatch', function (suffix) {
       {
         argument: {
           url: 'https://lnbits.com/?lightning=LNURL1DP68GURN8GHJ7MRWVF5HGUEWVDHK6TMHD96XSERJV9MJ7CTSDYHHVVF0D3H82UNV9UM9JDENFPN5SMMK2359J5RKWVMKZ5ZVWAV4VJD63TM',
+        },
+        expected: [
+          'ReceiveDetailsRoot',
+          {
+            screen: 'LNDCreateInvoice',
+            params: {
+              uri: 'lnurl1dp68gurn8ghj7mrwvf5hguewvdhk6tmhd96xserjv9mj7ctsdyhhvvf0d3h82unv9um9jdenfpn5smmk2359j5rkwvmkz5zvwav4vjd63tm',
+            },
+          },
+        ],
+      },
+      {
+        argument: {
+          url: 'dfxtaro:lightning:LNURL1DP68GURN8GHJ7MRWVF5HGUEWVDHK6TMHD96XSERJV9MJ7CTSDYHHVVF0D3H82UNV9UM9JDENFPN5SMMK2359J5RKWVMKZ5ZVWAV4VJD63TM',
         },
         expected: [
           'ReceiveDetailsRoot',

--- a/tests/unit/lnurl.test.js
+++ b/tests/unit/lnurl.test.js
@@ -16,6 +16,11 @@ describe('LNURL', function () {
     assert.strictEqual(Lnurl.findlnurl('DFXTARO:LIGHTNING:' + base.toUpperCase()), base);
     assert.strictEqual(Lnurl.findlnurl('dfxtaro:' + base), base);
     assert.strictEqual(Lnurl.findlnurl('bluewallet:lightning:' + base), base);
+    assert.strictEqual(Lnurl.findlnurl('dfxtaro://lightning:' + base), base);
+    assert.strictEqual(Lnurl.findlnurl('DFXTARO://LIGHTNING:' + base.toUpperCase()), base);
+    assert.strictEqual(Lnurl.findlnurl('bluewallet://lightning:' + base), base);
+    assert.strictEqual(Lnurl.findlnurl('mailto:' + base), base);
+    assert.strictEqual(Lnurl.findlnurl('MAILTO:' + base.toUpperCase()), base);
     assert.strictEqual(Lnurl.findlnurl('bs'), null);
     assert.strictEqual(Lnurl.findlnurl('https://site.com'), null);
     assert.strictEqual(Lnurl.findlnurl('https://site.com/?bs=' + base), null);

--- a/tests/unit/lnurl.test.js
+++ b/tests/unit/lnurl.test.js
@@ -10,6 +10,12 @@ describe('LNURL', function () {
     assert.strictEqual(Lnurl.findlnurl('https://site.com/?lightning=' + base.toUpperCase()), base);
     assert.strictEqual(Lnurl.findlnurl('https://site.com/?nada=nada&lightning=' + base), base);
     assert.strictEqual(Lnurl.findlnurl('https://site.com/?nada=nada&lightning=' + base.toUpperCase()), base);
+    assert.strictEqual(Lnurl.findlnurl('lightning:' + base), base);
+    assert.strictEqual(Lnurl.findlnurl('dfxtaro:lightning:' + base), base);
+    assert.strictEqual(Lnurl.findlnurl('dfxtaro:lightning:' + base.toUpperCase()), base);
+    assert.strictEqual(Lnurl.findlnurl('DFXTARO:LIGHTNING:' + base.toUpperCase()), base);
+    assert.strictEqual(Lnurl.findlnurl('dfxtaro:' + base), base);
+    assert.strictEqual(Lnurl.findlnurl('bluewallet:lightning:' + base), base);
     assert.strictEqual(Lnurl.findlnurl('bs'), null);
     assert.strictEqual(Lnurl.findlnurl('https://site.com'), null);
     assert.strictEqual(Lnurl.findlnurl('https://site.com/?bs=' + base), null);


### PR DESCRIPTION
Collects independent bug fixes.

## 1. LNURL-auth QR codes never reach the auth screen

Scanning a lightning-login QR whose payload is wrapped in the app's own URI scheme (`dfxtaro:lightning:LNURL1...`, decodes to an `lnurla?tag=login` request) misbehaves on both home-screen buttons: the **scan** button strands the user on the lightning receive/invoice screen, the **send** button just closes the scanner.

Two independent defects:

**Detection — `Lnurl.findlnurl()` does not tolerate the app scheme prefix.** Its regex is anchored to the string start and only accepts `lightning:` or `http...?lightning=` prefixes. Both scan handlers gate on `DeeplinkSchemaMatch.isLnUrl(rawValue)` (`screen/wallets/home.js`, `screen/send/ScanCodeSend.tsx`) before routing, so a `dfxtaro:`-prefixed payload never takes the LNURL path: home falls through to `navigationRouteFor` (which strips the scheme and routes any LNURL to `ReceiveDetailsRoot > LNDCreateInvoice`), ScanCodeSend matches nothing and hits its final `goBack()`.

**Routing — the `LnurlAuth` screen was unreachable from where the redirects fire.** `LnurlAuth` was registered only in the wallets stack, but both redirect sites dispatch a bare `navigate('LnurlAuth')` from sibling modal stacks: `LnurlNavigationForwarder` (send stack) and `LNDCreateInvoice.processLnurl` (receive stack). React Navigation bubbles the action to the root, finds no such route, and silently no-ops in release builds. This also affected lightning-login deep links, not just camera scans.

Fix:
- `class/lnurl.js`: strip a leading `dfxtaro:`/`bluewallet:` scheme in `findlnurl()` (same spirit as the existing `mailto:` strip), so every `isLnUrl` gate sees through the wrapper and both buttons route login QRs to `LnurlNavigationForwarder` — camera, image-import and clipboard paths alike.
- `navigation/`: register `LnurlAuth` in `SendDetailsStack` and `ReceiveDetailsStack` (mirroring how `LnurlPay` is registered per stack). `LNDCreateInvoice`'s existing `navigate('LnurlAuth')` now resolves in-stack, unchanged.
- `screen/lnd/lnurlNavigationForwarder.tsx`: the login branch now replaces the modal with `SendDetailsRoot > LnurlAuth`, consistent with its pay/withdraw sibling branches.
- `class/deeplink-schema-match.js`: remove `assertNavigationByLnurl` — never had a caller since its introduction and routes to a screen name that is registered nowhere (`OpenCryptoPaySend`); an abandoned draft of the forwarder's logic.

`LnurlAuth` itself is stack-agnostic (inline success state, close via `getParent().popToTop()`), so hosting it in the modal stacks is safe.

Tests: `findlnurl` cases for scheme-wrapped payloads (lower/upper case, with and without `lightning:`); `isLnUrl` accepts the wrapped form; `navigationRouteFor` case for a `dfxtaro:lightning:LNURL1...` URL. `npm run lint` and `npm run unit` green locally (0 errors; 32 suites, 223 passed / 1 pre-existing skip).

## 2. Dead entries in the hardcoded Electrum peer list

`electrum.jochen-hoenicke.de:50006` consistently refuses/times out (the host still resolves, the service is gone) — upstream BlueWallet carries the same server commented out of its list. Rotation starts at a random index, so roughly 1 in 8 connection attempts landed on it and burned the full 10 s `initElectrum` timeout before moving on.

Also removed the plain-TCP `50001` entries of `VPS.hsmiths.com`, `helicarrier.bauerj.eu` and `kirsche.emzy.de`: all three are dead, and the client never dials them anyway (`_initConnection` always prefers the `ssl` port).

Also added `bitcoin.lu.ke:50002` — the one entry in upstream BlueWallet's current peer list we were missing.

All eight resulting ssl endpoints verified alive with a `server.version` handshake (ElectrumX 1.10–2.0 / Fulcrum 1.11).
