### PR TITLE
Add Sentry crash/error reporting

### DIFF
--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -66,6 +66,9 @@ jobs:
           TRANSPARENCY_PASSWORD: ${{ secrets.TRANSPARENCY_PASSWORD }}
           TRANSPARENCY_ALIAS: ${{ secrets.TRANSPARENCY_ALIAS }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.dfxserve.com/
+          SENTRY_ORG: sentry
+          SENTRY_PROJECT: btc-taro
         run: ./scripts/build-release-apk.sh
 
       - name: Prepare release assets and checksums

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -65,6 +65,7 @@ jobs:
           TRANSPARENCY_KEYSTORE_HEX: ${{ secrets.TRANSPARENCY_KEYSTORE_HEX }}
           TRANSPARENCY_PASSWORD: ${{ secrets.TRANSPARENCY_PASSWORD }}
           TRANSPARENCY_ALIAS: ${{ secrets.TRANSPARENCY_ALIAS }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: ./scripts/build-release-apk.sh
 
       - name: Prepare release assets and checksums

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -7,6 +7,8 @@ name: Deploy (develop)
 #
 # Required repository secrets:
 #   KEYSTORE_FILE_HEX, KEYSTORE_PASSWORD, KEYSTORE_KEY_PASSWORD, KEYSTORE_ALIAS
+#   SENTRY_AUTH_TOKEN (required: a missing token fails this build intentionally,
+#   rather than silently shipping without crash symbolication)
 
 on:
   push:
@@ -48,8 +50,10 @@ jobs:
           KEYSTORE_KEY_PASSWORD: ${{ secrets.KEYSTORE_KEY_PASSWORD }}
           KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           BUILD_NUMBER: ${{ github.run_number }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: |
           set -euo pipefail
+          [ -n "${SENTRY_AUTH_TOKEN:-}" ] || { echo "Missing required env: SENTRY_AUTH_TOKEN" >&2; exit 1; }
           KS="$(mktemp /tmp/app-signing.XXXXXX.keystore)"; chmod 600 "$KS"
           trap 'shred -u "$KS" 2>/dev/null || rm -f "$KS"' EXIT
           printf '%s' "$KEYSTORE_FILE_HEX" | xxd -plain -revert > "$KS"

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -8,7 +8,8 @@ name: Deploy (develop)
 # Required repository secrets:
 #   KEYSTORE_FILE_HEX, KEYSTORE_PASSWORD, KEYSTORE_KEY_PASSWORD, KEYSTORE_ALIAS
 #   SENTRY_AUTH_TOKEN (required: a missing token fails this build intentionally,
-#   rather than silently shipping without crash symbolication)
+#   rather than silently shipping without crash symbolication). SENTRY_URL/ORG/
+#   PROJECT aren't secrets (see below) but sentry-cli needs all of it together.
 
 on:
   push:
@@ -51,9 +52,14 @@ jobs:
           KEYSTORE_ALIAS: ${{ secrets.KEYSTORE_ALIAS }}
           BUILD_NUMBER: ${{ github.run_number }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.dfxserve.com/
+          SENTRY_ORG: sentry
+          SENTRY_PROJECT: btc-taro
         run: |
           set -euo pipefail
-          [ -n "${SENTRY_AUTH_TOKEN:-}" ] || { echo "Missing required env: SENTRY_AUTH_TOKEN" >&2; exit 1; }
+          for var in SENTRY_AUTH_TOKEN SENTRY_URL SENTRY_ORG SENTRY_PROJECT; do
+            [ -n "${!var:-}" ] || { echo "Missing required env: $var" >&2; exit 1; }
+          done
           KS="$(mktemp /tmp/app-signing.XXXXXX.keystore)"; chmod 600 "$KS"
           trap 'shred -u "$KS" 2>/dev/null || rm -f "$KS"' EXIT
           printf '%s' "$KEYSTORE_FILE_HEX" | xxd -plain -revert > "$KS"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ name: Release
 #   iOS:     APP_STORE_CONNECT_KEY, APP_STORE_CONNECT_KEY_ID, APP_STORE_CONNECT_ISSUER_ID,
 #            MATCH_SSH_KEY (deploy key for the certs repo), MATCH_PASSWORD
 #   Android: PLAY_STORE_JSON_BASE64, KEYSTORE_*, TRANSPARENCY_*
+#   Both:    SENTRY_AUTH_TOKEN (required: a missing token fails the release
+#            intentionally, rather than silently shipping without crash
+#            symbolication - see the explicit guards in each Fastfile/script)
 
 on:
   workflow_dispatch:
@@ -110,6 +113,7 @@ jobs:
         working-directory: ios
         env:
           NEW_VERSION: ${{ github.ref_name }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bundle exec fastlane release
 
   android-deploy:
@@ -159,6 +163,7 @@ jobs:
           TRANSPARENCY_KEYSTORE_HEX: ${{ secrets.TRANSPARENCY_KEYSTORE_HEX }}
           TRANSPARENCY_PASSWORD: ${{ secrets.TRANSPARENCY_PASSWORD }}
           TRANSPARENCY_ALIAS: ${{ secrets.TRANSPARENCY_ALIAS }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
         run: bundle exec fastlane release
       - name: Prepare release assets + checksums
         run: bash ./.github/scripts/prepare-release-assets.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ name: Release
 #   Android: PLAY_STORE_JSON_BASE64, KEYSTORE_*, TRANSPARENCY_*
 #   Both:    SENTRY_AUTH_TOKEN (required: a missing token fails the release
 #            intentionally, rather than silently shipping without crash
-#            symbolication - see the explicit guards in each Fastfile/script)
+#            symbolication - see the explicit guards in each Fastfile/script).
+#            SENTRY_URL/ORG/PROJECT aren't secrets but are just as required -
+#            sentry-cli needs all four together to know where to upload.
 
 on:
   workflow_dispatch:
@@ -114,6 +116,9 @@ jobs:
         env:
           NEW_VERSION: ${{ github.ref_name }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.dfxserve.com/
+          SENTRY_ORG: sentry
+          SENTRY_PROJECT: btc-taro
         run: bundle exec fastlane release
 
   android-deploy:
@@ -164,6 +169,9 @@ jobs:
           TRANSPARENCY_PASSWORD: ${{ secrets.TRANSPARENCY_PASSWORD }}
           TRANSPARENCY_ALIAS: ${{ secrets.TRANSPARENCY_ALIAS }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: https://sentry.dfxserve.com/
+          SENTRY_ORG: sentry
+          SENTRY_PROJECT: btc-taro
         run: bundle exec fastlane release
       - name: Prepare release assets + checksums
         run: bash ./.github/scripts/prepare-release-assets.sh

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,7 @@ vendor/*
 audit/**/*.apk
 audit/play-store-unpacked/
 audit/local-build-unpacked/
+
+# Sentry (contains a local auth.token; CI must supply SENTRY_AUTH_TOKEN via env instead)
+android/sentry.properties
+ios/sentry.properties

--- a/App.js
+++ b/App.js
@@ -32,6 +32,20 @@ import WidgetCommunication from './blue_modules/WidgetCommunication';
 import HandoffComponent from './components/handoff';
 import Privacy from './blue_modules/Privacy';
 import { addEventListener } from '@react-native-community/netinfo';
+import * as Sentry from '@sentry/react-native';
+
+Sentry.init({
+  dsn: 'https://3442e1e21177204b9c8d25d2f682b485@sentry.dfxserve.com/4',
+
+  // Do not attach IP address, cookies, or other PII to events.
+  sendDefaultPii: false,
+
+  // Enable Logs
+  enableLogs: true,
+
+  // uncomment the line below to enable Spotlight (https://spotlightjs.com)
+  // spotlight: __DEV__,
+});
 const currency = require('./blue_modules/currency');
 const BlueElectrum = require('./blue_modules/BlueElectrum');
 
@@ -223,4 +237,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default App;
+export default Sentry.wrap(App);

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,6 +41,7 @@ def releaseVersionName = project.findProperty('MYAPP_VERSION_NAME') ?: '2.0.5'
  */
 def jscFlavor = 'io.github.react-native-community:jsc-android:2026004.+'
 
+apply from: new File(["node", "--print", "require.resolve('@sentry/react-native/package.json')"].execute().text.trim(), "../sentry.gradle")
 android {
     androidResources {
         noCompress += ["bundle"]

--- a/blue_modules/analytics.js
+++ b/blue_modules/analytics.js
@@ -1,6 +1,20 @@
 const BlueApp = require('../BlueApp');
+const Sentry = require('@sentry/react-native');
 
-BlueApp.isDoNotTrackEnabled();
+// Sentry.init() runs synchronously at import time (App.js), before this module loads,
+// so a client already exists here. Toggling client.getOptions().enabled is the same
+// mechanism the SDK itself uses internally (see Client.close()) to gate event sending.
+const setSentryEnabled = enabled => {
+  const client = Sentry.getClient();
+  if (client) {
+    client.getOptions().enabled = enabled;
+  }
+};
+
+// Apply the persisted opt-out choice as soon as it's read, closing the gap that made
+// upstream BlueWallet remove Sentry entirely (opt-out toggle didn't stop network calls,
+// BlueWallet/BlueWallet#3309/#3621): until this resolves, Sentry stays at its init default.
+BlueApp.isDoNotTrackEnabled().then(doNotTrack => setSentryEnabled(!doNotTrack));
 
 const A = async event => {};
 
@@ -14,10 +28,13 @@ A.ENUM = {
   NAVIGATED_TO_WALLETS_HODLHODL: 'NAVIGATED_TO_WALLETS_HODLHODL',
 };
 
-A.setOptOut = value => {};
+A.setOptOut = value => {
+  setSentryEnabled(!value);
+};
 
 A.logError = errorString => {
   console.error(errorString);
+  Sentry.captureException(errorString instanceof Error ? errorString : new Error(String(errorString)));
 };
 
 module.exports = A;

--- a/docs/crash-reports.md
+++ b/docs/crash-reports.md
@@ -1,8 +1,18 @@
-# Crash reports (Apple native, no third-party tools)
+# Crash reports
 
-The app ships **no crash-reporting SDK** and sends no telemetry. We rely on Apple's built-in
-crash collection, which surfaces in **Xcode → Window → Organizer → Crashes** (and the crash
-section of App Store Connect) for the app id `swiss.dfx.bitcoin`.
+The app ships the Sentry SDK (`@sentry/react-native`, self-hosted at `sentry.dfxserve.com`),
+which is now the primary way JS and native crashes/errors reach us — see `App.js` for the
+`Sentry.init()` config and `blue_modules/analytics.js` for how it respects the in-app
+Do Not Track toggle. No PII is collected (`sendDefaultPii: false`).
+
+The Apple-native flow below (Organizer/App Store Connect crash reports, no SDK involved)
+still works as a fallback — for example for a user who's opted out of Sentry via Do Not
+Track, or for pre-Sentry builds. It only covers iOS; Android crash triage goes through Sentry.
+
+## Apple-native fallback (no third-party tools)
+
+Apple's built-in crash collection surfaces in **Xcode → Window → Organizer → Crashes** (and the
+crash section of App Store Connect) for the app id `swiss.dfx.bitcoin`.
 
 For a crash to appear there, readable, four things must line up:
 

--- a/ios/BlueWallet.xcodeproj/project.pbxproj
+++ b/ios/BlueWallet.xcodeproj/project.pbxproj
@@ -281,6 +281,7 @@
 				C18D00A61007A84C9887DEDE /* [CP] Copy Pods Resources */,
 				68CD4C52AC5B27E333599B5C /* [CP] Embed Pods Frameworks */,
 				B8C9D0E12F3A4567890BCDEF012 /* [BW] Generate hermesvm dSYM */,
+				67FA2AB96E734BD69471087C /* Upload Debug Symbols to Sentry */,
 			);
 			buildRules = (
 			);
@@ -382,7 +383,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export EXTRA_PACKAGER_ARGS=\"--sourcemap-output $TMPDIR/$(md5 -qs \"$CONFIGURATION_BUILD_DIR\")-main.jsbundle.map\"\nexport NODE_BINARY=$(which node)\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
+			shellScript = "export EXTRA_PACKAGER_ARGS=\"--sourcemap-output $TMPDIR/$(md5 -qs \"$CONFIGURATION_BUILD_DIR\")-main.jsbundle.map\"\nexport NODE_BINARY=$(which node)\n/bin/sh `\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'\"` ../node_modules/react-native/scripts/react-native-xcode.sh\n";
+		};
+		67FA2AB96E734BD69471087C /* Upload Debug Symbols to Sentry */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Upload Debug Symbols to Sentry";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/bin/sh ../node_modules/@sentry/react-native/scripts/sentry-xcode-debug-files.sh";
 		};
 		68CD4C52AC5B27E333599B5C /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -400,22 +415,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-BlueWallet/Pods-BlueWallet-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		B8C9D0E12F3A4567890BCDEF012 /* [BW] Generate hermesvm dSYM */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermesvm.framework/hermesvm",
-			);
-			name = "[BW] Generate hermesvm dSYM";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ \"${CONFIGURATION}\" != \"Release\" ]; then\n  exit 0\nfi\nEMBEDDED=\"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermesvm.framework/hermesvm\"\nHERMES_BIN=\"\"\nif [ -f \"$EMBEDDED\" ]; then\n  HERMES_BIN=\"$EMBEDDED\"\nelse\n  XCFR=\"${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/universal/hermesvm.xcframework/ios-arm64/hermesvm.framework/hermesvm\"\n  if [ -f \"$XCFR\" ]; then\n    HERMES_BIN=\"$XCFR\"\n  else\n    HERMES_BIN=$(find \"${PODS_ROOT}/hermes-engine\" -path \"*hermesvm.framework/hermesvm\" -type f 2>/dev/null | head -n 1)\n  fi\nfi\nif [ -z \"$HERMES_BIN\" ] || [ ! -f \"$HERMES_BIN\" ]; then\n  echo \"[BW] Hermes binary not found; skip dSYM\"\n  exit 0\nfi\nif [ -z \"${DWARF_DSYM_FOLDER_PATH}\" ]; then\n  echo \"[BW] warning: DWARF_DSYM_FOLDER_PATH unset; skip Hermes dSYM\"\n  exit 0\nfi\nOUT=\"${DWARF_DSYM_FOLDER_PATH}/hermesvm.framework.dSYM\"\necho \"[BW] Hermes dSYM: dsymutil -> $OUT\"\nrm -rf \"$OUT\"\n/usr/bin/xcrun dsymutil \"$HERMES_BIN\" -o \"$OUT\"\nexit 0\n";
 			showEnvVarsInLog = 0;
 		};
 		6F7747C31A9EE6DDC5108476 /* [CP] Check Pods Manifest.lock */ = {
@@ -438,6 +437,22 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		B8C9D0E12F3A4567890BCDEF012 /* [BW] Generate hermesvm dSYM */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermesvm.framework/hermesvm",
+			);
+			name = "[BW] Generate hermesvm dSYM";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${CONFIGURATION}\" != \"Release\" ]; then\n  exit 0\nfi\nEMBEDDED=\"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermesvm.framework/hermesvm\"\nHERMES_BIN=\"\"\nif [ -f \"$EMBEDDED\" ]; then\n  HERMES_BIN=\"$EMBEDDED\"\nelse\n  XCFR=\"${PODS_ROOT}/hermes-engine/destroot/Library/Frameworks/universal/hermesvm.xcframework/ios-arm64/hermesvm.framework/hermesvm\"\n  if [ -f \"$XCFR\" ]; then\n    HERMES_BIN=\"$XCFR\"\n  else\n    HERMES_BIN=$(find \"${PODS_ROOT}/hermes-engine\" -path \"*hermesvm.framework/hermesvm\" -type f 2>/dev/null | head -n 1)\n  fi\nfi\nif [ -z \"$HERMES_BIN\" ] || [ ! -f \"$HERMES_BIN\" ]; then\n  echo \"[BW] Hermes binary not found; skip dSYM\"\n  exit 0\nfi\nif [ -z \"${DWARF_DSYM_FOLDER_PATH}\" ]; then\n  echo \"[BW] warning: DWARF_DSYM_FOLDER_PATH unset; skip Hermes dSYM\"\n  exit 0\nfi\nOUT=\"${DWARF_DSYM_FOLDER_PATH}/hermesvm.framework.dSYM\"\necho \"[BW] Hermes dSYM: dsymutil -> $OUT\"\nrm -rf \"$OUT\"\n/usr/bin/xcrun dsymutil \"$HERMES_BIN\" -o \"$OUT\"\nexit 0\n";
 			showEnvVarsInLog = 0;
 		};
 		C18D00A61007A84C9887DEDE /* [CP] Copy Pods Resources */ = {
@@ -730,6 +745,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = i386;
@@ -760,7 +776,6 @@
 				SWIFT_VERSION = 4.2;
 				USE_HERMES = true;
 				VALIDATE_PRODUCT = YES;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 			};
 			name = Release;
 		};

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3204,6 +3204,35 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
+  - RNSentry (8.20.0):
+    - boost
+    - DoubleConversion
+    - fast_float
+    - fmt
+    - glog
+    - hermes-engine
+    - RCT-Folly
+    - RCT-Folly/Fabric
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-renderercss
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - SocketRocket
+    - Yoga
   - RNShare (12.2.6):
     - boost
     - DoubleConversion
@@ -3529,6 +3558,7 @@ DEPENDENCIES:
   - RNReactNativeHapticFeedback (from `../node_modules/react-native-haptic-feedback`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
+  - "RNSentry (from `../node_modules/@sentry/react-native`)"
   - RNShare (from `../node_modules/react-native-share`)
   - RNSVG (from `../node_modules/react-native-svg`)
   - RNVectorIcons (from `../node_modules/react-native-vector-icons`)
@@ -3772,6 +3802,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
     :path: "../node_modules/react-native-screens"
+  RNSentry:
+    :path: "../node_modules/@sentry/react-native"
   RNShare:
     :path: "../node_modules/react-native-share"
   RNSVG:
@@ -3794,7 +3826,7 @@ SPEC CHECKSUMS:
   FBLazyVector: 309703e71d3f2f1ed7dc7889d58309c9d77a95a4
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
-  hermes-engine: b3aba6d3a2b3f10b03122a31ffece1bc54387d41
+  hermes-engine: dc94106234dd2972d5e115a1143ae205ca6827e0
   lottie-ios: 8f959969761e9c45d70353667d00af0e5b9cadb3
   lottie-react-native: 983fd0489530e8d40f173de7f04e2f88b9317a15
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
@@ -3901,6 +3933,7 @@ SPEC CHECKSUMS:
   RNReactNativeHapticFeedback: 43181767a132b77676b6a58b7ed852928e0d4862
   RNReanimated: 18324d3313d6477e1d12836c20c3ee30afb5de30
   RNScreens: 7f643ee0fd1407dc5085c7795460bd93da113b8f
+  RNSentry: 66e61962f44e1a19ccb38306586990a8f696fda1
   RNShare: 51d221e8ac06263e91168c604b94274fdcc4784f
   RNSVG: 595abfa0f9ac26d56afcaaedf4e37a00f54cab71
   RNVectorIcons: 791f13226ec4a3fd13062eda9e892159f0981fae
@@ -3912,4 +3945,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: a92df18318be23818a3e971cce0991f61d44fdb1
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.17.0

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -113,8 +113,10 @@ platform :ios do
   lane :release do
     # Fail fast with a clear message instead of deep inside the Xcode "Upload
     # Debug Symbols to Sentry" build phase, which would fail the whole build
-    # on a missing token anyway but with a much less obvious error.
-    UI.user_error!("SENTRY_AUTH_TOKEN is required for store release builds") if ENV.fetch("SENTRY_AUTH_TOKEN", "").empty?
+    # on any of these missing anyway but with a much less obvious error.
+    %w[SENTRY_AUTH_TOKEN SENTRY_URL SENTRY_ORG SENTRY_PROJECT].each do |var|
+      UI.user_error!("#{var} is required for store release builds") if ENV.fetch(var, "").empty?
+    end
 
     setup_ci
     info = resolve_release_info(ENV["NEW_VERSION"] || "dev")

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -111,6 +111,11 @@ platform :ios do
   # the App Store listing staged alongside the TestFlight build.
   desc "Tag-driven store release: TestFlight + stage the App Store listing"
   lane :release do
+    # Fail fast with a clear message instead of deep inside the Xcode "Upload
+    # Debug Symbols to Sentry" build phase, which would fail the whole build
+    # on a missing token anyway but with a much less obvious error.
+    UI.user_error!("SENTRY_AUTH_TOKEN is required for store release builds") if ENV.fetch("SENTRY_AUTH_TOKEN", "").empty?
+
     setup_ci
     info = resolve_release_info(ENV["NEW_VERSION"] || "dev")
     api_key = get_api_key

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -10,6 +10,16 @@ def get_api_key
   )
 end
 
+# Every lane that builds the Release configuration hits the Xcode "Upload Debug
+# Symbols to Sentry" build phase unconditionally. Fail fast with a clear message
+# here instead of deep inside that build phase, which fails the whole build on
+# any of these missing anyway but with a much less obvious error.
+def require_sentry_env!
+  %w[SENTRY_AUTH_TOKEN SENTRY_URL SENTRY_ORG SENTRY_PROJECT].each do |var|
+    UI.user_error!("#{var} is required for a Release-configuration build") if ENV.fetch(var, "").empty?
+  end
+end
+
 # Run `deliver` (App Store listing push) as best-effort: a failure is logged
 # loudly but does NOT fail the lane. While the app has no editable App Store
 # version yet (TestFlight-only), `deliver` cannot create the first version via
@@ -51,6 +61,8 @@ platform :ios do
   # never mutates them. The ASC API key authorises match + the TestFlight upload.
   desc "Build and upload an internal build to TestFlight"
   lane :beta do
+    require_sentry_env!
+
     # Required fastlane CI signing prep (not a stopgap): makes a dedicated, unlocked
     # keychain the session default so match installs the cert there and sets its
     # key-partition-list — codesign then reads the key without the GUI prompt that
@@ -111,12 +123,7 @@ platform :ios do
   # the App Store listing staged alongside the TestFlight build.
   desc "Tag-driven store release: TestFlight + stage the App Store listing"
   lane :release do
-    # Fail fast with a clear message instead of deep inside the Xcode "Upload
-    # Debug Symbols to Sentry" build phase, which would fail the whole build
-    # on any of these missing anyway but with a much less obvious error.
-    %w[SENTRY_AUTH_TOKEN SENTRY_URL SENTRY_ORG SENTRY_PROJECT].each do |var|
-      UI.user_error!("#{var} is required for store release builds") if ENV.fetch(var, "").empty?
-    end
+    require_sentry_env!
 
     setup_ci
     info = resolve_release_info(ENV["NEW_VERSION"] || "dev")

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,5 +1,7 @@
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 
+const { withSentryConfig } = require('@sentry/react-native/metro');
+
 /**
  * Metro configuration
  * https://facebook.github.io/metro/docs/configuration
@@ -15,4 +17,4 @@ const config = {
   },
 };
 
-module.exports = mergeConfig(getDefaultConfig(__dirname), config);
+module.exports = withSentryConfig(mergeConfig(getDefaultConfig(__dirname), config));

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@react-navigation/drawer": "7.9.8",
         "@react-navigation/native": "7.2.2",
         "@react-navigation/native-stack": "7.14.10",
+        "@sentry/react-native": "^8.20.0",
         "@spsina/bip47": "github:BlueWallet/bip47#df82345",
         "aez": "1.0.1",
         "aezeed": "^0.0.5",
@@ -4751,6 +4752,357 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.3.0.tgz",
+      "integrity": "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.67.0.tgz",
+      "integrity": "sha512-/ZhsAvte4rYhg0A0RtSFFgAgXhyMOfQIeOAfMfptN+X6IVSYOfkA9jtrP+Ej4+6vlaUFWRir1HweF56y63dEEA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.67.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0",
+        "@sentry/feedback": "10.67.0",
+        "@sentry/replay": "10.67.0",
+        "@sentry/replay-canvas": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser-utils": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.67.0.tgz",
+      "integrity": "sha512-HUzaf0xAnPAB+OHBkD7N1Py+CTbD5InHulQ/pdhX4JctWtxuwD8odMD1LzdPnW8J6gVHlDVvcVBR8mXMZYSLSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.6.1.tgz",
+      "integrity": "sha512-9KGZEe/o+vdHS69JhkNztPysqknnI3W5cceovi2G3yb5z29At6SAbGGOdFe3qxYDfC/c2Uw5MKYfev8K9xFI9Q==",
+      "hasInstallScript": true,
+      "license": "FSL-1.1-MIT",
+      "dependencies": {
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "undici": "^6.22.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "3.6.1",
+        "@sentry/cli-linux-arm": "3.6.1",
+        "@sentry/cli-linux-arm64": "3.6.1",
+        "@sentry/cli-linux-i686": "3.6.1",
+        "@sentry/cli-linux-x64": "3.6.1",
+        "@sentry/cli-win32-arm64": "3.6.1",
+        "@sentry/cli-win32-i686": "3.6.1",
+        "@sentry/cli-win32-x64": "3.6.1"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.6.1.tgz",
+      "integrity": "sha512-hit8SHXYTSZnKvT87/n/5RLwJnl0Nm24dewqEXwMzw7YkDFg7Ptq0bIhvGWINgyuBsmEfXGMnrbBZw5sueBtnQ==",
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.6.1.tgz",
+      "integrity": "sha512-FgfKPa4sXianCQxpujNE1JrJYbF6Ug+UPjwdEGAnCZtDeRRQdXbSIih7ikaocg4BcpHxwoRm0BHG1wYeizkCbQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.6.1.tgz",
+      "integrity": "sha512-+6UpbQo56wW5pf1TTBfNoYzf+WuG7c1fj9DAKchQwUzDN7886OwSYC326rDyh/PaafszYj5gAOElFhymNVA1WA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.6.1.tgz",
+      "integrity": "sha512-xDzb2knLayJKv6FGggjrfvQiIpA4wvYvxeNV6B3plTlu1Qunkz5889A+Ayrp4wv19bgMVI6wLdKF9U2TpHPTbQ==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.6.1.tgz",
+      "integrity": "sha512-OJChq61ZoKFLAVC+LPqensvBcoToxnAfAZF19emTLNQNjBbGZBL6G/4P0uK4tlwlhB5wAeobu58xX2kfJEgkjA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.6.1.tgz",
+      "integrity": "sha512-SR4JESQdr1+XmK3kAVa9BAUdOA9QYkreJkWzUlj1oXbTlD5OdRmzc1yMHlkrkbbKSu6vrlqYiEaox3Pgsc08sg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.6.1.tgz",
+      "integrity": "sha512-EBOR2Yx5nYUcwbGXp5AHuQPjNZ9QLcoKlTKAt9ygQX4SF7S0pwnrAfXktkA4QOZqSXtzlKhrpwwnWNq0zPksNw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.6.1.tgz",
+      "integrity": "sha512-qQkVQOMoE5U6NtigezFNYSJncP1DOuauvp7JS+1DRpE5pXTKjHkOT6niWceGQc7wH4UGk6iwzOkNzx6klNd4Yw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "FSL-1.1-MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/cli/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.67.0.tgz",
+      "integrity": "sha512-b6U3pJ8AUvN9aouq0vl+VZI8KT8RslBsfGMFuNwRr313zOmdmFJBZqTiUw9VGgJ2jGKxLO9alm9rlxBfX4hf+w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/expo-upload-sourcemaps": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/expo-upload-sourcemaps/-/expo-upload-sourcemaps-8.20.0.tgz",
+      "integrity": "sha512-FWIJmNTWWY+E/tHQdFIxKMzEB0n47mF8W+1otcXr1hqEsePgBjMqeY2X3NhGRrt4b8rvTCXCjPlc3APyR+nCAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/cli": "3.6.1"
+      },
+      "bin": {
+        "expo-upload-sourcemaps": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@expo/env": "*",
+        "dotenv": "*"
+      },
+      "peerDependenciesMeta": {
+        "@expo/env": {
+          "optional": true
+        },
+        "dotenv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/feedback": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.67.0.tgz",
+      "integrity": "sha512-I4ML2/SF3enwikb6ZSoRiqolQrx0zSzTSnUgwCmugICF/jpHW0th1pCray9R+t1Zzibw/Dpj4t/DNXaSDRa2MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.67.0.tgz",
+      "integrity": "sha512-fS0DplcP9eMxBIRurPC/uxa4NrFK+l9ZsnvQo7wZvNutc7DpTAH0hgFt6laVNCe57s1pFo+OZuKsYBA6JDvH4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.67.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react-native": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.20.0.tgz",
+      "integrity": "sha512-Visy8xWo4wJm3OW1QWiHB4avj0mp+En4fiY9uiaPmWhgX0RIx2fwAm73x3o5+etZdRDnC6oVhV5skofy9rEC6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/babel-plugin-component-annotate": "5.3.0",
+        "@sentry/browser": "10.67.0",
+        "@sentry/cli": "3.6.1",
+        "@sentry/core": "10.67.0",
+        "@sentry/expo-upload-sourcemaps": "8.20.0",
+        "@sentry/react": "10.67.0"
+      },
+      "bin": {
+        "sentry-eas-build-on-complete": "scripts/eas-build-hook.js",
+        "sentry-eas-build-on-error": "scripts/eas-build-hook.js",
+        "sentry-eas-build-on-success": "scripts/eas-build-hook.js",
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/replay": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.67.0.tgz",
+      "integrity": "sha512-nkEUgPCR82EcyJkCf3XCE9H0R5KisCqyCAaSGxe7NpAoQbvASHx4MUNgXVAn+D0M494gvPZh6lFH7JgzqTcSqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser-utils": "10.67.0",
+        "@sentry/core": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/replay-canvas": {
+      "version": "10.67.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.67.0.tgz",
+      "integrity": "sha512-neNA4T6MFtZzMdKYetiR+LZd9BNSd0q2szMn0wk+A15PqHE/IN7a34V6JZc9rCtmzB0wldh0eWGOBb49MSNKjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.67.0",
+        "@sentry/replay": "10.67.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -16694,6 +17046,15 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-8.3.0.tgz",
@@ -16752,6 +17113,12 @@
         "retry": "^0.12.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/public-encrypt": {
       "version": "4.0.3",
@@ -20133,6 +20500,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@react-navigation/drawer": "7.9.8",
     "@react-navigation/native": "7.2.2",
     "@react-navigation/native-stack": "7.14.10",
+    "@sentry/react-native": "^8.20.0",
     "@spsina/bip47": "github:BlueWallet/bip47#df82345",
     "aez": "1.0.1",
     "aezeed": "^0.0.5",

--- a/scripts/build-release-apk.sh
+++ b/scripts/build-release-apk.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 #   TRANSPARENCY_ALIAS
 #   SENTRY_AUTH_TOKEN         required so the release build fails loud instead of
 #                             silently shipping without crash symbolication
+#   SENTRY_URL, SENTRY_ORG, SENTRY_PROJECT
+#                             not secrets, but sentry-cli needs all three to know
+#                             where to upload - without them it defaults to
+#                             sentry.io and fails with "An organization ID or
+#                             slug is required"
 #
 # Optional:
 #   BUILD_NUMBER              deterministic versionCode override
@@ -21,7 +26,8 @@ cd "$REPO_ROOT"
 
 # ── validate ──────────────────────────────────────────────────────────────────
 for var in KEYSTORE_FILE_HEX KEYSTORE_PASSWORD KEYSTORE_KEY_PASSWORD KEYSTORE_ALIAS \
-           TRANSPARENCY_KEYSTORE_HEX TRANSPARENCY_PASSWORD TRANSPARENCY_ALIAS SENTRY_AUTH_TOKEN; do
+           TRANSPARENCY_KEYSTORE_HEX TRANSPARENCY_PASSWORD TRANSPARENCY_ALIAS \
+           SENTRY_AUTH_TOKEN SENTRY_URL SENTRY_ORG SENTRY_PROJECT; do
   [ -n "${!var:-}" ] || { echo "Missing required env: $var" >&2; exit 1; }
 done
 

--- a/scripts/build-release-apk.sh
+++ b/scripts/build-release-apk.sh
@@ -9,6 +9,8 @@ set -euo pipefail
 #   TRANSPARENCY_KEYSTORE_HEX hex-encoded code transparency keystore
 #   TRANSPARENCY_PASSWORD
 #   TRANSPARENCY_ALIAS
+#   SENTRY_AUTH_TOKEN         required so the release build fails loud instead of
+#                             silently shipping without crash symbolication
 #
 # Optional:
 #   BUILD_NUMBER              deterministic versionCode override
@@ -19,7 +21,7 @@ cd "$REPO_ROOT"
 
 # ── validate ──────────────────────────────────────────────────────────────────
 for var in KEYSTORE_FILE_HEX KEYSTORE_PASSWORD KEYSTORE_KEY_PASSWORD KEYSTORE_ALIAS \
-           TRANSPARENCY_KEYSTORE_HEX TRANSPARENCY_PASSWORD TRANSPARENCY_ALIAS; do
+           TRANSPARENCY_KEYSTORE_HEX TRANSPARENCY_PASSWORD TRANSPARENCY_ALIAS SENTRY_AUTH_TOKEN; do
   [ -n "${!var:-}" ] || { echo "Missing required env: $var" >&2; exit 1; }
 done
 

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+
+// tests/setup.js globally stubs this module out for every other unit test
+// (jest.fn() with a placeholder ENUM) - undo that here to test the real thing.
+jest.unmock('../../blue_modules/analytics');
+
+jest.mock('../../BlueApp', () => ({
+  isDoNotTrackEnabled: jest.fn().mockResolvedValue(false),
+}));
+
+const mockSentryOptions = { enabled: true };
+jest.mock('@sentry/react-native', () => ({
+  getClient: jest.fn(() => ({ getOptions: () => mockSentryOptions })),
+  captureException: jest.fn(),
+}));
+
+describe('blue_modules/analytics', () => {
+  beforeEach(() => {
+    mockSentryOptions.enabled = true;
+    jest.clearAllMocks();
+  });
+
+  it('setOptOut(true) disables the Sentry client (opting out must actually stop event delivery)', () => {
+    const A = require('../../blue_modules/analytics');
+    A.setOptOut(true);
+    assert.strictEqual(mockSentryOptions.enabled, false);
+  });
+
+  it('setOptOut(false) re-enables the Sentry client', () => {
+    const A = require('../../blue_modules/analytics');
+    mockSentryOptions.enabled = false;
+    A.setOptOut(false);
+    assert.strictEqual(mockSentryOptions.enabled, true);
+  });
+
+  it('logError forwards an Error instance to Sentry.captureException unchanged', () => {
+    const A = require('../../blue_modules/analytics');
+    const Sentry = require('@sentry/react-native');
+    const err = new Error('boom');
+
+    A.logError(err);
+
+    assert.strictEqual(Sentry.captureException.mock.calls.length, 1);
+    assert.strictEqual(Sentry.captureException.mock.calls[0][0], err);
+  });
+
+  it('logError wraps a non-Error value in an Error before forwarding', () => {
+    const A = require('../../blue_modules/analytics');
+    const Sentry = require('@sentry/react-native');
+
+    A.logError('plain string error');
+
+    assert.strictEqual(Sentry.captureException.mock.calls.length, 1);
+    const forwarded = Sentry.captureException.mock.calls[0][0];
+    assert.ok(forwarded instanceof Error);
+    assert.strictEqual(forwarded.message, 'plain string error');
+  });
+});

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -55,4 +55,20 @@ describe('blue_modules/analytics', () => {
     assert.ok(forwarded instanceof Error);
     assert.strictEqual(forwarded.message, 'plain string error');
   });
+
+  // Separate from the tests above: the module also applies the persisted Do Not
+  // Track choice on load (before any explicit setOptOut call), which is what
+  // actually closes the upstream gap - resets the module registry so the
+  // top-level `BlueApp.isDoNotTrackEnabled().then(...)` runs fresh, then flushes
+  // the microtask queue before asserting. Last in the file since resetModules()
+  // affects the shared cache for any test declared after it.
+  it('applies the persisted Do Not Track state to Sentry on module load', async () => {
+    jest.resetModules();
+    require('../../BlueApp').isDoNotTrackEnabled.mockResolvedValueOnce(true);
+
+    require('../../blue_modules/analytics');
+    await new Promise(process.nextTick);
+
+    assert.strictEqual(mockSentryOptions.enabled, false);
+  });
 });


### PR DESCRIPTION
## Summary

- Install `@sentry/react-native`: JS init (`App.js`), native iOS/Android build integration for source map + debug symbol upload
- PII collection off (`sendDefaultPii: false`)
- Wire Sentry into the existing Do Not Track toggle (`blue_modules/analytics.js`) so opting out actually stops event delivery, not just in-app analytics — upstream BlueWallet dropped Sentry entirely in 2021 over exactly this gap (opt-out not stopping network calls)
- `sentry.properties` gitignored (contained a local auth token, never committed)
- CI (`deploy-develop.yml`, `build-release-apk.yml`, `release.yml`) now requires `SENTRY_AUTH_TOKEN` and fails release builds fast with a clear message if it's missing, rather than silently shipping without crash symbolication — see #204 for provisioning that secret

## Validation

- `npm run lint` (tsc + unused-loc + eslint): 0 errors, no new warnings
- `npm run unit`: 32 suites, 223 passed, 1 pre-existing skip
- End-to-end verified on both platforms (iOS Simulator + Android emulator): built, ran, dispatched a real error, confirmed receipt via the Sentry API with correct release/dist/device tags and no PII
- YAML/Ruby/bash syntax validated on all touched workflow/script/Fastfile changes

## Follow-up

Blocked on #204 (repo owner needs to add the `SENTRY_AUTH_TOKEN` secret) before release builds will succeed on this branch.