### PR TITLE
fix(ios): remove EXTRA_PACKAGER_ARGS sourcemap override breaking Sentry uploads

### DIFF
--- a/ios/BlueWallet.xcodeproj/project.pbxproj
+++ b/ios/BlueWallet.xcodeproj/project.pbxproj
@@ -383,7 +383,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export EXTRA_PACKAGER_ARGS=\"--sourcemap-output $TMPDIR/$(md5 -qs \"$CONFIGURATION_BUILD_DIR\")-main.jsbundle.map\"\nexport NODE_BINARY=$(which node)\n/bin/sh `\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'\"` ../node_modules/react-native/scripts/react-native-xcode.sh\n";
+			shellScript = "export NODE_BINARY=$(which node)\n/bin/sh `\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('@sentry/react-native/package.json')) + '/scripts/sentry-xcode.sh'\"` ../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
 		67FA2AB96E734BD69471087C /* Upload Debug Symbols to Sentry */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
## Problem

Broke the release pipeline immediately after #203 merged: the `v2.0.20` tag's `release.yml` run failed in the iOS `Archive` step with:

```
error: sentry-cli - Error: ENOENT: no such file or directory, open '.../Release-iphoneos/main.jsbundle.map'
```

Run: https://github.com/DFXswiss/btc-wallet/actions/runs/30163138702/job/89691619393

## Root cause

The "Bundle React Native code and images" build phase already set:

```
EXTRA_PACKAGER_ARGS="--sourcemap-output $TMPDIR/<hash>-main.jsbundle.map"
```

This predates #203 and was harmless, because nothing downstream ever read that file - the packager sourcemap was generated but unused.

#203 wraps this same phase with Sentry's `sentry-xcode.sh`, which sets `$SOURCEMAP_FILE` before invoking `react-native-xcode.sh`. That makes `react-native-xcode.sh` construct its own `--sourcemap-output <default path>` flag; the pre-existing `EXTRA_PACKAGER_ARGS` is appended *after* it on the same command line, so Metro honors the later (custom) flag and writes there instead. `react-native-xcode.sh`'s Hermes sourcemap-composition step then looks for the packager map at the default path - which was never created - and fails.

This only surfaces in a full Xcode **Archive** build (what `fastlane build_app` / `gym` does for TestFlight/App Store uploads) - not in a regular `react-native run-ios`, which is the only iOS build mode that got tested before #203 merged.

## Fix

Drop the now-redundant `EXTRA_PACKAGER_ARGS` override. Sentry's own `$SOURCEMAP_FILE` resolution is the single source of truth for this path now.

## Verification

Reproduced and confirmed fixed locally with a full unsigned `xcodebuild archive` of the `BlueWallet` scheme (Release config, matching the failing CI job):
- With the override in place: identical `ENOENT` on `main.jsbundle.map`.
- With it removed: the composed sourcemap (`.../DerivedSources/main.jsbundle.map`) is both created and read successfully, and the archive completes (`** ARCHIVE SUCCEEDED **`).

`npm run lint` / `npm run unit` unaffected (no JS changes).

## Urgency

This currently blocks every store release (`develop` → tag → `release.yml`) on both platforms' shared tag, since `release.yml` requires `ios-deploy` and `android-deploy` to both succeed before `github-release` runs. Would appreciate a fast review/merge.