### PR TITLE
Console logging cleanup and iOS Addresses screen QR fix

### DIFF
--- a/App.js
+++ b/App.js
@@ -81,7 +81,7 @@ const App = () => {
   const { walletsInitialized, wallets, addWallet, saveToDisk, setBalanceRefreshInterval, clearBalanceRefreshInterval } =
     useContext(BlueStorageContext);
   const appState = useRef(AppState.currentState);
-  const didAttemptInitialElectrumConnect = useRef(false);
+  const wasElectrumOnline = useRef(undefined);
 
   useCompanionListeners();
 
@@ -217,10 +217,16 @@ const App = () => {
       // so a cold start with no network burned the whole retry cascade for nothing.
       // NetInfo delivers the current state as soon as we subscribe, so this is the
       // earliest point at which the answer is actually known.
-      if (!isOffline && !didAttemptInitialElectrumConnect.current) {
-        didAttemptInitialElectrumConnect.current = true;
+      //
+      // Fires on the first report that says we have a network, and again on every
+      // offline -> online transition, since the cascade dies against the
+      // networkConnected guard while offline and nothing else re-enters it. Not
+      // level-triggered: reconnecting when already connected re-arms the 30 minute
+      // peer rotation timer.
+      if (!isOffline && wasElectrumOnline.current !== true) {
         BlueElectrum.connectMain();
       }
+      wasElectrumOnline.current = !isOffline;
     });
 
     return () => {

--- a/App.js
+++ b/App.js
@@ -142,7 +142,7 @@ const App = () => {
     DeviceQuickActions.popInitialAction().then(popInitialAction);
     EventEmitter?.getMostRecentUserActivity()
       .then(onUserActivityOpen)
-      .catch(() => console.log('No userActivity object sent'));
+      .catch(() => {});
     handleAppStateChange(undefined);
     eventEmitter?.addListener('openSettings', openSettings);
     eventEmitter?.addListener('onUserActivityOpen', onUserActivityOpen);
@@ -219,8 +219,9 @@ const App = () => {
       // earliest point at which the answer is actually known.
       //
       // Fires on the first report that says we have a network, and again on every
-      // offline -> online transition, since the cascade dies against the
-      // networkConnected guard while offline and nothing else re-enters it. Not
+      // offline -> online transition: while offline every connectMain() returns at
+      // the networkConnected guard, so reconnecting here is immediate instead of
+      // waiting for the next waitTillConnected() timeout to drive it. Not
       // level-triggered: reconnecting when already connected re-arms the 30 minute
       // peer rotation timer.
       if (!isOffline && wasElectrumOnline.current !== true) {

--- a/App.js
+++ b/App.js
@@ -81,6 +81,7 @@ const App = () => {
   const { walletsInitialized, wallets, addWallet, saveToDisk, setBalanceRefreshInterval, clearBalanceRefreshInterval } =
     useContext(BlueStorageContext);
   const appState = useRef(AppState.currentState);
+  const didAttemptInitialElectrumConnect = useRef(false);
 
   useCompanionListeners();
 
@@ -204,7 +205,22 @@ const App = () => {
 
   useEffect(() => {
     const unsubscribe = addEventListener(state => {
-      BlueElectrum.setNetworkConnected(state.isConnected);
+      // isConnected is `boolean | null`, where null means "not yet determined".
+      // Only a definite false means offline - treating unknown as offline would
+      // gate connectMain() off entirely (see the networkConnected check there)
+      // and leave Electrum wedged with no connection and no retry.
+      const isOffline = state.isConnected === false;
+      BlueElectrum.setNetworkConnected(!isOffline);
+
+      // The initial connect used to run at BlueApp.js module scope, before NetInfo
+      // had reported anything - and BlueElectrum defaults networkConnected to true,
+      // so a cold start with no network burned the whole retry cascade for nothing.
+      // NetInfo delivers the current state as soon as we subscribe, so this is the
+      // earliest point at which the answer is actually known.
+      if (!isOffline && !didAttemptInitialElectrumConnect.current) {
+        didAttemptInitialElectrumConnect.current = true;
+        BlueElectrum.connectMain();
+      }
     });
 
     return () => {

--- a/BlueApp.js
+++ b/BlueApp.js
@@ -738,7 +738,7 @@ class AppStorage {
         if (!(this.wallets[index].allowBIP47() && this.wallets[index].isBIP47Enabled())) return;
         await this.wallets[index].fetchBIP47SenderPaymentCodes();
       } catch (error) {
-        console.error('Failed to fetch sender payment codes for wallet', index, error);
+        console.error(`fetchSenderPaymentCodes: failed for wallet index ${index}`, error);
       }
     } else {
       for (const wallet of this.wallets) {
@@ -746,7 +746,7 @@ class AppStorage {
           if (!(wallet.allowBIP47() && wallet.isBIP47Enabled())) continue;
           await wallet.fetchBIP47SenderPaymentCodes();
         } catch (error) {
-          console.error('Failed to fetch sender payment codes for wallet', wallet.label, error);
+          console.error('fetchSenderPaymentCodes: failed for wallet', error);
         }
       }
     }

--- a/BlueApp.js
+++ b/BlueApp.js
@@ -408,7 +408,7 @@ class AppStorage {
             try {
               lndhub = await AsyncStorage.getItem(AppStorage.LNDHUB);
             } catch (error) {
-              console.error('BlueApp: failed to read LNDHub URI from storage', error);
+              console.error('loadFromDisk: failed to read LNDHub URI from storage', error);
             }
 
             if (unserializedWallet.baseURI) {

--- a/BlueApp.js
+++ b/BlueApp.js
@@ -33,8 +33,6 @@ let usedBucketNum = false;
 let savingInProgress = 0; // its both a flag and a counter of attempts to write to disk
 const prompt = require('./helpers/prompt');
 const currency = require('./blue_modules/currency');
-const BlueElectrum = require('./blue_modules/BlueElectrum');
-BlueElectrum.connectMain();
 
 class AppStorage {
   static FLAG_ENCRYPTED = 'data_encrypted';
@@ -113,14 +111,13 @@ class AppStorage {
     try {
       return await this.getItem(key);
     } catch (error) {
-      console.warn('error reading', key, error.message);
-      console.warn('fallback to realm');
+      console.warn(`getItemWithFallbackToRealm: keychain read failed for "${key}", falling back to realm`, error);
       const realmKeyValue = await this.openRealmKeyValue();
       const obj = realmKeyValue.objectForPrimaryKey('KeyValue', key); // search for a realm object with a primary key
       value = obj?.value;
       realmKeyValue.close();
       if (value) {
-        console.warn('successfully recovered', value.length, 'bytes from realm for key', key);
+        console.warn(`getItemWithFallbackToRealm: recovered ${value.length} bytes from realm for "${key}"`);
         return value;
       }
       return null;
@@ -132,7 +129,7 @@ class AppStorage {
     try {
       data = await this.getItemWithFallbackToRealm(AppStorage.FLAG_ENCRYPTED);
     } catch (error) {
-      console.warn('error reading `' + AppStorage.FLAG_ENCRYPTED + '` key:', error.message);
+      console.warn(`storageIsEncrypted: failed to read "${AppStorage.FLAG_ENCRYPTED}", assuming not encrypted`, error);
       return false;
     }
 
@@ -333,7 +330,7 @@ class AppStorage {
       try {
         realm = await this.getRealm();
       } catch (error) {
-        console.log('ERROR: ', error.message);
+        console.error('loadFromDisk: getRealm failed, wallet tx cache unavailable', error);
       }
       data = JSON.parse(data);
       if (!data.wallets) return false;
@@ -411,17 +408,13 @@ class AppStorage {
             try {
               lndhub = await AsyncStorage.getItem(AppStorage.LNDHUB);
             } catch (error) {
-              console.warn(error);
+              console.error('BlueApp: failed to read LNDHub URI from storage', error);
             }
 
             if (unserializedWallet.baseURI) {
               unserializedWallet.setBaseURI(unserializedWallet.baseURI); // not really necessary, just for the sake of readability
-              console.log('using saved uri for for ln wallet:', unserializedWallet.baseURI);
             } else if (lndhub) {
-              console.log('using wallet-wide settings ', lndhub, 'for ln wallet');
               unserializedWallet.setBaseURI(lndhub);
-            } else {
-              console.log('wallet does not have a baseURI. Continuing init...');
             }
             unserializedWallet.init();
             break;
@@ -435,7 +428,7 @@ class AppStorage {
         try {
           if (realm) this.inflateWalletFromRealm(realm, unserializedWallet);
         } catch (error) {
-          console.log('ERROR: ', error.message);
+          console.error('loadFromDisk: failed to inflate wallet from realm', error);
         }
 
         // done
@@ -584,7 +577,8 @@ class AppStorage {
    */
   async saveToDisk() {
     if (savingInProgress) {
-      if (++savingInProgress > 10) console.warn('ERROR: Critical error. Last actions were not saved'); // should never happen
+      // should never happen
+      if (++savingInProgress > 10) console.error(`saveToDisk: ${savingInProgress} concurrent save attempts, last actions were not saved`);
       await new Promise(resolve => setTimeout(resolve, 1000 * savingInProgress)); // sleep
       return this.saveToDisk();
     }
@@ -596,7 +590,7 @@ class AppStorage {
       try {
         realm = await this.getRealm();
       } catch (error) {
-        console.error(`saveToDisk: getRealm: ${error.message}`);
+        console.error('saveToDisk: getRealm failed, tx cache will not be written', error);
       }
       for (const key of this.wallets) {
         if (typeof key === 'boolean') continue;
@@ -669,9 +663,9 @@ class AppStorage {
       this.saveToRealmKeyValue(realmkeyValue, AppStorage.FLAG_ENCRYPTED, this.cachedPassword ? '1' : '');
       realmkeyValue.close();
     } catch (error) {
-      console.error('save to disk exception:', error.message);
+      console.error('saveToDisk: failed to persist wallet data', error);
       if (error.message.includes('Realm file decryption failed')) {
-        console.warn('purging realm key-value database file');
+        console.warn('saveToDisk: realm file decryption failed, purging realm key-value database file');
         this.purgeRealmKeyValueFile();
       }
     } finally {
@@ -942,9 +936,7 @@ const BlueApp = new AppStorage();
 let unlockAttempt = 0;
 
 const startAndDecrypt = async retry => {
-  console.log('startAndDecrypt');
   if (BlueApp.getWallets().length > 0) {
-    console.log('App already has some wallets, so we are in already started state, exiting startAndDecrypt');
     return true;
   }
   await BlueApp.migrateKeys();
@@ -961,7 +953,7 @@ const startAndDecrypt = async retry => {
   } catch (error) {
     // in case of exception reading from keystore, lets retry instead of assuming there is no storage and
     // proceeding with no wallets
-    console.warn('exception loading from disk:', error);
+    console.error('startAndDecrypt: failed to load wallets from disk, retrying', error);
     wasException = true;
   }
 
@@ -971,12 +963,11 @@ const startAndDecrypt = async retry => {
       await new Promise(resolve => setTimeout(resolve, 3000)); // sleep
       success = await BlueApp.loadFromDisk(password);
     } catch (error) {
-      console.warn('second exception loading from disk:', error);
+      console.error('startAndDecrypt: second attempt to load wallets from disk failed', error);
     }
   }
 
   if (success) {
-    console.log('loaded from disk');
     // We want to return true to let the UnlockWith screen that its ok to proceed.
     return true;
   }

--- a/WatchConnectivity.ios.js
+++ b/WatchConnectivity.ios.js
@@ -60,7 +60,7 @@ function WatchConnectivity() {
           });
           lastPreferredCurrency.current = preferredFiatCurrency.endPointKey;
         }
-      } catch (e) {}
+      } catch (_) {}
     }
   }, [preferredFiatCurrency, walletsInitialized, isReachable, isInstalled]);
 
@@ -100,7 +100,7 @@ function WatchConnectivity() {
             const decoded = await wallet.decodeInvoice(invoiceRequest);
             majorTomToGroundControl([], [decoded.payment_hash], []);
           }
-        } catch (e) {}
+        } catch (_) {}
         return invoiceRequest;
       } catch (error) {
         return error;

--- a/WatchConnectivity.ios.js
+++ b/WatchConnectivity.ios.js
@@ -59,13 +59,8 @@ function WatchConnectivity() {
             preferredFiatCurrency: preferredFiatCurrencyParsed.endPointKey,
           });
           lastPreferredCurrency.current = preferredFiatCurrency.endPointKey;
-        } else {
-          console.log('WatchConnectivity lastPreferredCurrency has not changed');
         }
-      } catch (e) {
-        console.log('WatchConnectivity useEffect preferredFiatCurrency error');
-        console.log(e);
-      }
+      } catch (e) {}
     }
   }, [preferredFiatCurrency, walletsInitialized, isReachable, isInstalled]);
 
@@ -73,8 +68,7 @@ function WatchConnectivity() {
     if (message.request === 'createInvoice') {
       handleLightningInvoiceCreateRequest(message.walletIndex, message.amount, message.description)
         .then(createInvoiceRequest => reply({ invoicePaymentRequest: createInvoiceRequest }))
-        .catch(e => {
-          console.log(e);
+        .catch(() => {
           reply({});
         });
     } else if (message.message === 'sendApplicationContext') {
@@ -83,9 +77,7 @@ function WatchConnectivity() {
     } else if (message.message === 'fetchTransactions') {
       fetchWalletTransactions()
         .then(() => saveToDisk())
-        .catch(e => {
-          console.log(e);
-        })
+        .catch(() => {})
         .finally(() => reply({}));
     } else if (message.message === 'hideBalance') {
       const walletIndex = message.walletIndex;
@@ -108,10 +100,7 @@ function WatchConnectivity() {
             const decoded = await wallet.decodeInvoice(invoiceRequest);
             majorTomToGroundControl([], [decoded.payment_hash], []);
           }
-        } catch (e) {
-          console.log('WatchConnectivity - Running in Simulator');
-          console.log(e);
-        }
+        } catch (e) {}
         return invoiceRequest;
       } catch (error) {
         return error;
@@ -121,11 +110,9 @@ function WatchConnectivity() {
 
   const sendWalletsToWatch = async () => {
     if (!Array.isArray(wallets)) {
-      console.log('No Wallets set to sync with Watch app. Exiting...');
       return;
     }
     if (!walletsInitialized) {
-      console.log('Wallets not initialized. Exiting...');
       return;
     }
     const walletsToProcess = [];

--- a/api/dfx/contexts/language.context.tsx
+++ b/api/dfx/contexts/language.context.tsx
@@ -17,7 +17,9 @@ export function LanguageContextProvider(props: PropsWithChildren): React.JSX.Ele
   const { getLanguages } = useLanguage();
 
   useEffect(() => {
-    getLanguages().then(setLanguages).catch(console.error);
+    getLanguages()
+      .then(setLanguages)
+      .catch(e => console.error('LanguageContext: failed to load languages', e));
   }, [getLanguages]);
 
   const context: LanguageInterface = useMemo(() => ({ languages: languages?.filter(l => l.enable) }), [languages]);

--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -77,19 +77,32 @@ let rotatePeerTimeout = null;
 let networkConnected = true;
 
 // Substrings safe to report for a user-configured peer: they describe the failure
-// mode without carrying the host or IP the native error string embeds.
+// mode without carrying the host or IP the native error string embeds. Matched
+// case-insensitively against the strings Android (SocketException/SSLHandshake)
+// and iOS (localizedDescription) actually produce, not Node errno names.
 const SAFE_ERROR_TOKENS = [
   'ECONNREFUSED',
-  'ETIMEDOUT',
-  'ENOTFOUND',
+  'ECONNRESET',
   'EHOSTUNREACH',
   'ENETUNREACH',
-  'ECONNRESET',
   'EPIPE',
-  'certificate',
+  'trust anchor',
+  'certif',
+  'ssl',
+  'tls',
   'handshake',
   'timed out',
+  'timeout',
   'refused',
+  'unable to resolve host',
+  'no address associated',
+  'unreachable',
+  'no route',
+  'reset',
+  'broken pipe',
+  // Ordered last: these are the least specific, so a more precise token wins first.
+  'failed to connect',
+  'osstatus',
 ];
 
 async function isDisabled() {
@@ -171,8 +184,8 @@ async function _initConnection() {
   // .code - only allowlisted tokens can ever be emitted for a custom peer.
   const scrubPeer = e => {
     if (!isCustomPeer) return e;
-    const text = String(e?.code ?? e?.message ?? e ?? '');
-    return SAFE_ERROR_TOKENS.find(token => text.includes(token)) ?? 'connection error';
+    const text = String(e?.code ?? e?.message ?? e ?? '').toLowerCase();
+    return SAFE_ERROR_TOKENS.find(token => text.includes(token.toLowerCase())) ?? 'connection error';
   };
 
   try {

--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -102,12 +102,10 @@ async function setDisabled(disabled = true) {
 
 async function connectMain() {
   if (await isDisabled()) {
-    console.log('Electrum connection disabled by user. Skipping connectMain call');
     return;
   }
 
   if (!networkConnected) {
-    console.warn('Network is not connected, skipping Electrum connection');
     return;
   }
 
@@ -115,7 +113,6 @@ async function connectMain() {
 
   connectionPromise = _initConnection().finally(() => {
     if (isMainClientConnected()) {
-      console.log('Electrum connection established, rotating peer in 30 minutes');
       connectionAttempt = 0;
       clearTimeout(rotatePeerTimeout);
       rotatePeerTimeout = setTimeout(
@@ -128,7 +125,6 @@ async function connectMain() {
     } else if (connectionAttempt++ > hardcodedPeers.length * 2) {
       mainClient?.close?.();
     } else {
-      console.log('Electrum connection not established, trying again');
       connectMain();
     }
 
@@ -139,7 +135,6 @@ async function connectMain() {
 
 async function _initConnection() {
   if (await isDisabled()) {
-    console.log('Electrum connection disabled by user. Skipping _initConnection call');
     return;
   }
 
@@ -147,9 +142,12 @@ async function _initConnection() {
 
   let usingPeer = await getNextPeer();
   const savedPeer = await getSavedPeer();
+  let isCustomPeer = false;
   if (savedPeer && savedPeer.host && (savedPeer.tcp || savedPeer.ssl)) {
     usingPeer = savedPeer;
+    isCustomPeer = true;
   }
+  const peerLabel = isCustomPeer ? 'user-configured server' : usingPeer.host;
 
   try {
     await DefaultPreference.setName('group.swiss.dfx.bitcoin');
@@ -167,15 +165,14 @@ async function _initConnection() {
     WidgetCommunication.reloadAllTimelines();
   } catch (e) {
     // Must be running on Android
-    console.log(e);
   }
 
+  const connectStartedAt = Date.now();
   try {
-    console.log('begin connection:', JSON.stringify(usingPeer));
     mainClient = new ElectrumClient(net, tls, usingPeer.ssl || usingPeer.tcp, usingPeer.host, usingPeer.ssl ? 'tls' : 'tcp');
 
     mainClient.onError = function (e) {
-      console.log('electrum mainClient.onError():', e.message);
+      console.warn(`[electrum] socket error on ${peerLabel}, reconnecting`, e);
       mainClient.close();
       connectMain();
     };
@@ -198,7 +195,7 @@ async function _initConnection() {
       throw new Error('Electrum connection timed out');
     }
 
-    console.log('connected to ', ver);
+    console.log(`[electrum] connected to ${peerLabel} in ${Date.now() - connectStartedAt}ms - ${ver[0]}`);
     serverName = ver[0];
 
     if (ver[0].startsWith('ElectrumPersonalServer') || ver[0].startsWith('electrs') || ver[0].startsWith('Fulcrum')) {
@@ -230,7 +227,12 @@ async function _initConnection() {
     }
     // AsyncStorage.setItem(storageKey, JSON.stringify(peers));  TODO: refactor
   } catch (e) {
-    console.log('bad connection:', JSON.stringify(usingPeer), e);
+    // Duration separates "server is slow" (~10s, the initElectrum race timed out)
+    // from "server refused / DNS failed" (fast). Attempt number shows cascade depth.
+    console.warn(
+      `[electrum] connect to ${peerLabel} failed after ${Date.now() - connectStartedAt}ms (attempt ${connectionAttempt + 1})`,
+      e,
+    );
   }
 }
 
@@ -465,8 +467,14 @@ module.exports.multiGetBalanceByAddress = async function (addresses, batchsize) 
       balances = await mainClient.blockchainScripthash_getBalanceBatch(scripthashes);
     }
 
+    const balanceErrors = balances.filter(bal => bal.error);
+    if (balanceErrors.length) {
+      console.warn(
+        `multiGetBalanceByAddress: ${balanceErrors.length} of ${balances.length} addresses returned errors`,
+        balanceErrors[0].error,
+      );
+    }
     for (const bal of balances) {
-      if (bal.error) console.warn('multiGetBalanceByAddress():', bal.error);
       ret.balance += +bal.result.confirmed;
       ret.unconfirmed_balance += +bal.result.unconfirmed;
       ret.addresses[scripthash2addr[bal.param]] = bal.result;
@@ -554,8 +562,14 @@ module.exports.multiGetHistoryByAddress = async function (addresses, batchsize) 
       results = await mainClient.blockchainScripthash_getHistoryBatch(scripthashes);
     }
 
+    const historyErrors = results.filter(history => history.error);
+    if (historyErrors.length) {
+      console.warn(
+        `multiGetHistoryByAddress: ${historyErrors.length} of ${results.length} addresses returned errors`,
+        historyErrors[0].error,
+      );
+    }
     for (const history of results) {
-      if (history.error) console.warn('multiGetHistoryByAddress():', history.error);
       ret[scripthash2addr[history.param]] = history.result || [];
       for (const result of history.result || []) {
         if (result.tx_hash) txhashHeightCache[result.tx_hash] = result.height; // cache tx height
@@ -588,7 +602,7 @@ module.exports.multiGetTransactionByTxid = async function (txids, batchsize, ver
       try {
         ret[txid] = JSON.parse(jsonString.cache_value);
       } catch (error) {
-        console.log(error, 'cache failed to parse', jsonString.cache_value);
+        console.warn('multiGetTransactionByTxid: cached transaction failed to parse, refetching', error);
       }
     }
 
@@ -632,18 +646,26 @@ module.exports.multiGetTransactionByTxid = async function (txids, batchsize, ver
       } catch (_) {
         if (String(_?.message ?? _).startsWith('verbose transactions are currently unsupported')) {
           // electrs-esplora. cant use verbose, so fetching txs one by one and decoding locally
+          let failed = 0;
+          let lastError;
           for (const txid of chunk) {
             try {
               let tx = await mainClient.blockchainTransaction_get(txid, false);
               tx = txhexToElectrumTransaction(tx);
               results.push({ result: tx, param: txid });
             } catch (error) {
-              console.log(error);
+              failed++;
+              lastError = error;
             }
+          }
+          if (failed) {
+            console.warn(`multiGetTransactionByTxid: ${failed} of ${chunk.length} single fetches failed (non-verbose fallback)`, lastError);
           }
         } else {
           // fallback. pretty sure we are connected to EPS.  we try getting transactions one-by-one. this way we wont
           // fail and only non-tracked by EPS transactions will be omitted
+          let failed = 0;
+          let lastError;
           for (const txid of chunk) {
             try {
               let tx = await mainClient.blockchainTransaction_get(txid, verbose);
@@ -654,8 +676,12 @@ module.exports.multiGetTransactionByTxid = async function (txids, batchsize, ver
               }
               results.push({ result: tx, param: txid });
             } catch (error) {
-              console.log(error);
+              failed++;
+              lastError = error;
             }
+          }
+          if (failed) {
+            console.warn(`multiGetTransactionByTxid: ${failed} of ${chunk.length} single fetches failed (EPS fallback)`, lastError);
           }
         }
       }
@@ -711,7 +737,6 @@ module.exports.multiGetTransactionByTxid = async function (txids, batchsize, ver
  */
 module.exports.waitTillConnected = async function () {
   if (await isDisabled()) {
-    console.warn('Electrum connections disabled by user. waitTillConnected skipping...');
     return;
   }
 

--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -91,6 +91,7 @@ const SAFE_ERROR_TOKENS = [
   'ECONNRESET',
   'EHOSTUNREACH',
   'ENETUNREACH',
+  'ETIMEDOUT',
   'EPIPE',
   'unable to resolve host',
   'no address associated',

--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -76,6 +76,22 @@ let rotatePeerTimeout = null;
 
 let networkConnected = true;
 
+// Substrings safe to report for a user-configured peer: they describe the failure
+// mode without carrying the host or IP the native error string embeds.
+const SAFE_ERROR_TOKENS = [
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ECONNRESET',
+  'EPIPE',
+  'certificate',
+  'handshake',
+  'timed out',
+  'refused',
+];
+
 async function isDisabled() {
   if (isDisabledCache !== undefined) return isDisabledCache;
 
@@ -150,8 +166,14 @@ async function _initConnection() {
   const peerLabel = isCustomPeer ? 'user-configured server' : usingPeer.host;
   // Native socket errors embed the host/IP ("failed to connect to <host>/<ip>",
   // "Unable to resolve host ..."), which would leak a user-configured server's
-  // address past the peerLabel masking above. Reduce those to a code.
-  const scrubPeer = e => (isCustomPeer ? String(e?.code ?? e?.name ?? 'connection error') : e);
+  // address past the peerLabel masking above. react-native-tcp-socket emits the
+  // error as a plain string, so match against an allowlist rather than reading
+  // .code - only allowlisted tokens can ever be emitted for a custom peer.
+  const scrubPeer = e => {
+    if (!isCustomPeer) return e;
+    const text = String(e?.code ?? e?.message ?? e ?? '');
+    return SAFE_ERROR_TOKENS.find(token => text.includes(token)) ?? 'connection error';
+  };
 
   try {
     await DefaultPreference.setName('group.swiss.dfx.bitcoin');

--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -79,30 +79,36 @@ let networkConnected = true;
 // Substrings safe to report for a user-configured peer: they describe the failure
 // mode without carrying the host or IP the native error string embeds. Matched
 // case-insensitively against the strings Android (SocketException/SSLHandshake)
-// and iOS (localizedDescription) actually produce, not Node errno names.
+// and iOS (localizedDescription) actually produce - including the errno names
+// those strings embed verbatim, e.g. "connect failed: ECONNREFUSED".
+//
+// ORDER MATTERS. The text being matched still contains the hostname, so a short
+// token can match from inside it: a DNS failure against "electrum-ssl.example.com"
+// would report 'ssl' if that token came first. Unambiguous multi-word tokens are
+// listed before short generic ones for that reason.
 const SAFE_ERROR_TOKENS = [
   'ECONNREFUSED',
   'ECONNRESET',
   'EHOSTUNREACH',
   'ENETUNREACH',
   'EPIPE',
+  'unable to resolve host',
+  'no address associated',
   'trust anchor',
-  'certif',
-  'ssl',
-  'tls',
+  'broken pipe',
+  'no route',
+  'failed to connect',
   'handshake',
   'timed out',
   'timeout',
-  'refused',
-  'unable to resolve host',
-  'no address associated',
   'unreachable',
-  'no route',
-  'reset',
-  'broken pipe',
-  // Ordered last: these are the least specific, so a more precise token wins first.
-  'failed to connect',
+  'refused',
   'osstatus',
+  // Short and liable to appear inside a hostname - last resort only.
+  'certif',
+  'reset',
+  'ssl',
+  'tls',
 ];
 
 async function isDisabled() {

--- a/blue_modules/BlueElectrum.js
+++ b/blue_modules/BlueElectrum.js
@@ -148,6 +148,10 @@ async function _initConnection() {
     isCustomPeer = true;
   }
   const peerLabel = isCustomPeer ? 'user-configured server' : usingPeer.host;
+  // Native socket errors embed the host/IP ("failed to connect to <host>/<ip>",
+  // "Unable to resolve host ..."), which would leak a user-configured server's
+  // address past the peerLabel masking above. Reduce those to a code.
+  const scrubPeer = e => (isCustomPeer ? String(e?.code ?? e?.name ?? 'connection error') : e);
 
   try {
     await DefaultPreference.setName('group.swiss.dfx.bitcoin');
@@ -163,7 +167,7 @@ async function _initConnection() {
     }
 
     WidgetCommunication.reloadAllTimelines();
-  } catch (e) {
+  } catch (_) {
     // Must be running on Android
   }
 
@@ -172,7 +176,7 @@ async function _initConnection() {
     mainClient = new ElectrumClient(net, tls, usingPeer.ssl || usingPeer.tcp, usingPeer.host, usingPeer.ssl ? 'tls' : 'tcp');
 
     mainClient.onError = function (e) {
-      console.warn(`[electrum] socket error on ${peerLabel}, reconnecting`, e);
+      console.warn(`_initConnection: socket error on ${peerLabel}, reconnecting`, scrubPeer(e));
       mainClient.close();
       connectMain();
     };
@@ -195,7 +199,7 @@ async function _initConnection() {
       throw new Error('Electrum connection timed out');
     }
 
-    console.log(`[electrum] connected to ${peerLabel} in ${Date.now() - connectStartedAt}ms - ${ver[0]}`);
+    console.log(`_initConnection: connected to ${peerLabel} in ${Date.now() - connectStartedAt}ms - ${ver[0]}`);
     serverName = ver[0];
 
     if (ver[0].startsWith('ElectrumPersonalServer') || ver[0].startsWith('electrs') || ver[0].startsWith('Fulcrum')) {
@@ -230,8 +234,8 @@ async function _initConnection() {
     // Duration separates "server is slow" (~10s, the initElectrum race timed out)
     // from "server refused / DNS failed" (fast). Attempt number shows cascade depth.
     console.warn(
-      `[electrum] connect to ${peerLabel} failed after ${Date.now() - connectStartedAt}ms (attempt ${connectionAttempt + 1})`,
-      e,
+      `_initConnection: connect to ${peerLabel} failed after ${Date.now() - connectStartedAt}ms (attempt ${connectionAttempt + 1})`,
+      scrubPeer(e),
     );
   }
 }

--- a/blue_modules/currency.js
+++ b/blue_modules/currency.js
@@ -85,7 +85,6 @@ async function updateExchangeRate() {
     // not updating too often
     return;
   }
-  console.log('updating exchange rate...');
 
   let rate;
   try {
@@ -160,7 +159,7 @@ function satoshiToLocalCurrency(satoshi, format = true) {
       maximumFractionDigits: 8,
     });
   } catch (error) {
-    console.warn('currency: Intl.NumberFormat unavailable for preferred fiat, formatting degraded', error);
+    console.warn('satoshiToLocalCurrency: Intl.NumberFormat unavailable for preferred fiat, formatting degraded', error);
     formatter = new Intl.NumberFormat(FiatUnit.USD.locale, {
       style: 'currency',
       currency: preferredFiatCurrency.endPointKey,

--- a/blue_modules/currency.js
+++ b/blue_modules/currency.js
@@ -161,8 +161,7 @@ function satoshiToLocalCurrency(satoshi, format = true) {
       maximumFractionDigits: 8,
     });
   } catch (error) {
-    console.warn(error);
-    console.log(error);
+    console.warn('currency: Intl.NumberFormat unavailable for preferred fiat, formatting degraded', error);
     formatter = new Intl.NumberFormat(FiatUnit.USD.locale, {
       style: 'currency',
       currency: preferredFiatCurrency.endPointKey,

--- a/blue_modules/currency.js
+++ b/blue_modules/currency.js
@@ -95,8 +95,7 @@ async function updateExchangeRate() {
     exchangeRates.LAST_UPDATED_ERROR = false;
     await AsyncStorage.setItem(EXCHANGE_RATES_STORAGE_KEY, JSON.stringify(exchangeRates));
   } catch (Err) {
-    console.log('Error encountered when attempting to update exchange rate...');
-    console.warn(Err.message);
+    console.warn('updateExchangeRate: fetch failed, falling back to stored rates', Err);
     rate = JSON.parse(await AsyncStorage.getItem(EXCHANGE_RATES_STORAGE_KEY));
     rate.LAST_UPDATED_ERROR = true;
     exchangeRates.LAST_UPDATED_ERROR = true;

--- a/blue_modules/fs.js
+++ b/blue_modules/fs.js
@@ -28,7 +28,6 @@ const writeFileAndExportToAndroidDestionation = async ({ filename, contents, des
       alert(e.message);
     }
   } else {
-    console.log('Storage Permission: Denied');
     Alert.alert(loc.send.permission_storage_title, loc.send.permission_storage_denied_message, [
       {
         text: loc.send.open_settings,

--- a/blue_modules/fs.js
+++ b/blue_modules/fs.js
@@ -24,7 +24,7 @@ const writeFileAndExportToAndroidDestionation = async ({ filename, contents, des
       await RNFS.writeFile(filePath, contents);
       alert(loc.formatString(loc._.file_saved, { filePath: filename, destination: destinationLocalizedString }));
     } catch (e) {
-      console.log(e);
+      console.error('fs: writeFile to Android destination failed', e);
       alert(e.message);
     }
   } else {
@@ -50,9 +50,7 @@ const writeFileAndExport = async function (filename, contents) {
       url: 'file://' + filePath,
       saveToFiles: isDesktop,
     })
-      .catch(error => {
-        console.log(error);
-      })
+      .catch(() => {})
       .finally(() => {
         RNFS.unlink(filePath);
       });

--- a/blue_modules/fs.js
+++ b/blue_modules/fs.js
@@ -24,7 +24,9 @@ const writeFileAndExportToAndroidDestionation = async ({ filename, contents, des
       await RNFS.writeFile(filePath, contents);
       alert(loc.formatString(loc._.file_saved, { filePath: filename, destination: destinationLocalizedString }));
     } catch (e) {
-      console.error('fs: writeFile to Android destination failed', e);
+      // The message contains the full path, and filename is a wallet label at
+      // some call sites - report the code only.
+      console.error('fs: writeFile to Android destination failed', e?.code ?? 'write failed');
       alert(e.message);
     }
   } else {

--- a/blue_modules/noble_ecc.ts
+++ b/blue_modules/noble_ecc.ts
@@ -41,7 +41,6 @@ type Hex = string | Uint8Array;
 type PrivKey = Hex | bigint | number;
 
 necc.utils.privateAdd = (privateKey: PrivKey, tweak: Hex) => {
-  console.log({ privateKey, tweak });
   const p = normal(privateKey);
   const t = normal(tweak);
   return necc.utils.privateAdd(necc.utils.mod(p + t, necc.CURVE.n));

--- a/blue_modules/notifications.ts
+++ b/blue_modules/notifications.ts
@@ -168,7 +168,7 @@ const checkAndroidNotificationPermission = async () => {
   try {
     const { status } = await checkNotifications();
     return status === RESULTS.GRANTED;
-  } catch (err) {
+  } catch (_) {
     return false;
   }
 };
@@ -177,7 +177,7 @@ export const checkNotificationPermissionStatus = async () => {
   try {
     const { status } = await checkNotifications();
     return status;
-  } catch (error) {
+  } catch (_) {
     return 'unavailable';
   }
 };
@@ -234,7 +234,7 @@ export const tryToObtainPermissions = async (): Promise<boolean> => {
       return false;
     }
     return configureNotifications();
-  } catch (error) {
+  } catch (_) {
     return false;
   }
 };
@@ -348,7 +348,7 @@ export const addNotification = async (notification: TPayload) => {
     const stringified = await AsyncStorage.getItem(NOTIFICATIONS_STORAGE);
     notifications = JSON.parse(String(stringified));
     if (!Array.isArray(notifications)) notifications = [];
-  } catch (e) {
+  } catch (_) {
     notifications = [];
   }
 
@@ -444,7 +444,7 @@ const configureNotifications = async (onProcessNotifications?: () => void): Prom
       .catch(() => {});
 
     return await waitForRemoteRegistration();
-  } catch (error) {
+  } catch (_) {
     return false;
   }
 };
@@ -652,7 +652,7 @@ export const initializeNotifications = async (onProcessNotifications?: () => voi
     if (canProceed) {
       await configureNotifications(onProcessNotifications);
     }
-  } catch (error) {
+  } catch (_) {
     baseURI = groundControlUri;
     await AsyncStorage.setItem(GROUNDCONTROL_BASE_URI, groundControlUri).catch(() => {});
   }

--- a/blue_modules/notifications.ts
+++ b/blue_modules/notifications.ts
@@ -144,7 +144,6 @@ const storeIncomingNotification = async (
     markNotificationHandled(notificationKey);
 
     if (!payload.subText && !payload.message) {
-      console.warn('Notification missing required fields:', payload);
       return;
     }
 
@@ -154,7 +153,6 @@ const storeIncomingNotification = async (
       await onProcessNotificationsHandler();
     }
   } catch (error) {
-    console.error('Failed to store incoming notification:', error);
   } finally {
     if (completion) {
       if (status.foreground) {
@@ -169,10 +167,8 @@ const storeIncomingNotification = async (
 const checkAndroidNotificationPermission = async () => {
   try {
     const { status } = await checkNotifications();
-    console.log('Notification permission check:', status);
     return status === RESULTS.GRANTED;
   } catch (err) {
-    console.error('Failed to check notification permission:', err);
     return false;
   }
 };
@@ -182,7 +178,6 @@ export const checkNotificationPermissionStatus = async () => {
     const { status } = await checkNotifications();
     return status;
   } catch (error) {
-    console.error('Failed to check notification permissions:', error);
     return 'unavailable';
   }
 };
@@ -202,9 +197,7 @@ const handleAppStateChange = async (nextAppState: AppStateStatus) => {
         }
       }
     }
-  } catch (error) {
-    console.error('Failed handling app state notification refresh:', error);
-  }
+  } catch (error) {}
 };
 
 AppState.addEventListener('change', handleAppStateChange);
@@ -221,10 +214,7 @@ export const cleanUserOptOutFlag = async () => {
  * @returns {Promise<boolean>} TRUE if permissions were obtained, FALSE otherwise
  */
 export const tryToObtainPermissions = async (): Promise<boolean> => {
-  console.log('tryToObtainPermissions: Starting user-triggered permission request');
-
   if (!isNotificationsCapable) {
-    console.log('tryToObtainPermissions: Device not capable');
     return false;
   }
 
@@ -241,12 +231,10 @@ export const tryToObtainPermissions = async (): Promise<boolean> => {
       Platform.OS === 'android' && Platform.Version < 33 ? rationale : undefined,
     );
     if (status !== RESULTS.GRANTED) {
-      console.log('tryToObtainPermissions: Permission denied');
       return false;
     }
     return configureNotifications();
   } catch (error) {
-    console.error('Error requesting notification permissions:', error);
     return false;
   }
 };
@@ -256,68 +244,43 @@ export const tryToObtainPermissions = async (): Promise<boolean> => {
  * be notified if they were paid
  */
 export const majorTomToGroundControl = async (addresses: string[], hashes: string[], txids: string[]) => {
-  console.log('majorTomToGroundControl: Starting notification registration', {
-    addressCount: addresses?.length,
-    hashCount: hashes?.length,
-    txidCount: txids?.length,
+  const noAndDontAskFlag = await AsyncStorage.getItem(NOTIFICATIONS_NO_AND_DONT_ASK_FLAG);
+  if (noAndDontAskFlag === 'true') {
+    return;
+  }
+
+  if (!Array.isArray(addresses) || !Array.isArray(hashes) || !Array.isArray(txids)) {
+    throw new Error('No addresses, hashes, or txids provided');
+  }
+
+  const pushToken = await getPushToken();
+  if (!pushToken || !pushToken.token || !pushToken.os) {
+    return;
+  }
+
+  const requestBody = JSON.stringify({
+    addresses,
+    hashes,
+    txids,
+    token: pushToken.token,
+    os: pushToken.os,
   });
 
-  try {
-    const noAndDontAskFlag = await AsyncStorage.getItem(NOTIFICATIONS_NO_AND_DONT_ASK_FLAG);
-    if (noAndDontAskFlag === 'true') {
-      console.warn('User has opted out of notifications.');
-      return;
-    }
+  const response = await fetch(`${baseURI}/majorTomToGroundControl`, {
+    method: 'POST',
+    headers: _getHeaders(),
+    body: requestBody,
+  });
 
-    if (!Array.isArray(addresses) || !Array.isArray(hashes) || !Array.isArray(txids)) {
-      throw new Error('No addresses, hashes, or txids provided');
-    }
+  if (!response.ok) {
+    throw new Error(`Ground Control request failed with status ${response.status}: ${response.statusText}`);
+  }
 
-    const pushToken = await getPushToken();
-    console.log('majorTomToGroundControl: Retrieved push token:', !!pushToken);
-    if (!pushToken || !pushToken.token || !pushToken.os) {
-      return;
-    }
-
-    const requestBody = JSON.stringify({
-      addresses,
-      hashes,
-      txids,
-      token: pushToken.token,
-      os: pushToken.os,
-    });
-
-    let response;
-    try {
-      console.log('majorTomToGroundControl: Sending request to:', `${baseURI}/majorTomToGroundControl`);
-      response = await fetch(`${baseURI}/majorTomToGroundControl`, {
-        method: 'POST',
-        headers: _getHeaders(),
-        body: requestBody,
-      });
-    } catch (networkError) {
-      console.error('Network request failed:', networkError);
-      throw networkError;
-    }
-
-    if (!response.ok) {
-      throw new Error(`Ground Control request failed with status ${response.status}: ${response.statusText}`);
-    }
-
-    const responseText = await response.text();
-    if (responseText) {
-      try {
-        return JSON.parse(responseText);
-      } catch (jsonError) {
-        console.error('Error parsing response JSON:', jsonError);
-        throw jsonError;
-      }
-    } else {
-      return {};
-    }
-  } catch (error) {
-    console.error('Error in majorTomToGroundControl:', error);
-    throw error;
+  const responseText = await response.text();
+  if (responseText) {
+    return JSON.parse(responseText);
+  } else {
+    return {};
   }
 };
 
@@ -328,23 +291,18 @@ export const majorTomToGroundControl = async (addresses: string[], hashes: strin
  * sound: boolean
  */
 export const checkPermissions = async () => {
-  try {
-    if (Platform.OS === 'ios') {
-      return Notifications.ios.checkPermissions();
-    }
-
-    const { status } = await checkNotifications();
-    const granted = status === RESULTS.GRANTED;
-    return {
-      alert: granted,
-      badge: granted,
-      sound: granted,
-      status,
-    };
-  } catch (error) {
-    console.error('Error checking permissions:', error);
-    throw error;
+  if (Platform.OS === 'ios') {
+    return Notifications.ios.checkPermissions();
   }
+
+  const { status } = await checkNotifications();
+  const granted = status === RESULTS.GRANTED;
+  return {
+    alert: granted,
+    badge: granted,
+    sound: granted,
+    status,
+  };
 };
 
 /**
@@ -372,20 +330,16 @@ export const setLevels = async (levelAll: boolean) => {
     }
 
     if (!levelAll) {
-      console.log('Disabling notifications as user opted out...');
       Notifications.removeAllDeliveredNotifications();
       if (Platform.OS === 'ios') {
         Notifications.ios.setBadgeCount(0);
         Notifications.ios.cancelAllLocalNotifications();
       }
       await AsyncStorage.setItem(NOTIFICATIONS_NO_AND_DONT_ASK_FLAG, 'true');
-      console.log('Notifications disabled successfully');
     } else {
       await AsyncStorage.removeItem(NOTIFICATIONS_NO_AND_DONT_ASK_FLAG);
     }
-  } catch (error) {
-    console.error('Error setting notification levels:', error);
-  }
+  } catch (error) {}
 };
 
 export const addNotification = async (notification: TPayload) => {
@@ -395,7 +349,6 @@ export const addNotification = async (notification: TPayload) => {
     notifications = JSON.parse(String(stringified));
     if (!Array.isArray(notifications)) notifications = [];
   } catch (e) {
-    console.error(e);
     notifications = [];
   }
 
@@ -404,19 +357,15 @@ export const addNotification = async (notification: TPayload) => {
 };
 
 const postTokenConfig = async () => {
-  console.log('postTokenConfig: Starting token configuration');
   const pushToken = await getPushToken();
-  console.log('postTokenConfig: Retrieved push token:', !!pushToken);
 
   if (!pushToken || !pushToken.token || !pushToken.os) {
-    console.log('postTokenConfig: Invalid token or missing OS info');
     return;
   }
 
   try {
     const lang = (await AsyncStorage.getItem('lang')) || 'en';
     const appVersion = getSystemName() + ' ' + getSystemVersion() + ';' + getApplicationName() + ' ' + getVersion();
-    console.log('postTokenConfig: Posting configuration', { lang, appVersion });
 
     await fetch(`${baseURI}/setTokenConfiguration`, {
       method: 'POST',
@@ -429,19 +378,13 @@ const postTokenConfig = async () => {
       }),
     });
   } catch (e) {
-    console.error(e);
     await AsyncStorage.setItem('lang', 'en');
     throw e;
   }
 };
 
 const _setPushToken = async (token: TPushToken) => {
-  try {
-    return await AsyncStorage.setItem(PUSH_TOKEN, JSON.stringify(token));
-  } catch (error) {
-    console.error('Error setting push token:', error);
-    throw error;
-  }
+  return await AsyncStorage.setItem(PUSH_TOKEN, JSON.stringify(token));
 };
 
 /**
@@ -450,7 +393,6 @@ const _setPushToken = async (token: TPushToken) => {
  * @returns {Promise<boolean>} whether successfully registered for remote push notifications
  */
 const configureNotifications = async (onProcessNotifications?: () => void): Promise<boolean> => {
-  console.log('configureNotifications()');
   if (onProcessNotifications) {
     onProcessNotificationsHandler = onProcessNotifications;
   }
@@ -458,7 +400,6 @@ const configureNotifications = async (onProcessNotifications?: () => void): Prom
   try {
     const { status } = await checkNotifications();
     if (status !== RESULTS.GRANTED) {
-      console.log('configureNotifications: Permissions not granted');
       return false;
     }
 
@@ -467,21 +408,17 @@ const configureNotifications = async (onProcessNotifications?: () => void): Prom
     if (notificationSubscriptions.length === 0) {
       notificationSubscriptions = [
         Notifications.events().registerRemoteNotificationsRegistered(async event => {
-          console.log('processing event', event);
           const token = createPushToken(event.deviceToken);
           if (__DEV__) {
-            console.log('configureNotifications: Token received:', token);
           }
           await _setPushToken(token);
-          await postTokenConfig().catch(error => console.error('Failed to post token configuration:', error));
+          await postTokenConfig().catch(() => {});
           settlePendingRegistration(true);
         }),
-        Notifications.events().registerRemoteNotificationsRegistrationFailed(error => {
-          console.error('Registration error:', error);
+        Notifications.events().registerRemoteNotificationsRegistrationFailed(() => {
           settlePendingRegistration(false);
         }),
         Notifications.events().registerRemoteNotificationsRegistrationDenied(() => {
-          console.log('Remote notification registration denied');
           settlePendingRegistration(false);
         }),
         Notifications.events().registerNotificationReceivedForeground(async (notification, completion) => {
@@ -503,15 +440,13 @@ const configureNotifications = async (onProcessNotifications?: () => void): Prom
     Notifications.getInitialNotification()
       .then(async initialNotification => {
         if (initialNotification) {
-          console.log('App was launched by a push notification:', initialNotification);
           await storeIncomingNotification(initialNotification, { foreground: false, userInteraction: true });
         }
       })
-      .catch(error => console.error('Failed to retrieve initial notification:', error));
+      .catch(() => {});
 
     return await waitForRemoteRegistration();
   } catch (error) {
-    console.error('Error in configureNotifications:', error);
     return false;
   }
 };
@@ -536,7 +471,6 @@ export const getPushToken = async (): Promise<TPushToken> => {
     const token = await AsyncStorage.getItem(PUSH_TOKEN);
     return JSON.parse(String(token)) as TPushToken;
   } catch (e) {
-    console.error(e);
     AsyncStorage.removeItem(PUSH_TOKEN);
     throw e;
   }
@@ -576,7 +510,6 @@ export const unsubscribe = async (addresses: string[], hashes: string[], txids: 
 
   const token = await getPushToken();
   if (!token?.token || !token?.os) {
-    console.error('No push token or OS found');
     return;
   }
 
@@ -588,23 +521,17 @@ export const unsubscribe = async (addresses: string[], hashes: string[], txids: 
     os: token.os,
   });
 
-  try {
-    const response = await fetch(`${baseURI}/unsubscribe`, {
-      method: 'POST',
-      headers: _getHeaders(),
-      body,
-    });
+  const response = await fetch(`${baseURI}/unsubscribe`, {
+    method: 'POST',
+    headers: _getHeaders(),
+    body,
+  });
 
-    if (!response.ok) {
-      console.error('Failed to unsubscribe:', response.statusText);
-      return;
-    }
-
-    return response;
-  } catch (error) {
-    console.error('Error during unsubscribe:', error);
-    throw error;
+  if (!response.ok) {
+    return;
   }
+
+  return response;
 };
 
 const _getHeaders = () => {
@@ -621,20 +548,15 @@ export const clearStoredNotifications = async () => {
 };
 
 export const getDeliveredNotifications: () => Promise<Record<string, any>[]> = () => {
-  try {
-    if (Platform.OS !== 'ios') {
-      return Promise.resolve([]);
-    }
-
-    return Notifications.ios
-      .getDeliveredNotifications()
-      .then(notifications =>
-        notifications.map(notification => normalizeNotificationPayload(notification, { foreground: true, userInteraction: false })),
-      );
-  } catch (error) {
-    console.error('Error getting delivered notifications:', error);
-    throw error;
+  if (Platform.OS !== 'ios') {
+    return Promise.resolve([]);
   }
+
+  return Notifications.ios
+    .getDeliveredNotifications()
+    .then(notifications =>
+      notifications.map(notification => normalizeNotificationPayload(notification, { foreground: true, userInteraction: false })),
+    );
 };
 
 export const removeDeliveredNotifications = (identifiers: string[] = []) => {
@@ -658,13 +580,8 @@ export const getDefaultUri = () => {
 };
 
 export const saveUri = async (uri: string) => {
-  try {
-    baseURI = uri || groundControlUri;
-    await AsyncStorage.setItem(GROUNDCONTROL_BASE_URI, baseURI);
-  } catch (error) {
-    console.error('Error saving URI:', error);
-    throw error;
-  }
+  baseURI = uri || groundControlUri;
+  await AsyncStorage.setItem(GROUNDCONTROL_BASE_URI, baseURI);
 };
 
 export const getSavedUri = async () => {
@@ -675,12 +592,9 @@ export const getSavedUri = async () => {
     }
     return baseUriStored;
   } catch (e) {
-    console.error(e);
     try {
       await AsyncStorage.setItem(GROUNDCONTROL_BASE_URI, groundControlUri);
-    } catch (storageError) {
-      console.error('Failed to reset URI:', storageError);
-    }
+    } catch (storageError) {}
     throw e;
   }
 };
@@ -693,7 +607,6 @@ export const isNotificationsEnabled = async () => {
 
     return !isDisabledByUser && !!token && !!levels.level_all;
   } catch (error) {
-    console.log('Error checking notification levels:', error);
     if (error instanceof SyntaxError) {
       throw error;
     }
@@ -708,11 +621,9 @@ export const getStoredNotifications = async (): Promise<TPayload[]> => {
     if (!Array.isArray(notifications)) notifications = [];
   } catch (e) {
     if (e instanceof SyntaxError) {
-      console.error('Invalid notifications format:', e);
       notifications = [];
       await AsyncStorage.setItem(NOTIFICATIONS_STORAGE, '[]');
     } else {
-      console.error('Error accessing notifications:', e);
       throw e;
     }
   }
@@ -721,25 +632,19 @@ export const getStoredNotifications = async (): Promise<TPayload[]> => {
 };
 
 export const initializeNotifications = async (onProcessNotifications?: () => void) => {
-  console.log('initializeNotifications: Starting initialization');
-
   try {
     const noAndDontAskFlag = await AsyncStorage.getItem(NOTIFICATIONS_NO_AND_DONT_ASK_FLAG);
-    console.log('initializeNotifications: No ask flag status:', noAndDontAskFlag);
 
     if (noAndDontAskFlag === 'true') {
-      console.warn('User has opted out of notifications.');
       return;
     }
 
     const baseUriStored = await AsyncStorage.getItem(GROUNDCONTROL_BASE_URI);
     baseURI = baseUriStored || groundControlUri;
-    console.log('Base URI set to:', baseURI);
 
     setApplicationIconBadgeNumber(0);
 
     currentPermissionStatus = await checkNotificationPermissionStatus();
-    console.log('initializeNotifications: Permission status:', currentPermissionStatus);
 
     const canProceed =
       Platform.OS === 'android'
@@ -747,14 +652,11 @@ export const initializeNotifications = async (onProcessNotifications?: () => voi
         : currentPermissionStatus === 'granted';
 
     if (canProceed) {
-      console.log('initializeNotifications: Can proceed with notification setup');
       await configureNotifications(onProcessNotifications);
     } else {
-      console.log('Notifications require user action to enable');
     }
   } catch (error) {
-    console.error('Failed to initialize notifications:', error);
     baseURI = groundControlUri;
-    await AsyncStorage.setItem(GROUNDCONTROL_BASE_URI, groundControlUri).catch(err => console.error('Failed to reset URI:', err));
+    await AsyncStorage.setItem(GROUNDCONTROL_BASE_URI, groundControlUri).catch(() => {});
   }
 };

--- a/blue_modules/notifications.ts
+++ b/blue_modules/notifications.ts
@@ -197,7 +197,7 @@ const handleAppStateChange = async (nextAppState: AppStateStatus) => {
         }
       }
     }
-  } catch (error) {}
+  } catch (_) {}
 };
 
 AppState.addEventListener('change', handleAppStateChange);
@@ -339,7 +339,7 @@ export const setLevels = async (levelAll: boolean) => {
     } else {
       await AsyncStorage.removeItem(NOTIFICATIONS_NO_AND_DONT_ASK_FLAG);
     }
-  } catch (error) {}
+  } catch (_) {}
 };
 
 export const addNotification = async (notification: TPayload) => {
@@ -384,7 +384,7 @@ const postTokenConfig = async () => {
 };
 
 const _setPushToken = async (token: TPushToken) => {
-  return await AsyncStorage.setItem(PUSH_TOKEN, JSON.stringify(token));
+  return AsyncStorage.setItem(PUSH_TOKEN, JSON.stringify(token));
 };
 
 /**
@@ -409,8 +409,6 @@ const configureNotifications = async (onProcessNotifications?: () => void): Prom
       notificationSubscriptions = [
         Notifications.events().registerRemoteNotificationsRegistered(async event => {
           const token = createPushToken(event.deviceToken);
-          if (__DEV__) {
-          }
           await _setPushToken(token);
           await postTokenConfig().catch(() => {});
           settlePendingRegistration(true);
@@ -653,7 +651,6 @@ export const initializeNotifications = async (onProcessNotifications?: () => voi
 
     if (canProceed) {
       await configureNotifications(onProcessNotifications);
-    } else {
     }
   } catch (error) {
     baseURI = groundControlUri;

--- a/blue_modules/notifications.ts
+++ b/blue_modules/notifications.ts
@@ -152,7 +152,7 @@ const storeIncomingNotification = async (
     if (payload.foreground && onProcessNotificationsHandler) {
       await onProcessNotificationsHandler();
     }
-  } catch (error) {
+  } catch (_) {
   } finally {
     if (completion) {
       if (status.foreground) {
@@ -592,7 +592,7 @@ export const getSavedUri = async () => {
   } catch (e) {
     try {
       await AsyncStorage.setItem(GROUNDCONTROL_BASE_URI, groundControlUri);
-    } catch (storageError) {}
+    } catch (_) {}
     throw e;
   }
 };

--- a/blue_modules/storage-context.js
+++ b/blue_modules/storage-context.js
@@ -179,7 +179,7 @@ export const BlueStorageProvider = ({ children }) => {
       setLastSuccessfulBalanceRefresh(Date.now());
     } catch (err) {
       noErr = false;
-      console.warn('refreshAllWalletTransactions failed, retrying on next interval', err);
+      console.warn('refreshAllWalletTransactions: failed, retrying on next interval', err);
     } finally {
       setWalletTransactionUpdateStatus(WalletTransactionsStatus.NONE);
     }
@@ -203,7 +203,7 @@ export const BlueStorageProvider = ({ children }) => {
       await fetchWalletTransactions(index);
     } catch (err) {
       noErr = false;
-      console.warn('fetchAndSaveWalletTransactions failed for wallet index ' + index + ', retrying on next refresh', err);
+      console.warn(`fetchAndSaveWalletTransactions: wallet index ${index} failed, retrying on next refresh`, err);
     } finally {
       setWalletTransactionUpdateStatus(WalletTransactionsStatus.NONE);
     }
@@ -238,9 +238,12 @@ export const BlueStorageProvider = ({ children }) => {
         return;
       }
 
+      // isConnected is `boolean | null`; only a definite false means offline. Coercing
+      // unknown to offline would gate connectMain() off for every caller.
       const netInfo = await fetchNetInfo();
-      BlueElectrum.setNetworkConnected(netInfo.isConnected);
-      if (!netInfo.isConnected) return;
+      const isOffline = netInfo.isConnected === false;
+      BlueElectrum.setNetworkConnected(!isOffline);
+      if (isOffline) return;
 
       setBalanceRefreshInterval();
     } catch (err) {

--- a/blue_modules/storage-context.js
+++ b/blue_modules/storage-context.js
@@ -156,7 +156,6 @@ export const BlueStorageProvider = ({ children }) => {
 
   const refreshAllWalletTransactions = async () => {
     if (!BlueApp.wallets.length) return;
-    console.log('refreshAllWalletTransactions');
 
     let noErr = true;
     try {
@@ -180,7 +179,7 @@ export const BlueStorageProvider = ({ children }) => {
       setLastSuccessfulBalanceRefresh(Date.now());
     } catch (err) {
       noErr = false;
-      console.warn(err);
+      console.warn('refreshAllWalletTransactions failed, retrying on next interval', err);
     } finally {
       setWalletTransactionUpdateStatus(WalletTransactionsStatus.NONE);
     }
@@ -204,7 +203,7 @@ export const BlueStorageProvider = ({ children }) => {
       await fetchWalletTransactions(index);
     } catch (err) {
       noErr = false;
-      console.warn(err);
+      console.warn('fetchAndSaveWalletTransactions failed for wallet index ' + index + ', retrying on next refresh', err);
     } finally {
       setWalletTransactionUpdateStatus(WalletTransactionsStatus.NONE);
     }
@@ -221,9 +220,9 @@ export const BlueStorageProvider = ({ children }) => {
   const setBalanceRefreshInterval = () => {
     if (!wallets) return;
     clearBalanceRefreshInterval();
-    refreshAllWalletTransactions().catch(console.error);
+    refreshAllWalletTransactions().catch(err => console.error('setBalanceRefreshInterval: initial refresh rejected', err));
     balanceRefreshInterval.current = setInterval(() => {
-      refreshAllWalletTransactions().catch(console.error);
+      refreshAllWalletTransactions().catch(err => console.error('setBalanceRefreshInterval: scheduled refresh rejected', err));
     }, 20 * 1000);
   };
 

--- a/blue_modules/storage-context.js
+++ b/blue_modules/storage-context.js
@@ -69,7 +69,6 @@ export const BlueStorageProvider = ({ children }) => {
   const saveToDisk = useCallback(
     async (force = false) => {
       if (BlueApp.getWallets().length === 0 && !force) {
-        console.log('not saving empty wallets array');
         return;
       }
       BlueApp.tx_metadata = txMetadata;
@@ -193,7 +192,6 @@ export const BlueStorageProvider = ({ children }) => {
       // 5sec debounce:
       setWalletTransactionUpdateStatus(walletID);
       if (+new Date() - _lastTimeTriedToRefetchWallet[walletID] < 5000) {
-        console.log('re-fetch wallet happens too fast; NOP');
         return;
       }
       _lastTimeTriedToRefetchWallet[walletID] = +new Date();
@@ -247,7 +245,7 @@ export const BlueStorageProvider = ({ children }) => {
 
       setBalanceRefreshInterval();
     } catch (err) {
-      console.error('Error revalidating balances', err);
+      console.error('revalidateBalancesInterval: failed', err);
     }
   };
 

--- a/class/Ntag424.js
+++ b/class/Ntag424.js
@@ -164,7 +164,6 @@ Ntag424.AuthEv2First = async function (keyNo, pKey) {
 
     const bytes = hexToBytes('9071000005' + keyNo + '0300000000');
     const Result = await Ntag424.sendAPDUCommand(bytes);
-    console.log('Result: ', bytesToHex([Result.sw1, Result.sw2]));
     const resultData = bytesToHex(Result.response);
     // 91AF is the successful code
     const resultCode = bytesToHex([Result.sw1, Result.sw2]);
@@ -190,7 +189,6 @@ Ntag424.AuthEv2First = async function (keyNo, pKey) {
 
       const secondAuthBytes = hexToBytes('90AF000020' + RndARndBEnc + '00');
       const secondAuthRes = await Ntag424.sendAPDUCommand(secondAuthBytes);
-      console.log('Result: ', bytesToHex([secondAuthRes.sw1, secondAuthRes.sw2]));
       // 9100 is the successful code
       const secondAuthResultCode = bytesToHex([secondAuthRes.sw1, secondAuthRes.sw2]);
       if (secondAuthResultCode == '9100') {
@@ -260,7 +258,6 @@ Ntag424.AuthEv2First = async function (keyNo, pKey) {
 Ntag424.AuthEv2NonFirst = async (keyNo, pKey) => {
   const bytes = hexToBytes('9077000001' + keyNo + '00');
   const Result = await Ntag424.sendAPDUCommand(bytes);
-  console.log('auth ev2 non first part 1 Result: ', bytesToHex([Result.sw1, Result.sw2]));
   const resultData = bytesToHex(Result.response);
   // 91AF is the successful code
   const resultCode = bytesToHex([Result.sw1, Result.sw2]);
@@ -286,7 +283,6 @@ Ntag424.AuthEv2NonFirst = async (keyNo, pKey) => {
 
     const secondAuthBytes = hexToBytes('90AF000020' + RndARndBEnc + '00');
     const secondAuthRes = await Ntag424.sendAPDUCommand(secondAuthBytes);
-    console.log('auth ev2 non first part 2 Result: ', bytesToHex([secondAuthRes.sw1, secondAuthRes.sw2]));
     // 9100 is the successful code
     const secondAuthResultCode = bytesToHex([secondAuthRes.sw1, secondAuthRes.sw2]);
     if (secondAuthResultCode == '9100') {
@@ -440,7 +436,6 @@ Ntag424.changeFileSettings = async cmdData => {
 
   const changeFileSettingsRes = await Ntag424.sendAPDUCommand(hexToBytes(changeFileSettingsHex));
   const resCode = bytesToHex([changeFileSettingsRes.sw1, changeFileSettingsRes.sw2]);
-  console.log('changeFileSettingsRes Result: ', resCode);
   if (resCode == '9100') {
     return Promise.resolve('Successful');
   } else {
@@ -502,7 +497,6 @@ Ntag424.changeKey = async (keyNo, key, newKey, keyVersion) => {
   const changeKeyRes = await Ntag424.sendAPDUCommand(hexToBytes(changeKeyHex));
 
   const resCode = bytesToHex([changeKeyRes.sw1, changeKeyRes.sw2]);
-  console.log('changeKeyRes Result: ', resCode);
   if (resCode == '9100') {
     return Promise.resolve('Successful');
   } else {
@@ -632,7 +626,6 @@ Ntag424.readData = async offset => {
   const readDataRes = await Ntag424.sendAPDUCommand(hexToBytes(readDataHex));
   const resData = readDataRes.response;
   const resCode = bytesToHex([readDataRes.sw1, readDataRes.sw2]);
-  console.log('readData Res: ', resCode, resData);
   if (resCode == '9100') {
     return Promise.resolve(resData);
   } else {
@@ -658,7 +651,6 @@ Ntag424.isoReadBinary = async offset => {
 
   const isoSelectFileBytes = hexToBytes('00A4000002E10400');
   const isoSelectRes = await Ntag424.sendAPDUCommand(isoSelectFileBytes);
-  console.log('isoSelectRes: ', bytesToHex([isoSelectRes.sw1, isoSelectRes.sw2]));
   const resultHex = bytesToHex([isoSelectRes.sw1, isoSelectRes.sw2]);
   if (resultHex == '9000') {
   } else {
@@ -675,7 +667,6 @@ Ntag424.isoReadBinary = async offset => {
   const res = await Ntag424.sendAPDUCommand(hexToBytes(cmdHex));
   const resData = res.response;
   const resCode = bytesToHex([res.sw1, res.sw2]);
-  console.log('isoReadBinary Res: ', resCode, resData);
   if (resCode == '9000') {
     return Promise.resolve(resData);
   } else {
@@ -818,7 +809,6 @@ Ntag424.setConfiguration = async (option, configData) => {
 
   const res = await Ntag424.sendAPDUCommand(hexToBytes(apduHex));
   const resCode = bytesToHex([res.sw1, res.sw2]);
-  console.log('setConfiguration Result: ', resCode);
   if (resCode == '9100') {
     return Promise.resolve('Successful');
   } else {

--- a/class/biometrics.js
+++ b/class/biometrics.js
@@ -35,8 +35,7 @@ function Biometric() {
       const { available } = await rnBiometrics.isSensorAvailable();
       return available;
     } catch (e) {
-      console.log('Biometrics isDeviceBiometricCapable failed');
-      console.log(e);
+      console.error('Biometrics: isDeviceBiometricCapable failed', e);
       Biometric.setBiometricUseEnabled(false);
       return false;
     }
@@ -48,8 +47,7 @@ function Biometric() {
       if (!available) return false;
       return mapBiometryType(biometryType);
     } catch (e) {
-      console.log('Biometrics biometricType failed');
-      console.log(e);
+      console.error('Biometrics: biometricType failed', e);
     }
     return false;
   };
@@ -80,8 +78,7 @@ function Biometric() {
       const { success } = await rnBiometrics.simplePrompt({ promptMessage: loc.settings.biom_conf_identity });
       return !!success;
     } catch (error) {
-      console.log('Biometrics authentication failed');
-      console.log(error);
+      console.error('Biometrics: authentication failed', error);
       return false;
     }
   };

--- a/class/deeplink-schema-match.js
+++ b/class/deeplink-schema-match.js
@@ -438,7 +438,7 @@ class DeeplinkSchemaMatch {
             }
           }
         } catch (e) {
-          console.log(e);
+          console.error('DeeplinkSchemaMatch: failed to extract lightning invoice from BIP-21 URI', e);
         }
         if (btc && lndInvoice) break;
       }

--- a/class/synced-async-storage.ts
+++ b/class/synced-async-storage.ts
@@ -83,7 +83,6 @@ export default class SyncedAsyncStorage {
       })
         .then(async response => {
           const text = await response.text();
-          console.log('saved, seq num:', text);
           resolve(text);
         })
         .catch(reason => reject(reason));
@@ -144,8 +143,6 @@ export default class SyncedAsyncStorage {
     const remoteSeqNum = (await response.text()) || '0';
     const localSeqNum = await this.getLocalSeqNum();
     if (+remoteSeqNum > +localSeqNum) {
-      console.log('remote storage is ahead, need to sync;', +remoteSeqNum, '>', +localSeqNum);
-
       // sort to ensure channel_manager comes first
       for (const key of (await this.getAllKeysRemote()).sort()) {
         const value = await this.getItemRemote(key);
@@ -153,8 +150,6 @@ export default class SyncedAsyncStorage {
       }
 
       await AsyncStorage.setItem(this.namespace + '_' + 'seqnum', remoteSeqNum);
-    } else {
-      console.log('storage is up-to-date, no need for sync');
     }
   }
 }

--- a/class/synced-async-storage.ts
+++ b/class/synced-async-storage.ts
@@ -150,7 +150,6 @@ export default class SyncedAsyncStorage {
       for (const key of (await this.getAllKeysRemote()).sort()) {
         const value = await this.getItemRemote(key);
         await AsyncStorage.setItem(this.namespace + '_' + key, value);
-        console.log('synced', key, 'to', value);
       }
 
       await AsyncStorage.setItem(this.namespace + '_' + 'seqnum', remoteSeqNum);

--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -714,7 +714,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
       // finally fetching balance
       await this._fetchBalance();
     } catch (err) {
-      console.warn(err);
+      console.warn('AbstractHDElectrumWallet.fetchBalance failed during rescan, keeping stale balance', err);
     }
   }
 

--- a/class/wallets/abstract-hd-electrum-wallet.ts
+++ b/class/wallets/abstract-hd-electrum-wallet.ts
@@ -714,7 +714,7 @@ export class AbstractHDElectrumWallet extends AbstractHDWallet {
       // finally fetching balance
       await this._fetchBalance();
     } catch (err) {
-      console.warn('AbstractHDElectrumWallet.fetchBalance failed during rescan, keeping stale balance', err);
+      console.warn('AbstractHDElectrumWallet.fetchBalance: failed during rescan, keeping stale balance', err);
     }
   }
 

--- a/class/wallets/abstract-hd-wallet.ts
+++ b/class/wallets/abstract-hd-wallet.ts
@@ -153,7 +153,7 @@ export class AbstractHDWallet extends LegacyWallet {
       try {
         txs = await BlueElectrum.getTransactionsByAddress(address);
       } catch (Err: any) {
-        console.warn('BlueElectrum.getTransactionsByAddress()', Err.message);
+        console.warn('getAddressAsync: address lookup failed, returning unverified external address', Err);
       }
       if (txs.length === 0) {
         // found free address
@@ -191,7 +191,7 @@ export class AbstractHDWallet extends LegacyWallet {
       try {
         txs = await BlueElectrum.getTransactionsByAddress(address);
       } catch (Err: any) {
-        console.warn('BlueElectrum.getTransactionsByAddress()', Err.message);
+        console.warn('getChangeAddressAsync: address lookup failed, returning unverified change address', Err);
       }
       if (txs.length === 0) {
         // found free address

--- a/class/wallets/hd-legacy-breadwallet-wallet.js
+++ b/class/wallets/hd-legacy-breadwallet-wallet.js
@@ -92,7 +92,7 @@ export class HDLegacyBreadwalletWallet extends HDLegacyP2PKHWallet {
       // finally fetching balance
       await this._fetchBalance();
     } catch (err) {
-      console.warn('HDLegacyBreadwalletWallet.fetchBalance failed during rescan, keeping stale balance', err);
+      console.warn('HDLegacyBreadwalletWallet.fetchBalance: failed during rescan, keeping stale balance', err);
     }
   }
 

--- a/class/wallets/hd-legacy-breadwallet-wallet.js
+++ b/class/wallets/hd-legacy-breadwallet-wallet.js
@@ -92,7 +92,7 @@ export class HDLegacyBreadwalletWallet extends HDLegacyP2PKHWallet {
       // finally fetching balance
       await this._fetchBalance();
     } catch (err) {
-      console.warn(err);
+      console.warn('HDLegacyBreadwalletWallet.fetchBalance failed during rescan, keeping stale balance', err);
     }
   }
 

--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -117,7 +117,7 @@ export class LegacyWallet extends AbstractWallet {
       this.unconfirmed_balance = Number(balance.unconfirmed);
       this._lastBalanceFetch = +new Date();
     } catch (error) {
-      console.warn('LegacyWallet.fetchBalance failed, keeping stale balance', error);
+      console.warn('LegacyWallet.fetchBalance: failed, keeping stale balance', error);
     }
   }
 

--- a/class/wallets/legacy-wallet.ts
+++ b/class/wallets/legacy-wallet.ts
@@ -117,7 +117,7 @@ export class LegacyWallet extends AbstractWallet {
       this.unconfirmed_balance = Number(balance.unconfirmed);
       this._lastBalanceFetch = +new Date();
     } catch (error) {
-      console.warn(error);
+      console.warn('LegacyWallet.fetchBalance failed, keeping stale balance', error);
     }
   }
 
@@ -152,7 +152,7 @@ export class LegacyWallet extends AbstractWallet {
 
       this.utxo = newUtxos;
     } catch (error) {
-      console.warn(error);
+      console.warn('LegacyWallet.fetchUtxo: txhex hydration failed, utxo set may be partial', error);
     }
   }
 
@@ -368,7 +368,6 @@ export class LegacyWallet extends AbstractWallet {
    */
   async broadcastTx(txhex: string): Promise<boolean> {
     const broadcast = await BlueElectrum.broadcastV2(txhex);
-    console.log({ broadcast });
     if (broadcast.indexOf('successfully') !== -1) return true;
     return broadcast.length === 64; // this means return string is txid (precise length), so it was broadcasted ok
   }

--- a/components/AmountInput.js
+++ b/components/AmountInput.js
@@ -90,7 +90,6 @@ class AmountInput extends Component {
    */
   onAmountUnitChange(previousUnit, newUnit) {
     const amount = this.props.amount || 0;
-    const log = `${amount}(${previousUnit}) ->`;
     let sats = 0;
     switch (previousUnit) {
       case BitcoinUnit.BTC:
@@ -109,7 +108,6 @@ class AmountInput extends Component {
     }
 
     const newInputValue = formatBalancePlain(sats, newUnit, false);
-    console.log(`${log} ${sats}(sats) -> ${newInputValue}(${newUnit})`);
 
     if (newUnit === BitcoinUnit.LOCAL_CURRENCY && previousUnit === BitcoinUnit.SATS) {
       // we cache conversion, so when we will need reverse conversion there wont be a rounding error

--- a/components/DynamicQRCode.js
+++ b/components/DynamicQRCode.js
@@ -87,7 +87,7 @@ export class DynamicQRCode extends Component {
   };
 
   onError = () => {
-    console.log('Data is too large for QR Code.');
+    console.warn('DynamicQRCode: payload too large to encode');
     this.setState({ displayQRCode: false });
   };
 

--- a/components/DynamicQRCode.js
+++ b/components/DynamicQRCode.js
@@ -41,7 +41,7 @@ export class DynamicQRCode extends Component {
         },
       );
     } catch (e) {
-      console.log(e);
+      console.error('DynamicQRCode: failed to initialise fragment encoder', e);
       this.setState({ displayQRCode: false, hideControls });
     }
   }

--- a/components/QRCodeComponent.tsx
+++ b/components/QRCodeComponent.tsx
@@ -74,7 +74,7 @@ const QRCodeComponent: React.FC<QRCodeComponentProps> = ({
       const shareImageBase64 = {
         url: `data:image/png;base64,${data}`,
       };
-      Share.open(shareImageBase64).catch((error: any) => console.log(error));
+      Share.open(shareImageBase64).catch(() => {});
     });
   };
 

--- a/components/TooltipMenu.android.js
+++ b/components/TooltipMenu.android.js
@@ -19,9 +19,7 @@ const ToolTipMenu = (props, ref) => {
     }
   }, [ref]);
 
-  const dismissMenu = () => {
-    console.log('dismissMenu Not implemented');
-  };
+  const dismissMenu = () => {};
 
   const showMenu = () => {
     const menu = [];

--- a/components/TooltipMenu.android.js
+++ b/components/TooltipMenu.android.js
@@ -19,6 +19,7 @@ const ToolTipMenu = (props, ref) => {
     }
   }, [ref]);
 
+  // Android popup menus cannot be dismissed programmatically; the ref contract needs the method regardless.
   const dismissMenu = () => {};
 
   const showMenu = () => {

--- a/components/TooltipMenu.ios.js
+++ b/components/TooltipMenu.ios.js
@@ -2,7 +2,6 @@ import React, { forwardRef, useCallback, useMemo } from 'react';
 import ContextMenu from 'react-native-context-menu-view';
 import PropTypes from 'prop-types';
 import { TouchableOpacity } from 'react-native';
-import QRCodeComponent from './QRCodeComponent';
 
 const mapAction = action => {
   const item = {
@@ -64,8 +63,6 @@ const ToolTipMenu = (props, ref) => {
 
   const isButton = !!props.isButton;
   const isMenuPrimaryAction = !!props.isMenuPrimaryAction;
-  const previewQRCode = props.previewQRCode ?? false;
-  const previewValue = props.previewValue;
   const disabled = props.disabled ?? false;
   const buttonStyle = props.buttonStyle;
 
@@ -81,7 +78,6 @@ const ToolTipMenu = (props, ref) => {
       onPress={handlePress}
       dropdownMenuMode={isMenuPrimaryAction}
       previewBackgroundColor="transparent"
-      preview={previewQRCode ? <QRCodeComponent value={previewValue} isMenuAvailable={false} /> : undefined}
       style={isButton ? buttonStyle : undefined}
     >
       {props.onPress ? (
@@ -105,9 +101,7 @@ ToolTipMenu.propTypes = {
   onPressMenuItem: PropTypes.func.isRequired,
   isMenuPrimaryAction: PropTypes.bool,
   isButton: PropTypes.bool,
-  previewQRCode: PropTypes.bool,
   onPress: PropTypes.func,
-  previewValue: PropTypes.string,
   disabled: PropTypes.bool,
   buttonStyle: PropTypes.object,
 };

--- a/components/WalletsCarousel.js
+++ b/components/WalletsCarousel.js
@@ -292,8 +292,7 @@ const WalletsCarousel = forwardRef((props, ref) => {
   }));
 
   const onScrollToIndexFailed = error => {
-    console.log('onScrollToIndexFailed');
-    console.log(error);
+    console.debug('WalletsCarousel: scrollToIndex failed, falling back to scrollToOffset', error);
     flatListRef.current.scrollToOffset({ offset: error.averageItemLength * error.index, animated: true });
     setTimeout(() => {
       if (props.data.length !== 0 && flatListRef.current !== null) {

--- a/components/addresses/AddressItem.js
+++ b/components/addresses/AddressItem.js
@@ -110,8 +110,6 @@ const AddressItem = ({ item, balanceUnit, walletID, allowSignVerifyMessage }) =>
         ref={menuRef}
         actions={getAvailableActions()}
         onPressMenuItem={onToolTipPress}
-        previewQRCode
-        previewValue={item.address}
         onPress={navigateToReceive}
       >
         <ListItem key={item.key} containerStyle={stylesHook.container}>

--- a/components/addresses/AddressItem.js
+++ b/components/addresses/AddressItem.js
@@ -65,7 +65,7 @@ const AddressItem = ({ item, balanceUnit, walletID, allowSignVerifyMessage }) =>
   };
 
   const handleSharePress = () => {
-    Share.open({ message: item.address }).catch(error => console.log(error));
+    Share.open({ message: item.address }).catch(() => {});
   };
 
   const onToolTipPress = id => {

--- a/helpers/prompt.ts
+++ b/helpers/prompt.ts
@@ -30,7 +30,6 @@ module.exports = (
           {
             text: continueButtonText,
             onPress: password => {
-              console.log('OK Pressed');
               resolve(password);
             },
             style: isOKDestructive ? 'destructive' : 'default',
@@ -40,7 +39,6 @@ module.exports = (
           {
             text: continueButtonText,
             onPress: password => {
-              console.log('OK Pressed');
               resolve(password);
             },
           },

--- a/helpers/select-wallet.ts
+++ b/helpers/select-wallet.ts
@@ -39,7 +39,6 @@ module.exports = function (
       if (!selectedWallet) return;
 
       setTimeout(() => resolve(selectedWallet), 1);
-      console.warn('trying to navigate back to', currentScreenName);
       navigateFunc(currentScreenName);
     };
 

--- a/hooks/cameraPermisions.hook.ts
+++ b/hooks/cameraPermisions.hook.ts
@@ -57,7 +57,7 @@ const useCameraPermissions = () => {
           setCameraStatus(false);
         }
       } catch (err) {
-        console.warn(err);
+        console.warn('cameraPermissions: permission query failed, treating as denied', err);
       }
     })();
   }, []);

--- a/hooks/qrCodeScaner.hook.ts
+++ b/hooks/qrCodeScaner.hook.ts
@@ -45,7 +45,7 @@ export function useQrCodeScanner() {
         setIsLoadingAnimatedQRCode(true);
       }
     } catch (error) {
-      console.warn(error);
+      console.debug('qrCodeScanner: UR fragment decode failed', error);
       setIsLoading(true);
       Alert.alert(
         loc.send.scan_error,
@@ -85,7 +85,7 @@ export function useQrCodeScanner() {
         setAnimatedQRCodeData(animatedQRCodeData);
       }
     } catch (error) {
-      console.warn(error);
+      console.debug('qrCodeScanner: animated QR fragment decode failed', error);
       setIsLoading(true);
       Alert.alert(
         loc.send.scan_error,
@@ -149,7 +149,7 @@ export function useQrCodeScanner() {
       try {
         onBarScanned(ret.data);
       } catch (e) {
-        console.log(e);
+        console.debug('qrCodeScanner: onBarScanned handler threw', e);
       }
     }
     setIsLoading(false);

--- a/hooks/useCompanionListeners.ts
+++ b/hooks/useCompanionListeners.ts
@@ -46,7 +46,6 @@ const useCompanionListeners = () => {
       for (const payload of notifications2process) {
         const wasTapped = payload.foreground === false || (payload.foreground === true && payload.userInteraction);
 
-        console.log('processing push notification:', payload);
         let wallet;
         switch (+payload.type) {
           case 2:

--- a/hooks/useCompanionListeners.ts
+++ b/hooks/useCompanionListeners.ts
@@ -24,7 +24,6 @@ const useCompanionListeners = () => {
 
   const processPushNotifications = useCallback(async (): Promise<boolean> => {
     if (!walletsInitialized) {
-      console.log('not processing push notifications because wallets are not initialized');
       return false;
     }
 
@@ -39,7 +38,7 @@ const useCompanionListeners = () => {
         try {
           removeAllDeliveredNotifications();
         } catch (error) {
-          console.error('Failed to remove delivered notifications:', error);
+          console.error('useCompanionListeners: failed to remove delivered notifications', error);
         }
       }, 5000);
 
@@ -83,8 +82,6 @@ const useCompanionListeners = () => {
             }
             return true;
           }
-        } else {
-          console.log('could not find wallet while processing push notification, NOP');
         }
       }
 
@@ -92,7 +89,7 @@ const useCompanionListeners = () => {
         refreshAllWalletTransactions();
       }
     } catch (error) {
-      console.error('Failed to process push notifications:', error);
+      console.error('useCompanionListeners: failed to process push notifications', error);
     }
     return false;
   }, [walletsInitialized, wallets, fetchAndSaveWalletTransactions, refreshAllWalletTransactions]);

--- a/models/networkTransactionFees.js
+++ b/models/networkTransactionFees.js
@@ -35,7 +35,7 @@ export default class NetworkTransactionFees {
           resolve(networkFee);
         }
       } catch (err) {
-        console.warn(err);
+        console.warn('networkTransactionFees: fee estimate fetch failed, using hardcoded defaults', err);
         const networkFee = new NetworkTransactionFee(2, 1, 1);
         resolve(networkFee);
       }

--- a/screen/boltcard/add.tsx
+++ b/screen/boltcard/add.tsx
@@ -81,7 +81,7 @@ const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigation
   }, []);
 
   const setupBoltcardErrorHandler = (error: any) => {
-    if (!error.type) return console.log(error);
+    if (!error.type) return console.error('boltcard/add: card setup failed with untyped error', error);
     switch (error.type) {
       case TypeError.AUTH_FAILED:
         if (error.code === '91ae') return navigate('WrittenCardError');

--- a/screen/boltcard/add.tsx
+++ b/screen/boltcard/add.tsx
@@ -90,7 +90,7 @@ const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigation
         if (error.code === '6982') return navigate('WrittenCardError');
         break;
       default:
-        console.log(JSON.stringify(error));
+        console.error('boltcard/add: unhandled card setup error', error);
     }
   };
 

--- a/screen/boltcard/delete.tsx
+++ b/screen/boltcard/delete.tsx
@@ -68,7 +68,7 @@ const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigati
         await deleteBoltcard(ldsWallet.getAdminKey(), card);
         updateProgress(`${loc.boltcard.writting_hold}\n\n${progress.next()}`);
       } catch (_) {
-        console.log(_);
+        console.error('boltcard/delete: server-side card deletion failed after card was wiped', _);
       }
       ldsWallet.deleteBoltcard(card);
       await saveToDisk();
@@ -86,7 +86,7 @@ const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigati
     } catch (error) {
       setIsLoading(false);
       stopNfcSession();
-      console.error(error);
+      console.error('boltcard/delete: card deletion flow failed', error);
     }
   };
 

--- a/screen/boltcard/details.tsx
+++ b/screen/boltcard/details.tsx
@@ -119,7 +119,7 @@ const BoltcardDetails: React.FC & { navigationOptions?: ReturnType<typeof naviga
       resetInputs();
     } catch (error) {
       setIsUpdating(false);
-      console.log('ERROR: ', error);
+      console.error('boltcard/details: failed to update card', error);
     }
   };
 

--- a/screen/boltcard/details.tsx
+++ b/screen/boltcard/details.tsx
@@ -39,18 +39,14 @@ const BoltcardDetails: React.FC & { navigationOptions?: ReturnType<typeof naviga
   const { amountSats: txLimitSats, formattedUnit: txLimitUnit, inputProps: txLimitInputProps, resetInput: resetTxLimit } = useInputAmount();
 
   const initPolling = useCallback(async () => {
-    try {
-      pollInterval.current = setInterval(async () => {
-        if (isPolling) return;
-        setIsPolling(true);
-        const latestHits = await getHits(ldsWallet.getInvoiceId());
-        ldsWallet.cachedHits = latestHits;
-        setHits(latestHits);
-        setIsPolling(false);
-      }, 5000);
-    } catch (_) {
-      console.log(_);
-    }
+    pollInterval.current = setInterval(async () => {
+      if (isPolling) return;
+      setIsPolling(true);
+      const latestHits = await getHits(ldsWallet.getInvoiceId());
+      ldsWallet.cachedHits = latestHits;
+      setHits(latestHits);
+      setIsPolling(false);
+    }, 5000);
   }, [card]);
 
   const stopPolling = () => {

--- a/screen/lnd/browser.js
+++ b/screen/lnd/browser.js
@@ -409,25 +409,20 @@ export default class Browser extends Component {
           }
 
           if (json && json.enable) {
-            console.log('webln enabled');
             this.setState({ weblnEnabled: true });
           }
         }}
         onLoadStart={e => {
           alreadyInjected = false;
-          console.log('load start');
           this.setState({ pageIsLoading: true, weblnEnabled: false });
         }}
         onLoadEnd={e => {
-          console.log('load end');
           this.setState({ url: e.nativeEvent.url, pageIsLoading: false });
         }}
         onLoadProgress={e => {
-          console.log('progress:', e.nativeEvent.progress);
           if (!alreadyInjected && e.nativeEvent.progress > 0.5) {
             this.webView.current?.injectJavaScript(injectedParadise);
             alreadyInjected = true;
-            console.log('injected');
           }
         }}
       />

--- a/screen/lnd/browser.js
+++ b/screen/lnd/browser.js
@@ -330,7 +330,6 @@ export default class Browser extends Component {
         source={{ uri: this.state.url }}
         onMessage={e => {
           // this is a handler which receives messages sent from within the browser
-          console.log('---- message from the bus:', e.nativeEvent.data);
           let json = false;
           try {
             json = JSON.parse(e.nativeEvent.data);
@@ -354,11 +353,10 @@ export default class Browser extends Component {
               'Page',
               'This page asks for permission to pay an invoice',
               [
-                { text: 'Cancel', onPress: () => console.log('Cancel Pressed'), style: 'cancel' },
+                { text: 'Cancel', style: 'cancel' },
                 {
                   text: 'Pay',
                   onPress: () => {
-                    console.log('OK Pressed');
                     this.props.navigation.navigate('SendDetailsRoot', {
                       screen: 'ScanLndInvoice',
                       params: {
@@ -384,7 +382,7 @@ export default class Browser extends Component {
               'Page',
               'This page wants to pay you ' + amount + ' sats (' + json.makeInvoice.defaultMemo + ')',
               [
-                { text: 'No thanks', onPress: () => console.log('Cancel Pressed'), style: 'cancel' },
+                { text: 'No thanks', style: 'cancel' },
                 {
                   text: 'Accept',
                   onPress: async () => {

--- a/screen/lnd/cashierPos.tsx
+++ b/screen/lnd/cashierPos.tsx
@@ -130,7 +130,7 @@ const CashierPos = () => {
       setIsWaitingForPayment(true);
       initInvoicePolling();
     } catch (error) {
-      console.log(error);
+      console.error('lnd/cashierPos: failed to generate invoice', error);
     }
   };
 

--- a/screen/lnd/lndCreateInvoice.js
+++ b/screen/lnd/lndCreateInvoice.js
@@ -81,7 +81,7 @@ const LNDCreateInvoice = () => {
         await processLnurl(uri);
       }
     } catch (e) {
-      console.log(e);
+      console.error('lndCreateInvoice: failed to prepare receive details', e);
     }
     setIsLoading(false);
   };
@@ -373,7 +373,7 @@ const LNDCreateInvoice = () => {
   }
 
   const handleShareButtonPressed = () => {
-    Share.open({ message: wallet.current.lnAddress }).catch(error => console.log(error));
+    Share.open({ message: wallet.current.lnAddress }).catch(() => {});
   };
 
   return (

--- a/screen/lnd/lndReceive.tsx
+++ b/screen/lnd/lndReceive.tsx
@@ -197,7 +197,7 @@ const LNDReceive = () => {
   };
 
   const handleShareButtonPressed = () => {
-    Share.open({ message: invoiceRequest || wallet.lnAddress }).catch(error => console.log(error));
+    Share.open({ message: invoiceRequest || wallet.lnAddress }).catch(() => {});
   };
 
   if (isPaid) {

--- a/screen/lnd/lndViewAdditionalInvoiceInformation.js
+++ b/screen/lnd/lndViewAdditionalInvoiceInformation.js
@@ -33,7 +33,7 @@ const LNDViewAdditionalInvoiceInformation = () => {
           setWalletInfo(wallet.info_raw);
         })
         .catch(error => {
-          console.log(error);
+          console.error('lndViewAdditionalInvoiceInformation: wallet.fetchInfo failed', error);
           alert(loc.errors.network);
           goBack();
         });

--- a/screen/lnd/lndViewInvoice.js
+++ b/screen/lnd/lndViewInvoice.js
@@ -138,7 +138,6 @@ const LNDViewInvoice = () => {
 
   useEffect(() => {
     setSelectedWallet(walletID);
-    console.log('LNDViewInvoice - useEffect');
     if (!invoice.ispaid) {
       fetchInvoiceInterval.current = setInterval(async () => {
         if (isFetchingInvoices) {
@@ -174,9 +173,7 @@ const LNDViewInvoice = () => {
                 }
               }
             }
-          } catch (error) {
-            console.log(error);
-          }
+          } catch (error) {}
         }
       }, 3000);
     } else {
@@ -201,7 +198,7 @@ const LNDViewInvoice = () => {
   };
 
   const handleOnSharePressed = () => {
-    Share.open({ message: `lightning:${invoice.payment_request}` }).catch(error => console.log(error));
+    Share.open({ message: `lightning:${invoice.payment_request}` }).catch(() => {});
   };
 
   useEffect(() => {

--- a/screen/lnd/lndViewInvoice.js
+++ b/screen/lnd/lndViewInvoice.js
@@ -173,7 +173,7 @@ const LNDViewInvoice = () => {
                 }
               }
             }
-          } catch (error) {}
+          } catch (_) {}
         }
       }, 3000);
     } else {

--- a/screen/lnd/lnurlNavigationForwarder.tsx
+++ b/screen/lnd/lnurlNavigationForwarder.tsx
@@ -193,7 +193,7 @@ const LnurlNavigationForwarder = () => {
 
       throw new Error('Unsupported lnurl');
     } catch (error) {
-      console.error(error);
+      console.error('lnurlNavigationForwarder: failed to route lnurl', error);
       navigation.goBack();
     }
   };

--- a/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
+++ b/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
@@ -130,7 +130,7 @@ const OpenCrytoPayCommitOnchain = () => {
         amount: Number(amountFormatted),
       });
     } catch (error) {
-      console.error('error', error);
+      console.error('openCryptoPay: onchain commit failed', error);
       setIsServerError(true);
     } finally {
       setIsLoading(false);

--- a/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
+++ b/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
@@ -117,7 +117,7 @@ const OpenCrytoPayCommitOnchain = () => {
       const result = await paymentLink.commitOnchainPayment(_tx);
 
       if (result.error) {
-        console.error('error', result);
+        console.error('openCryptoPay: commitOnchainPayment rejected', result.error, result.statusCode);
         throw new Error(`${result.error} - ${result.message} - ${result.statusCode}`);
       }
 

--- a/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
+++ b/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
@@ -68,10 +68,7 @@ const OpenCrytoPayCommitOnchain = () => {
   });
 
   useEffect(() => {
-    console.log('openCrytoPayCommitOnchain - useEffect');
-    console.log('address = ', recipients);
     Biometric.isBiometricUseCapableAndEnabled().then(setIsBiometricUseCapableAndEnabled);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
+++ b/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
@@ -117,8 +117,9 @@ const OpenCrytoPayCommitOnchain = () => {
       const result = await paymentLink.commitOnchainPayment(_tx);
 
       if (result.error) {
-        console.error('openCryptoPay: commitOnchainPayment rejected', result.error, result.statusCode);
-        throw new Error(`${result.error} - ${result.message} - ${result.statusCode}`);
+        // Not result.message: the outer catch logs this error, and the message can
+        // carry payment detail. It is never displayed - the catch only flags state.
+        throw new Error(`openCryptoPay commit rejected: ${result.error} (${result.statusCode})`);
       }
 
       const amount = recipients.reduce((acc, recipient) => acc + recipient.value, 0);

--- a/screen/receive/aztecoRedeem.js
+++ b/screen/receive/aztecoRedeem.js
@@ -81,10 +81,6 @@ export default class AztecoRedeem extends Component {
     }
   }
 
-  async componentDidMount() {
-    console.log('AztecoRedeem - componentDidMount');
-  }
-
   onWalletSelect = toWallet => {
     this.setState({ toWallet }, () => {
       this.props.navigation.pop();

--- a/screen/receive/details.js
+++ b/screen/receive/details.js
@@ -126,8 +126,6 @@ const ReceiveDetails = () => {
 
   // re-fetching address balance periodically
   useEffect(() => {
-    console.log('receive/defails - useEffect');
-
     if (fetchAddressInterval.current) {
       // interval already exists, lets cleanup it and recreate, so theres no duplicate intervals
       clearInterval(fetchAddressInterval.current);
@@ -140,9 +138,7 @@ const ReceiveDetails = () => {
         const address2use = address || decoded.address;
         if (!address2use) return;
 
-        console.log('checking address', address2use, 'for balance...');
         const balance = await BlueElectrum.getBalanceByAddress(address2use);
-        console.log('...got', balance);
 
         if (balance.unconfirmed > 0) {
           if (initialConfirmed === 0 && initialUnconfirmed === 0) {
@@ -211,7 +207,7 @@ const ReceiveDetails = () => {
           }
         }
       } catch (error) {
-        console.log(error);
+        console.warn('receiveDetails: balance poll tick failed, retrying next tick', error);
       }
     }, intervalMs);
   }, [bip21encoded, address, initialConfirmed, initialUnconfirmed, intervalMs, refreshAllWalletTransactions, walletID]);
@@ -326,7 +322,6 @@ const ReceiveDetails = () => {
   };
 
   const obtainWalletAddress = useCallback(async () => {
-    console.log('receive/details - componentDidMount');
     wallet.setUserHasSavedExport(true);
     let newAddress;
     if (address) {
@@ -396,7 +391,7 @@ const ReceiveDetails = () => {
   }, [amountSats, customLabel]);
 
   const handleShareButtonPressed = () => {
-    Share.open({ message: bip21encoded }).catch(error => console.log(error));
+    Share.open({ message: bip21encoded }).catch(() => {});
   };
 
   const onWalletChange = id => {

--- a/screen/send/ScanQRCode.js
+++ b/screen/send/ScanQRCode.js
@@ -369,7 +369,7 @@ const ScanQRCode = () => {
       onBarScanned({ data: { ...card, secrets: authKeys } });
     } catch (error) {
       setHoldCardModalVisible(false);
-      console.log('#### error ###', error, error?.message, error.constructor?.name);
+      console.error('ScanQRCode: NFC card read failed', error);
     }
     stopNfcSession();
   };

--- a/screen/send/ScanQRCode.js
+++ b/screen/send/ScanQRCode.js
@@ -173,7 +173,7 @@ const ScanQRCode = () => {
         setUrHave(Math.floor(decoder.estimatedPercentComplete() * 100));
       }
     } catch (error) {
-      console.warn(error);
+      console.debug('ScanQRCode: UR fragment decode failed', error);
       setIsLoading(true);
       Alert.alert(
         loc.send.scan_error,
@@ -221,7 +221,7 @@ const ScanQRCode = () => {
         setAnimatedQRCodeData(animatedQRCodeData);
       }
     } catch (error) {
-      console.warn(error);
+      console.debug('ScanQRCode: animated QR fragment decode failed', error);
       setIsLoading(true);
       Alert.alert(
         loc.send.scan_error,
@@ -292,7 +292,7 @@ const ScanQRCode = () => {
         }
         onBarScanned(ret.data);
       } catch (e) {
-        console.log(e);
+        console.debug('ScanQRCode: onBarScanned handler threw', e);
       }
     }
     setIsLoading(false);

--- a/screen/send/confirm.js
+++ b/screen/send/confirm.js
@@ -60,10 +60,7 @@ const Confirm = () => {
   });
 
   useEffect(() => {
-    console.log('send/confirm - useEffect');
-    console.log('address = ', recipients);
     Biometric.isBiometricUseCapableAndEnabled().then(setIsBiometricUseCapableAndEnabled);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {

--- a/screen/send/create.js
+++ b/screen/send/create.js
@@ -46,7 +46,6 @@ const SendCreate = () => {
   useEffect(() => {
     Privacy.enableBlur();
 
-    console.log('send/create - useEffect');
     return () => {
       Privacy.disableBlur();
     };
@@ -61,9 +60,7 @@ const SendCreate = () => {
         url: 'file://' + filePath,
         saveToFiles: isDesktop,
       })
-        .catch(error => {
-          console.log(error);
-        })
+        .catch(() => {})
         .finally(() => {
           RNFS.unlink(filePath);
         });
@@ -83,7 +80,7 @@ const SendCreate = () => {
           await RNFS.writeFile(filePath, tx);
           alert(loc.formatString(loc.send.txSaved, { filePath }));
         } catch (e) {
-          console.log(e);
+          console.error('send/create: failed to write transaction file to downloads', e);
           alert(e.message);
         }
       } else {

--- a/screen/send/create.js
+++ b/screen/send/create.js
@@ -74,7 +74,6 @@ const SendCreate = () => {
       });
 
       if (granted === PermissionsAndroid.RESULTS.GRANTED || Platform.Version >= 33) {
-        console.log('Storage Permission: Granted');
         const filePath = RNFS.DownloadDirectoryPath + `/${fileName}`;
         try {
           await RNFS.writeFile(filePath, tx);
@@ -84,7 +83,6 @@ const SendCreate = () => {
           alert(e.message);
         }
       } else {
-        console.log('Storage Permission: Denied');
         Alert.alert(loc.send.permission_storage_title, loc.send.permission_storage_denied_message, [
           {
             text: loc.send.open_settings,

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -145,7 +145,7 @@ const SendDetails = () => {
         setAmountUnit(BitcoinUnit.BTC);
         setPayjoinUrl(pjUrl);
       } catch (error) {
-        console.log(error);
+        console.error('send/details: failed to parse incoming payment request', error);
         Alert.alert(loc.errors.error, loc.send.details_error_decode);
       }
     } else if (routeParams.address) {
@@ -390,31 +390,24 @@ const SendDetails = () => {
       let error;
       if (!transaction.amount || transaction.amount < 0 || parseFloat(transaction.amount) === 0) {
         error = loc.send.details_amount_field_is_not_valid;
-        console.log('validation error');
       } else if (parseFloat(transaction.amountSats) <= 500) {
         error = loc.send.details_amount_field_is_less_than_minimum_amount_sat;
-        console.log('validation error');
       } else if (!requestedSatPerByte || parseFloat(requestedSatPerByte) < 1) {
         error = loc.send.details_fee_field_is_not_valid;
-        console.log('validation error');
       } else if (!transaction.address) {
         error = loc.send.details_address_field_is_not_valid;
-        console.log('validation error');
       } else if (balance - transaction.amountSats < 0) {
         // first sanity check is that sending amount is not bigger than available balance
         error = frozenBalance > 0 ? loc.send.details_total_exceeds_balance_frozen : loc.send.details_total_exceeds_balance;
-        console.log('validation error');
       } else if (transaction.address) {
         const address = transaction.address.trim().toLowerCase();
         if (address.startsWith('lnb') || address.startsWith('lightning:lnb')) {
           error = loc.send.provided_address_is_invoice;
-          console.log('validation error');
         }
       }
 
       if (!error) {
         if (!wallet.isAddressValid(transaction.address)) {
-          console.log('validation error');
           error = loc.send.details_address_field_is_not_valid;
         }
       }
@@ -441,7 +434,6 @@ const SendDetails = () => {
     const change = await getChangeAddressAsync();
     const requestedSatPerByte = Number(feeRate);
     const lutxo = utxo || wallet.getUtxo();
-    console.log({ requestedSatPerByte, lutxo: lutxo.length });
 
     const targets = [];
     for (const transaction of addresses) {
@@ -469,7 +461,6 @@ const SendDetails = () => {
     );
 
     if (tx && routeParams.launchedBy && psbt) {
-      console.warn('navigating back to ', routeParams.launchedBy);
       navigation.navigate(routeParams.launchedBy, { psbt });
     }
 

--- a/screen/send/details.js
+++ b/screen/send/details.js
@@ -199,7 +199,7 @@ const SendDetails = () => {
         if (!fees?.fastestFee) return;
         setNetworkTransactionFees(fees);
       })
-      .catch(e => console.log('loading cached recommendedFees error', e));
+      .catch(e => console.warn('send/details: loading cached recommendedFees failed', e));
 
     // load fresh fees from servers
 
@@ -210,7 +210,7 @@ const SendDetails = () => {
         setNetworkTransactionFees(fees);
         await AsyncStorage.setItem(NetworkTransactionFee.StorageKey, JSON.stringify(fees));
       })
-      .catch(e => console.log('loading recommendedFees error', e))
+      .catch(e => console.warn('send/details: loading recommendedFees failed', e))
       .finally(() => {
         setNetworkTransactionFeesIsLoading(false);
       });
@@ -233,7 +233,7 @@ const SendDetails = () => {
         // we need to re-calculate fees
         setDumb(v => !v);
       })
-      .catch(e => console.log('fetchUtxo error', e));
+      .catch(e => console.warn('send/details: fetchUtxo failed', e));
   }, [wallet]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // recalc fees in effect so we don't block render

--- a/screen/send/success.js
+++ b/screen/send/success.js
@@ -31,10 +31,6 @@ const Success = () => {
       color: colors.alternativeTextColor2,
     },
   });
-  useEffect(() => {
-    console.log('send/success - useEffect');
-  }, []);
-
   return (
     <SafeAreaView style={[styles.root, stylesHook.root]}>
       <SuccessView

--- a/screen/settings/SettingsPrivacy.js
+++ b/screen/settings/SettingsPrivacy.js
@@ -34,7 +34,7 @@ const SettingsPrivacy = () => {
         setIsQuickActionsEnabled(await DeviceQuickActions.getEnabled());
         setIsDisplayWidgetBalanceAllowed(await WidgetCommunication.isBalanceDisplayAllowed());
       } catch (e) {
-        console.log(e);
+        console.error('SettingsPrivacy: failed to load privacy settings', e);
       }
       setIsLoading(false);
     })();
@@ -47,7 +47,7 @@ const SettingsPrivacy = () => {
       await BlueClipboard().setReadClipboardAllowed(value);
       setIsReadClipboardAllowed(value);
     } catch (e) {
-      console.log(e);
+      console.error('SettingsPrivacy: failed to persist clipboard-read setting, UI now out of sync', e);
     }
     setIsLoading(false);
   };
@@ -59,7 +59,7 @@ const SettingsPrivacy = () => {
       A.setOptOut(value);
       await setDoNotTrack(value);
     } catch (e) {
-      console.log(e);
+      console.error('SettingsPrivacy: failed to persist Do-Not-Track setting, opt-out may not be honored', e);
     }
     setIsLoading(false);
   };
@@ -70,7 +70,7 @@ const SettingsPrivacy = () => {
       await DeviceQuickActions.setEnabled(value);
       setIsQuickActionsEnabled(value);
     } catch (e) {
-      console.log(e);
+      console.error('SettingsPrivacy: failed to persist quick-actions setting, UI now out of sync', e);
     }
     setIsLoading(false);
   };
@@ -81,7 +81,7 @@ const SettingsPrivacy = () => {
       await WidgetCommunication.setBalanceDisplayAllowed(value);
       setIsDisplayWidgetBalanceAllowed(value);
     } catch (e) {
-      console.log(e);
+      console.error('SettingsPrivacy: failed to persist widget-balance setting, UI now out of sync', e);
     }
     setIsLoading(false);
   };

--- a/screen/settings/about.js
+++ b/screen/settings/about.js
@@ -117,7 +117,7 @@ const About = () => {
       openAppStoreIfInAppFails: true,
       fallbackPlatformURL: 'https://dfx.swiss',
     };
-    Rate.rate(options, () => {});
+    Rate.rate(options);
   };
 
   return (

--- a/screen/settings/about.js
+++ b/screen/settings/about.js
@@ -117,11 +117,7 @@ const About = () => {
       openAppStoreIfInAppFails: true,
       fallbackPlatformURL: 'https://dfx.swiss',
     };
-    Rate.rate(options, success => {
-      if (success) {
-        console.log('User Rated.');
-      }
-    });
+    Rate.rate(options, () => {});
   };
 
   return (

--- a/screen/settings/currency.js
+++ b/screen/settings/currency.js
@@ -76,7 +76,7 @@ const Currency = () => {
                   setSelectedCurrency(item);
                   setPreferredFiatCurrency();
                 } catch (error) {
-                  console.log(error);
+                  console.error('currencySettings: failed to change preferred fiat currency', error);
                   alert(loc.settings.currency_fetch_error);
                 } finally {
                   setIsSavingNewPreferredCurrency(false);

--- a/screen/settings/electrumSettings.js
+++ b/screen/settings/electrumSettings.js
@@ -135,7 +135,7 @@ class ElectrumSettings extends Component {
   clearHistoryAlert() {
     ReactNativeHapticFeedback.trigger('impactHeavy', { ignoreAndroidSystemSettings: false });
     Alert.alert(loc.settings.electrum_clear_alert_title, loc.settings.electrum_clear_alert_message, [
-      { text: loc.settings.electrum_clear_alert_cancel, onPress: () => console.log('Cancel Pressed'), style: 'cancel' },
+      { text: loc.settings.electrum_clear_alert_cancel, style: 'cancel' },
       { text: loc.settings.electrum_clear_alert_ok, onPress: () => this.clearHistory() },
     ]);
   }
@@ -188,7 +188,6 @@ class ElectrumSettings extends Component {
             WidgetCommunication.reloadAllTimelines();
           } catch (e) {
             // Must be running on Android
-            console.log(e);
           }
           ReactNativeHapticFeedback.trigger('notificationSuccess', { ignoreAndroidSystemSettings: false });
           alert(loc.settings.electrum_saved);
@@ -217,7 +216,6 @@ class ElectrumSettings extends Component {
             WidgetCommunication.reloadAllTimelines();
           } catch (e) {
             // Must be running on Android
-            console.log(e);
           }
           ReactNativeHapticFeedback.trigger('notificationSuccess', { ignoreAndroidSystemSettings: false });
           alert(loc.settings.electrum_saved);

--- a/screen/settings/electrumSettings.js
+++ b/screen/settings/electrumSettings.js
@@ -186,7 +186,7 @@ class ElectrumSettings extends Component {
             await DefaultPreference.clear(BlueElectrum.ELECTRUM_SSL_PORT);
             await DefaultPreference.clear(BlueElectrum.ELECTRUM_TCP_PORT);
             WidgetCommunication.reloadAllTimelines();
-          } catch (e) {
+          } catch (_) {
             // Must be running on Android
           }
           ReactNativeHapticFeedback.trigger('notificationSuccess', { ignoreAndroidSystemSettings: false });
@@ -214,7 +214,7 @@ class ElectrumSettings extends Component {
             await DefaultPreference.set(BlueElectrum.ELECTRUM_TCP_PORT, port);
             await DefaultPreference.set(BlueElectrum.ELECTRUM_SSL_PORT, sslPort);
             WidgetCommunication.reloadAllTimelines();
-          } catch (e) {
+          } catch (_) {
             // Must be running on Android
           }
           ReactNativeHapticFeedback.trigger('notificationSuccess', { ignoreAndroidSystemSettings: false });

--- a/screen/settings/lightningSettings.tsx
+++ b/screen/settings/lightningSettings.tsx
@@ -109,7 +109,7 @@ const LightningSettings: React.FC & { navigationOptions: NavigationOptionsGetter
       alert(loc.settings.lightning_saved);
     } catch (error) {
       alert(loc.settings.lightning_error_lndhub_uri);
-      console.log(error);
+      console.error('lightningSettings: failed to save LNDHub URI', error);
     }
     setIsLoading(false);
   }, [URI]);

--- a/screen/settings/notificationSettings.tsx
+++ b/screen/settings/notificationSettings.tsx
@@ -92,7 +92,7 @@ const NotificationSettings: React.FC & { navigationOptions: NavigationOptionsGet
         alert(loc.settings.saved);
       }
     } catch (error) {
-      console.warn(error);
+      console.error('notificationSettings: failed to save GroundControl URI', error);
     }
     setIsLoading(false);
   }, [URI]);

--- a/screen/transactions/CPFP.js
+++ b/screen/transactions/CPFP.js
@@ -111,7 +111,6 @@ export default class CPFP extends Component {
   }
 
   async componentDidMount() {
-    console.log('transactions/CPFP - componentDidMount');
     this.setState({
       isLoading: true,
       newFeeRate: '',

--- a/screen/transactions/RBFBumpFee.js
+++ b/screen/transactions/RBFBumpFee.js
@@ -20,7 +20,6 @@ export default class RBFBumpFee extends CPFP {
   static contextType = BlueStorageContext;
 
   async componentDidMount() {
-    console.log('transactions/RBFBumpFee - componentDidMount');
     this.setState({
       isLoading: true,
       newFeeRate: '',

--- a/screen/transactions/RBFCancel.js
+++ b/screen/transactions/RBFCancel.js
@@ -33,7 +33,6 @@ export default class RBFCancel extends CPFP {
       (await tx.canCancelTx())
     ) {
       const info = await tx.getInfo();
-      console.log({ info });
       return this.setState({ nonReplaceable: false, feeRate: info.feeRate + 1, isLoading: false, tx });
       // 1 sat makes a lot of difference, since sometimes because of rounding created tx's fee might be insufficient
     } else {

--- a/screen/transactions/RBFCancel.js
+++ b/screen/transactions/RBFCancel.js
@@ -12,7 +12,6 @@ import alert from '../../components/Alert';
 export default class RBFCancel extends CPFP {
   static contextType = BlueStorageContext;
   async componentDidMount() {
-    console.log('transactions/RBFCancel - componentDidMount');
     this.setState({
       isLoading: true,
       newFeeRate: '',

--- a/screen/transactions/details.js
+++ b/screen/transactions/details.js
@@ -89,13 +89,6 @@ const TransactionsDetails = () => {
       }
     }
 
-    for (const w of wallets) {
-      for (const t of w.getTransactions()) {
-        if (t.hash === hash) {
-          console.log('tx', hash, 'belongs to', w.getLabel());
-        }
-      }
-    }
     if (txMetadata[foundTx.hash]) {
       if (txMetadata[foundTx.hash].memo) {
         setMemo(txMetadata[foundTx.hash].memo);

--- a/screen/transactions/details.js
+++ b/screen/transactions/details.js
@@ -114,7 +114,8 @@ const TransactionsDetails = () => {
       .then(supported => {
         if (supported) {
           Linking.openURL(url).catch(e => {
-            console.warn('transactionDetails: openURL failed for block explorer', e);
+            // The rejection message embeds the full URL, i.e. the txid - log neither.
+            console.warn('transactionDetails: openURL failed for block explorer');
             alert(e.message);
           });
         } else {
@@ -123,7 +124,8 @@ const TransactionsDetails = () => {
         }
       })
       .catch(e => {
-        console.warn('transactionDetails: canOpenURL failed for block explorer', e);
+        // Same here: the rejection message embeds the URL and therefore the txid.
+        console.warn('transactionDetails: canOpenURL failed for block explorer');
         alert(e.message);
       });
   };

--- a/screen/transactions/details.js
+++ b/screen/transactions/details.js
@@ -114,18 +114,16 @@ const TransactionsDetails = () => {
       .then(supported => {
         if (supported) {
           Linking.openURL(url).catch(e => {
-            console.log('openURL failed in handleOnOpenTransactionOnBlockExporerTapped');
-            console.log(e.message);
+            console.warn('transactionDetails: openURL failed for block explorer', e);
             alert(e.message);
           });
         } else {
-          console.log('canOpenURL supported is false in handleOnOpenTransactionOnBlockExporerTapped');
+          console.warn('transactionDetails: block explorer URL not supported');
           alert(loc.transactions.open_url_error);
         }
       })
       .catch(e => {
-        console.log('canOpenURL failed in handleOnOpenTransactionOnBlockExporerTapped');
-        console.log(e.message);
+        console.warn('transactionDetails: canOpenURL failed for block explorer', e);
         alert(e.message);
       });
   };

--- a/screen/transactions/transactionStatus.js
+++ b/screen/transactions/transactionStatus.js
@@ -120,7 +120,6 @@ const TransactionsStatus = () => {
       fetchTxInterval.current = undefined;
     }
 
-    console.log('setting up interval to check tx...');
     fetchTxInterval.current = setInterval(async () => {
       try {
         setIntervalMs(31000); // upon first execution we increase poll interval;

--- a/screen/transactions/transactionStatus.js
+++ b/screen/transactions/transactionStatus.js
@@ -111,8 +111,6 @@ const TransactionsStatus = () => {
 
   // re-fetching tx status periodically
   useEffect(() => {
-    console.log('transactionStatus - useEffect');
-
     if (!tx || tx?.confirmations) return;
     if (!hash) return;
 
@@ -127,10 +125,8 @@ const TransactionsStatus = () => {
       try {
         setIntervalMs(31000); // upon first execution we increase poll interval;
 
-        console.log('checking tx', hash, 'for confirmations...');
         const transactions = await BlueElectrum.multiGetTransactionByTxid([hash], 10, true);
         const txFromElectrum = transactions[hash];
-        console.log('got txFromElectrum=', txFromElectrum);
 
         const address = (txFromElectrum?.vout[0]?.scriptPubKey?.addresses || []).pop();
 
@@ -142,11 +138,9 @@ const TransactionsStatus = () => {
             if (tempTxM.tx_hash === hash) txFromMempool = tempTxM;
           }
           if (!txFromMempool) return;
-          console.log('txFromMempool=', txFromMempool);
 
           const satPerVbyte = Math.round(txFromMempool.fee / txFromElectrum.vsize);
           const fees = await NetworkTransactionFees.recommendedFees();
-          console.log('fees=', fees, 'satPerVbyte=', satPerVbyte);
           if (satPerVbyte >= fees.fastestFee) {
             setEta(loc.formatString(loc.transactions.eta_fastest));
           } else if (satPerVbyte >= fees.mediumFee) {
@@ -168,7 +162,7 @@ const TransactionsStatus = () => {
           wallet?.current?.getID() && fetchAndSaveWalletTransactions(wallet.current.getID());
         }
       } catch (error) {
-        console.log(error);
+        console.warn('transactionStatus: confirmation poll tick failed, retrying next tick', error);
       }
     }, intervalMs);
   }, [hash, intervalMs, tx, fetchAndSaveWalletTransactions]);
@@ -215,10 +209,6 @@ const TransactionsStatus = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [wallet.current]);
-
-  useEffect(() => {
-    console.log('transactionStatus - useEffect');
-  }, []);
 
   const checkPossibilityOfCPFP = async () => {
     if (!wallet.current.allowRBF()) {

--- a/screen/wallets/addMultisigStep2.js
+++ b/screen/wallets/addMultisigStep2.js
@@ -250,7 +250,7 @@ const WalletsAddMultisigStep2 = () => {
     try {
       onBarScanned(ret.data);
     } catch (e) {
-      console.log(e);
+      console.debug('addMultisigStep2: onBarScanned handler threw', e);
     }
   };
 

--- a/screen/wallets/addMultisigStep2.js
+++ b/screen/wallets/addMultisigStep2.js
@@ -69,7 +69,7 @@ const WalletsAddMultisigStep2 = () => {
     } catch (e) {
       setIsLoading(false);
       alert(e.message);
-      console.log('create MS wallet error', e);
+      console.error('addMultisigStep2: failed to create multisig wallet', e);
     }
   };
 

--- a/screen/wallets/details.js
+++ b/screen/wallets/details.js
@@ -153,7 +153,9 @@ const WalletDetails = () => {
   useEffect(() => {
     if (isMainWallet && !ownershipProof) {
       setTimeout(() => {
-        getOwnershipProof().then(setOwnershipProof).catch(console.error);
+        getOwnershipProof()
+          .then(setOwnershipProof)
+          .catch(e => console.error('walletDetails: failed to obtain ownership proof', e));
       }, 1);
     }
   }, []);

--- a/screen/wallets/dfx/cashierPos.tsx
+++ b/screen/wallets/dfx/cashierPos.tsx
@@ -121,7 +121,7 @@ const CashierDfxPos = () => {
         setPosStatus(PosStatus.WAITING_CASHIER);
       }
     } catch (error) {
-      console.error('cashierPos: payment status poll failed', error);
+      console.error('dfx/cashierPos: payment status poll failed', error);
       setPosStatus(PosStatus.NOT_AVAILABLE);
     }
   };
@@ -152,7 +152,7 @@ const CashierDfxPos = () => {
       onPendingPayment(paymentData);
       resetInput();
     } catch (error) {
-      console.error('cashierPos: createPayment failed', error);
+      console.error('dfx/cashierPos: createPayment failed', error);
     } finally {
       setIsGeneratingInvoice(false);
     }
@@ -163,7 +163,7 @@ const CashierDfxPos = () => {
       setIsCanceling(true);
       await cancelPayment(walletID, selectedRoute as number);
     } catch (error) {
-      console.error('cashierPos: cancelPayment failed', error);
+      console.error('dfx/cashierPos: cancelPayment failed', error);
     } finally {
       setIsCanceling(false);
       setPosStatus(PosStatus.WAITING_CASHIER);

--- a/screen/wallets/dfx/cashierPos.tsx
+++ b/screen/wallets/dfx/cashierPos.tsx
@@ -121,7 +121,7 @@ const CashierDfxPos = () => {
         setPosStatus(PosStatus.WAITING_CASHIER);
       }
     } catch (error) {
-      console.log(error);
+      console.error('cashierPos: payment status poll failed', error);
       setPosStatus(PosStatus.NOT_AVAILABLE);
     }
   };
@@ -152,7 +152,7 @@ const CashierDfxPos = () => {
       onPendingPayment(paymentData);
       resetInput();
     } catch (error) {
-      console.log(error);
+      console.error('cashierPos: createPayment failed', error);
     } finally {
       setIsGeneratingInvoice(false);
     }
@@ -163,7 +163,7 @@ const CashierDfxPos = () => {
       setIsCanceling(true);
       await cancelPayment(walletID, selectedRoute as number);
     } catch (error) {
-      console.log(error);
+      console.error('cashierPos: cancelPayment failed', error);
     } finally {
       setIsCanceling(false);
       setPosStatus(PosStatus.WAITING_CASHIER);

--- a/screen/wallets/dfx/receivePos.tsx
+++ b/screen/wallets/dfx/receivePos.tsx
@@ -101,7 +101,7 @@ const ReceiveDfxPos = () => {
         setPosStatus(PosStatus.WAITING_CASHIER);
       }
     } catch (error) {
-      console.log(error);
+      console.error('receivePos: payment status poll failed', error);
       setPosStatus(PosStatus.NOT_AVAILABLE);
     }
   };

--- a/screen/wallets/importMultisignature.tsx
+++ b/screen/wallets/importMultisignature.tsx
@@ -72,7 +72,7 @@ const ImportMultisignature: React.FC & { navigationOptions?: ReturnType<typeof n
       saveToDisk();
       delayedNavigationFunction(() => navigate('WalletTransactions'));
     } catch (error: any) {
-      console.log(error);
+      console.error('importMultisignature: failed to import multisig wallet', error);
       setIsError(true);
       setThreshold(0);
       setQuorum(0);

--- a/screen/wallets/selectWallet.js
+++ b/screen/wallets/selectWallet.js
@@ -98,7 +98,6 @@ const SelectWallet = () => {
   });
 
   useEffect(() => {
-    console.log('SelectWallet - useEffect');
     setIsLoading(false);
   }, []);
 

--- a/screen/wallets/signVerify.js
+++ b/screen/wallets/signVerify.js
@@ -62,7 +62,7 @@ const SignVerify = () => {
   const handleShare = () => {
     const baseUri = 'https://bluewallet.github.io/VerifySignature';
     const uri = `${baseUri}?a=${address}&m=${encodeURIComponent(message)}&s=${encodeURIComponent(signature)}`;
-    Share.open({ message: uri }).catch(error => console.log(error));
+    Share.open({ message: uri }).catch(() => {});
   };
 
   const handleSign = async () => {

--- a/screen/wallets/tappedCardDetails.tsx
+++ b/screen/wallets/tappedCardDetails.tsx
@@ -182,7 +182,7 @@ const TappedCardDetails = () => {
               setIsRegisteredInServer(uidIsCorrect && k0IsCorrect && k1IsCorrect && k2IsCorrect);
               setServerDetails(currCard);
             } catch (_) {
-              console.log(_);
+              console.error('tappedCardDetails: failed to verify card registration against server', _);
               setIsRegisteredInServer(false);
             }
           }

--- a/screen/wallets/viewEditMultisigCosigners.js
+++ b/screen/wallets/viewEditMultisigCosigners.js
@@ -321,7 +321,7 @@ const ViewEditMultisigCosigners = () => {
     try {
       wallet.replaceCosignerXpubWithSeed(currentlyEditingCosignerNum, hd.getSecret(), passphrase);
     } catch (e) {
-      console.log(e);
+      console.error('viewEditMultisigCosigners: failed to replace cosigner xpub with seed', e);
       return alert(e.message);
     }
 

--- a/screen/wallets/xpub.js
+++ b/screen/wallets/xpub.js
@@ -74,7 +74,7 @@ const WalletXpub = () => {
   };
 
   const handleShareButtonPressed = () => {
-    Share.open({ message: xpub }).catch(error => console.log(error));
+    Share.open({ message: xpub }).catch(() => {});
   };
 
   return isLoading ? (

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -16,13 +16,7 @@ console.warn = (...args) => {
 
 const consoleLogOrig = console.log;
 console.log = (...args) => {
-  if (
-    typeof args[0] === 'string' &&
-    (args[0].startsWith('updating exchange rate') ||
-      args[0].startsWith('begin connection') ||
-      args[0].startsWith('TLS Connected to') ||
-      args[0].startsWith('connected to'))
-  ) {
+  if (typeof args[0] === 'string' && (args[0].startsWith('TLS Connected to') || args[0].startsWith('_initConnection: connected to'))) {
     return;
   }
   consoleLogOrig.apply(consoleLogOrig, args);


### PR DESCRIPTION
Two changes on this branch: the console-logging pass it started as, and a fix for the iOS Addresses screen drawing a QR code over every row.

# Console logging cleanup

Goes through the app's console logging and cleans it up.

## Why

Console output already reaches Sentry as Logs. The React Native SDK registers `consoleLoggingIntegration()` automatically whenever `enableLogs` is set (`@sentry/react-native/dist/js/integrations/default.js`), with no level filter, so every `console.*` call in the app is forwarded — not just attached as breadcrumbs to crashes.

That makes the contents of our logs a live concern rather than a future one.

## What changed

**Payloads that should not leave the device.** Receive addresses and balances (logged every 5s while the Receive screen is open), recipient addresses and amounts, the full `getInfo()` result on the RBF-cancel path, push notification payloads, synced remote-storage values, NFC card read responses, webln bus messages, broadcast results, wallet labels, and full cached-transaction dumps.

Three of these only leaked through an *error object* rather than a formatted message, which is worth calling out because it is not obvious from reading the call site:

- `Linking.openURL` / `canOpenURL` embed the full URL in their rejection, so logging the error from the block-explorer handlers put the **txid** into the log.
- `react-native-fs` puts the full destination path in its write failure, and the filename is a wallet label at two call sites.
- The OpenCryptoPay commit path threw an Error built from the server's `message` field, which the outer catch then logged whole.

**Logging with no diagnostic value.** Screen lifecycle traces, UI stubs, per-poll narration, page-lifecycle logs, and expected states reported as problems — user settings, documented platform failures, share-sheet dismissals (`Share.open()` rejects when the user taps cancel).

**Swallowed exceptions.** A large set of `catch` blocks logged the error at `log`/`warn` with no message and no context. These now state the operation that failed and its consequence, and pass the error object rather than `error.message`, so stack traces survive.

**Unbounded emitters.** Per-address batch errors and per-txid fallback failures logged once per item with no cap. They now log once per batch with a count.

**Electrum instrumentation.** Connection outcomes record which peer, how long the attempt took, and which attempt it was, so a slow server can be told apart from an unreachable one. Runtime socket errors now name the peer, which they previously did not.

A user-configured peer is labelled rather than named, and the error is passed through an allowlist so only a fixed set of failure-mode tokens can be emitted — never the error text, which on Android embeds the host and IP. The token list is matched against the strings Android and iOS actually produce, and is ordered so an unambiguous token wins before a short one that could match from inside a hostname.

**Connection start moved out of module scope.** `BlueElectrum.connectMain()` ran at `BlueApp.js` import time, before NetInfo had reported anything — and `networkConnected` defaults to `true`, so a cold start with no network burned the full retry cascade against a device that had none. It now runs from the existing NetInfo listener, once the network state is known, and re-runs on every offline → online transition rather than once per app lifetime. Only an explicit `isConnected === false` counts as offline; `null` means "unknown" and must not gate the connection off — that applies to both callers of `setNetworkConnected`.

**Test log filters.** `tests/setup.js` mutes noisy Electrum/currency logs by prefix; two of its targets were deleted here and a third renamed, so it has been re-targeted.

Net effect: 245 → 111 console calls in app code, with `log` down from 155 to 9 and `error` up from 47 to 59 as swallowed exceptions moved to a level worth searching.

## Not included

- Level filtering at the Sentry client. All levels continue to be forwarded.
- The Electrum retry loop itself (18 attempts, no backoff). Upstream replaced `connectMain` with `ensureConnected()` in BlueWallet#8591; that port is separate work. The instrumentation here measures the problem rather than fixing it.
- Context memoization in `storage-context.js`, which breaks the transaction-status confirmation poll — tracked in #207.
- `blue_modules/notifications.ts` is now silent on every path, including push-registration failure. That was a deliberate call; those paths carried the push token and notification payloads, and the diagnostics can be restored separately as message-only logs if we want them.

# Addresses screen drew a QR code over every row (iOS)

Settings → on-chain wallet → Addresses covered the whole list with 300pt QR codes, one per row, stacked over each other.

`AddressItem` asked `TooltipMenu.ios.js` for a QR context-menu preview, which passes a `QRCodeComponent` to `react-native-context-menu-view`'s `preview` prop. The library renders that into `<View nativeID="ContextMenuPreview" style={{position:'absolute'}}>`, and its native `insertReactSubview:` is supposed to intercept that subview, keep it out of the view tree, and hand it to `UIContextMenuConfiguration` as the long-press preview (`ios/ContextMenuView.m`).

The intercept never fires on the New Architecture. It matches on the paper-era `UIView.nativeID` (`React/Views/UIView+React.h`), but Fabric sets a different property, `nativeId`, on `RCTViewComponentView` (`RCTViewComponentView.mm`), and `RCTLegacyViewManagerInteropComponentView` — which mounts Fabric children into legacy paper views — does not bridge the two. So `_customView` stays nil and no preview is ever shown, while the QR mounts as a real, absolutely positioned child of every row.

The preview is removed rather than repaired, for two reasons. Upstream BlueWallet's `components/TooltipMenu.tsx` carries no preview support at all, so this keeps the fork closer to upstream. And patching the pod to also read `nativeId` would leave the renderer believing it mounted a view it never received, so `unmountChildComponentView` would remove wrong-indexed subviews. Upstream issues: mpiannucci/react-native-context-menu-view#159 and #162.

Long press keeps its Copy / Share / Sign actions, and tapping a row still opens the address in Receive, where its QR is shown full size.

# Verification

**Console logging**

- `npx tsc --noEmit` clean
- `npx eslint` on all changed files: 0 errors, and the warning count and rule breakdown match `develop` for the same file set
- `npx prettier --check` clean, except two files that already fail on `develop` and were deliberately left in their existing form rather than mixing unrelated reformatting into this diff
- `npx jest tests/unit`: 33 suites, 228 passed, 1 skipped
- The Electrum error allowlist was checked by replaying real Android/iOS socket-error strings against hostnames deliberately containing token substrings, using the token array parsed from source

**Addresses screen**

- Reproduced and fixed on the iOS simulator (iPhone 17, iOS 26.4, Debug build against Metro): before, every row was covered by a QR code; after, the list renders normally
- On the fixed screen, all 42 `ContextMenu` nodes still carry their three actions and none carries a `preview` prop
- `npx eslint` and `npx prettier --check` clean on both changed files; `npx tsc --noEmit` clean; `npx jest tests/unit` unchanged at 33 suites, 228 passed, 1 skipped
