### PR TITLE
Report caught errors to Sentry, attribute logs, and fix the support id

### DIFF
--- a/App.js
+++ b/App.js
@@ -34,10 +34,10 @@ import Privacy from './blue_modules/Privacy';
 import { addEventListener } from '@react-native-community/netinfo';
 import { getUniqueIdSync } from 'react-native-device-info';
 import * as Sentry from '@sentry/react-native';
-// Not re-exported by @sentry/react-native. Both are pinned to exact versions so they
-// stay a single deduped instance: Sentry keys its carrier by SDK version, so a second
-// copy would make the integration's own client check never match and it would stop
-// filing issues silently.
+// Not re-exported by @sentry/react-native. Both are pinned to exact versions so they stay
+// a single deduped instance: Sentry keys its carrier by SDK version, so a copy at a
+// *different* version would get its own client, the integration's own client check would
+// never match, and it would stop filing issues silently.
 import { captureConsoleIntegration } from '@sentry/core';
 const BlueApp = require('./BlueApp');
 

--- a/App.js
+++ b/App.js
@@ -32,6 +32,7 @@ import WidgetCommunication from './blue_modules/WidgetCommunication';
 import HandoffComponent from './components/handoff';
 import Privacy from './blue_modules/Privacy';
 import { addEventListener } from '@react-native-community/netinfo';
+import { getUniqueIdSync } from 'react-native-device-info';
 import * as Sentry from '@sentry/react-native';
 // Not re-exported by @sentry/react-native. Both are pinned to exact versions so they
 // stay a single deduped instance: Sentry keys its carrier by SDK version, so a second
@@ -73,6 +74,13 @@ BlueApp.isDoNotTrackEnabled().then(doNotTrack => {
     // uncomment the line below to enable Spotlight (https://spotlightjs.com)
     // spotlight: __DEV__,
   });
+
+  // Identify the device here, not from analytics.js's own Do Not Track read: that
+  // module is imported first and so resolves first, and the scope->native bridge is
+  // installed inside init() without replaying a user set before it. Setting it there
+  // alone would leave native crashes carrying the SDK's own install id while JS
+  // events and logs carry this one - the same split this is meant to remove.
+  Sentry.setUser(doNotTrack ? null : { id: getUniqueIdSync() });
 });
 const currency = require('./blue_modules/currency');
 const BlueElectrum = require('./blue_modules/BlueElectrum');

--- a/App.js
+++ b/App.js
@@ -32,10 +32,11 @@ import WidgetCommunication from './blue_modules/WidgetCommunication';
 import HandoffComponent from './components/handoff';
 import Privacy from './blue_modules/Privacy';
 import { addEventListener } from '@react-native-community/netinfo';
-import { getUniqueIdSync } from 'react-native-device-info';
 import * as Sentry from '@sentry/react-native';
-// Not re-exported by @sentry/react-native, but it pins @sentry/core to an exact
-// version, so this resolves to the same deduped instance the SDK itself uses.
+// Not re-exported by @sentry/react-native. Both are pinned to exact versions so they
+// stay a single deduped instance: Sentry keys its carrier by SDK version, so a second
+// copy would make the integration's own client check never match and it would stop
+// filing issues silently.
 import { captureConsoleIntegration } from '@sentry/core';
 const BlueApp = require('./BlueApp');
 
@@ -72,15 +73,6 @@ BlueApp.isDoNotTrackEnabled().then(doNotTrack => {
     // uncomment the line below to enable Spotlight (https://spotlightjs.com)
     // spotlight: __DEV__,
   });
-
-  // Error events get a user id from the native layer, logs do not - the SDK's
-  // log enricher copies scope *attributes* onto each log but never the scope
-  // user. Without this every log row has user.id = null, so "6 Electrum drops"
-  // can't be told apart from "6 users affected". Same id the About screen shows
-  // for support, so this adds no identifier that isn't already reported.
-  if (!doNotTrack) {
-    Sentry.getGlobalScope().setAttributes({ 'user.id': getUniqueIdSync() });
-  }
 });
 const currency = require('./blue_modules/currency');
 const BlueElectrum = require('./blue_modules/BlueElectrum');

--- a/App.js
+++ b/App.js
@@ -32,7 +32,11 @@ import WidgetCommunication from './blue_modules/WidgetCommunication';
 import HandoffComponent from './components/handoff';
 import Privacy from './blue_modules/Privacy';
 import { addEventListener } from '@react-native-community/netinfo';
+import { getUniqueIdSync } from 'react-native-device-info';
 import * as Sentry from '@sentry/react-native';
+// Not re-exported by @sentry/react-native, but it pins @sentry/core to an exact
+// version, so this resolves to the same deduped instance the SDK itself uses.
+import { captureConsoleIntegration } from '@sentry/core';
 const BlueApp = require('./BlueApp');
 
 // blue_modules/analytics.js's setSentryEnabled() only toggles JS-side event
@@ -59,9 +63,24 @@ BlueApp.isDoNotTrackEnabled().then(doNotTrack => {
     // Enable Logs
     enableLogs: true,
 
+    // Without this, a caught error that only reaches console.error is recorded
+    // as a breadcrumb and a log, but never opens an issue - so nothing alerts on
+    // it. Errors only: console.warn is far too noisy (Electrum reconnects alone
+    // produce hundreds a day). Merged with the SDK's default integrations.
+    integrations: [captureConsoleIntegration({ levels: ['error'] })],
+
     // uncomment the line below to enable Spotlight (https://spotlightjs.com)
     // spotlight: __DEV__,
   });
+
+  // Error events get a user id from the native layer, logs do not - the SDK's
+  // log enricher copies scope *attributes* onto each log but never the scope
+  // user. Without this every log row has user.id = null, so "6 Electrum drops"
+  // can't be told apart from "6 users affected". Same id the About screen shows
+  // for support, so this adds no identifier that isn't already reported.
+  if (!doNotTrack) {
+    Sentry.getGlobalScope().setAttributes({ 'user.id': getUniqueIdSync() });
+  }
 });
 const currency = require('./blue_modules/currency');
 const BlueElectrum = require('./blue_modules/BlueElectrum');

--- a/BlueApp.js
+++ b/BlueApp.js
@@ -581,7 +581,11 @@ class AppStorage {
       // Error, not a bare string: the captureConsole integration titles an issue
       // after its own frame unless it finds an Error among the console args.
       if (++savingInProgress > 10)
-        console.error(new Error('saveToDisk: too many concurrent save attempts, last actions were not saved'), savingInProgress);
+        console.error(
+          'saveToDisk: too many concurrent save attempts, last actions were not saved',
+          new Error('saveToDisk: too many concurrent save attempts, last actions were not saved'),
+          savingInProgress,
+        );
       await new Promise(resolve => setTimeout(resolve, 1000 * savingInProgress)); // sleep
       return this.saveToDisk();
     }

--- a/BlueApp.js
+++ b/BlueApp.js
@@ -578,7 +578,10 @@ class AppStorage {
   async saveToDisk() {
     if (savingInProgress) {
       // should never happen
-      if (++savingInProgress > 10) console.error(`saveToDisk: ${savingInProgress} concurrent save attempts, last actions were not saved`);
+      // Error, not a bare string: the captureConsole integration titles an issue
+      // after its own frame unless it finds an Error among the console args.
+      if (++savingInProgress > 10)
+        console.error(new Error(`saveToDisk: ${savingInProgress} concurrent save attempts, last actions were not saved`));
       await new Promise(resolve => setTimeout(resolve, 1000 * savingInProgress)); // sleep
       return this.saveToDisk();
     }

--- a/BlueApp.js
+++ b/BlueApp.js
@@ -580,12 +580,12 @@ class AppStorage {
       // should never happen
       // Error, not a bare string: the captureConsole integration titles an issue
       // after its own frame unless it finds an Error among the console args.
-      if (++savingInProgress > 10)
-        console.error(
-          'saveToDisk: too many concurrent save attempts, last actions were not saved',
-          new Error('saveToDisk: too many concurrent save attempts, last actions were not saved'),
-          savingInProgress,
-        );
+      if (++savingInProgress > 10) {
+        // One literal: the string becomes the log message, the Error's message the issue
+        // title, and editing only one of two copies would make them disagree silently.
+        const error = new Error('saveToDisk: too many concurrent save attempts, last actions were not saved');
+        console.error(error.message, error, savingInProgress);
+      }
       await new Promise(resolve => setTimeout(resolve, 1000 * savingInProgress)); // sleep
       return this.saveToDisk();
     }

--- a/BlueApp.js
+++ b/BlueApp.js
@@ -581,7 +581,7 @@ class AppStorage {
       // Error, not a bare string: the captureConsole integration titles an issue
       // after its own frame unless it finds an Error among the console args.
       if (++savingInProgress > 10)
-        console.error(new Error(`saveToDisk: ${savingInProgress} concurrent save attempts, last actions were not saved`));
+        console.error(new Error('saveToDisk: too many concurrent save attempts, last actions were not saved'), savingInProgress);
       await new Promise(resolve => setTimeout(resolve, 1000 * savingInProgress)); // sleep
       return this.saveToDisk();
     }

--- a/api/dfx/contexts/language.context.tsx
+++ b/api/dfx/contexts/language.context.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 import { Language } from '../definitions/language';
-import { toError } from '../definitions/error';
+import { toError } from '../../../helpers/errors';
 import { useLanguage } from '../hooks/language.hook';
 
 interface LanguageInterface {
@@ -20,7 +20,7 @@ export function LanguageContextProvider(props: PropsWithChildren): React.JSX.Ele
   useEffect(() => {
     getLanguages()
       .then(setLanguages)
-      .catch(e => console.error(toError('LanguageContext: failed to load languages', e)));
+      .catch(e => console.error(toError('LanguageContext: failed to load languages', e), e));
   }, [getLanguages]);
 
   const context: LanguageInterface = useMemo(() => ({ languages: languages?.filter(l => l.enable) }), [languages]);

--- a/api/dfx/contexts/language.context.tsx
+++ b/api/dfx/contexts/language.context.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 import { Language } from '../definitions/language';
-import { toError } from '../../../helpers/errors';
+import { reportError } from '../../../helpers/errors';
 import { useLanguage } from '../hooks/language.hook';
 
 interface LanguageInterface {
@@ -20,7 +20,7 @@ export function LanguageContextProvider(props: PropsWithChildren): React.JSX.Ele
   useEffect(() => {
     getLanguages()
       .then(setLanguages)
-      .catch(e => console.error(toError('LanguageContext: failed to load languages', e), e));
+      .catch(e => reportError('LanguageContext: failed to load languages', e));
   }, [getLanguages]);
 
   const context: LanguageInterface = useMemo(() => ({ languages: languages?.filter(l => l.enable) }), [languages]);

--- a/api/dfx/contexts/language.context.tsx
+++ b/api/dfx/contexts/language.context.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 import { Language } from '../definitions/language';
+import { toError } from '../definitions/error';
 import { useLanguage } from '../hooks/language.hook';
 
 interface LanguageInterface {
@@ -19,7 +20,7 @@ export function LanguageContextProvider(props: PropsWithChildren): React.JSX.Ele
   useEffect(() => {
     getLanguages()
       .then(setLanguages)
-      .catch(e => console.error('LanguageContext: failed to load languages', e));
+      .catch(e => console.error(toError('LanguageContext: failed to load languages', e)));
   }, [getLanguages]);
 
   const context: LanguageInterface = useMemo(() => ({ languages: languages?.filter(l => l.enable) }), [languages]);

--- a/api/dfx/contexts/session.context.tsx
+++ b/api/dfx/contexts/session.context.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 import { Linking, Alert } from 'react-native';
-import { ApiError, toError } from '../definitions/error';
+import { ApiError } from '../definitions/error';
+import { toError } from '../../../helpers/errors';
 import { useWalletContext } from '../../../contexts/wallet.context';
 import Config from 'react-native-config';
 import jwtDecode from 'jwt-decode';
@@ -95,7 +96,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
         await call({ url: UserUrl.change, method: 'PUT', data: update }, token.accessToken);
       }
     } catch (e) {
-      console.error(toError('Failed to update language', e));
+      console.error(toError('Failed to update language', e), e);
     }
 
     return token;
@@ -170,10 +171,10 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
       // Both platforms put the whole URL in the rejection message, and this one carries the
       // session token and the balance. Replace it before it can reach an alert or a report.
       return await Linking.openURL(url).catch(() => {
-        throw new Error(`openServices: could not open the ${service} service`);
+        throw new Error(`openURL rejected for ${service}`);
       });
     } catch (e) {
-      console.error(toError('Failed to open services', e));
+      console.error(toError('Failed to open services', e), e);
       setIsUnavailable(true);
       throw e;
     }
@@ -195,7 +196,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
       connect(wallets.filter((w: any) => w.type !== MultisigHDWallet.type).map((w: any) => w.getID()))
         .then(() => setIsInitialized(true))
         .catch(e => {
-          console.error(toError('DFX session init failed', e));
+          console.error(toError('DFX session init failed', e), e);
           setIsUnavailable(true);
         });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/api/dfx/contexts/session.context.tsx
+++ b/api/dfx/contexts/session.context.tsx
@@ -191,7 +191,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
       connect(wallets.filter((w: any) => w.type !== MultisigHDWallet.type).map((w: any) => w.getID()))
         .then(() => setIsInitialized(true))
         .catch(e => {
-          console.error('DFX session init error: ', e.message?.toString());
+          console.error(new Error('DFX session init failed'), e.message?.toString());
           setIsUnavailable(true);
         });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/api/dfx/contexts/session.context.tsx
+++ b/api/dfx/contexts/session.context.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 import { Linking, Alert } from 'react-native';
-import { ApiError } from '../definitions/error';
+import { ApiError, toError } from '../definitions/error';
 import { useWalletContext } from '../../../contexts/wallet.context';
 import Config from 'react-native-config';
 import jwtDecode from 'jwt-decode';
@@ -95,7 +95,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
         await call({ url: UserUrl.change, method: 'PUT', data: update }, token.accessToken);
       }
     } catch (e) {
-      console.error('Failed to update language:', e);
+      console.error(toError('Failed to update language', e));
     }
 
     return token;
@@ -169,7 +169,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
       const url = `${Config.REACT_APP_SRV_URL}/${service}?session=${token}&balances=${balance}@BTC&redirect-uri=${redirectUri}&lang=${lang}`;
       return Linking.openURL(url);
     } catch (e) {
-      console.error('Failed to open services:', e);
+      console.error(toError('Failed to open services', e));
       setIsUnavailable(true);
       throw e;
     }
@@ -191,7 +191,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
       connect(wallets.filter((w: any) => w.type !== MultisigHDWallet.type).map((w: any) => w.getID()))
         .then(() => setIsInitialized(true))
         .catch(e => {
-          console.error('DFX session init failed', e);
+          console.error(toError('DFX session init failed', e));
           setIsUnavailable(true);
         });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/api/dfx/contexts/session.context.tsx
+++ b/api/dfx/contexts/session.context.tsx
@@ -191,7 +191,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
       connect(wallets.filter((w: any) => w.type !== MultisigHDWallet.type).map((w: any) => w.getID()))
         .then(() => setIsInitialized(true))
         .catch(e => {
-          console.error(new Error('DFX session init failed'), e.message?.toString());
+          console.error('DFX session init failed', e);
           setIsUnavailable(true);
         });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/api/dfx/contexts/session.context.tsx
+++ b/api/dfx/contexts/session.context.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, PropsWithChildren, useContext, useEffect, useMemo, useState } from 'react';
 import { Linking, Alert } from 'react-native';
 import { ApiError } from '../definitions/error';
-import { toError } from '../../../helpers/errors';
+import { reportError } from '../../../helpers/errors';
 import { useWalletContext } from '../../../contexts/wallet.context';
 import Config from 'react-native-config';
 import jwtDecode from 'jwt-decode';
@@ -96,7 +96,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
         await call({ url: UserUrl.change, method: 'PUT', data: update }, token.accessToken);
       }
     } catch (e) {
-      console.error(toError('Failed to update language', e), e);
+      reportError('Failed to update language', e);
     }
 
     return token;
@@ -174,7 +174,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
         throw new Error(`openURL rejected for ${service}`);
       });
     } catch (e) {
-      console.error(toError('Failed to open services', e), e);
+      reportError('Failed to open services', e);
       setIsUnavailable(true);
       throw e;
     }
@@ -196,7 +196,7 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
       connect(wallets.filter((w: any) => w.type !== MultisigHDWallet.type).map((w: any) => w.getID()))
         .then(() => setIsInitialized(true))
         .catch(e => {
-          console.error(toError('DFX session init failed', e), e);
+          reportError('DFX session init failed', e);
           setIsUnavailable(true);
         });
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/api/dfx/contexts/session.context.tsx
+++ b/api/dfx/contexts/session.context.tsx
@@ -167,7 +167,11 @@ export function DfxSessionContextProvider(props: PropsWithChildren<any>): React.
       const redirectUri = encodeURIComponent(`dfxtaro://?wallet-id=${walletId}`);
 
       const url = `${Config.REACT_APP_SRV_URL}/${service}?session=${token}&balances=${balance}@BTC&redirect-uri=${redirectUri}&lang=${lang}`;
-      return Linking.openURL(url);
+      // Both platforms put the whole URL in the rejection message, and this one carries the
+      // session token and the balance. Replace it before it can reach an alert or a report.
+      return await Linking.openURL(url).catch(() => {
+        throw new Error(`openServices: could not open the ${service} service`);
+      });
     } catch (e) {
       console.error(toError('Failed to open services', e));
       setIsUnavailable(true);

--- a/api/dfx/definitions/error.ts
+++ b/api/dfx/definitions/error.ts
@@ -3,13 +3,25 @@ export interface ApiError {
   message: string;
 }
 
-// api.hook.ts rejects with the parsed error body, which is an ApiError and not an Error.
-// Sentry files an issue from the first Error among the console arguments, so reporting a
-// raw body would collapse every failure into a single stackless issue titled
-// "... [object Object]". Normalize before logging: a real Error keeps its own message and
-// stack, a body becomes one titled by status so failures still group per cause.
+// api.hook.ts rejects with the parsed error body, which is an ApiError and not an Error, and
+// Sentry files an issue from the first Error among the console arguments. Reporting a raw
+// body would collapse every failure into one stackless issue titled "... [object Object]".
+//
+// Always wrap, including when the rejection already is an Error: the wrapper's stack points
+// at the call site, which is what keeps issues separated per site. Returning the original
+// unchanged instead would drop `context` and, for the commonest mobile failure of all
+// (`TypeError: Network request failed`, thrown with no app frames), merge every site in the
+// app into one unattributable issue. The original stays reachable as a linked exception.
 export function toError(context: string, e: unknown): Error {
-  if (e instanceof Error) return e;
-  const { statusCode, message } = (e ?? {}) as Partial<ApiError>;
-  return new Error(`${context} (${statusCode ?? 'network'}): ${message ?? String(e)}`);
+  const cause = e instanceof Error ? e : undefined;
+  const { statusCode, message } = (cause ? {} : (e ?? {})) as Partial<ApiError>;
+  // String() only reads well for primitives: an object gives "[object Object]", and a
+  // missing rejection gives the literal "undefined".
+  const detail = cause?.message ?? message ?? (e == null || typeof e === 'object' ? undefined : String(e));
+  const error = new Error(detail ? `${context}: ${detail}` : context);
+  // Once a stack contributes, Sentry groups on the exception type and ignores the message,
+  // so the status has to go in the type for a 400 and a 500 from one site to stay apart.
+  error.name = statusCode ? `ApiError${statusCode}` : 'ApiError';
+  if (cause) (error as Error & { cause?: unknown }).cause = cause;
+  return error;
 }

--- a/api/dfx/definitions/error.ts
+++ b/api/dfx/definitions/error.ts
@@ -2,3 +2,14 @@ export interface ApiError {
   statusCode: number;
   message: string;
 }
+
+// api.hook.ts rejects with the parsed error body, which is an ApiError and not an Error.
+// Sentry files an issue from the first Error among the console arguments, so reporting a
+// raw body would collapse every failure into a single stackless issue titled
+// "... [object Object]". Normalize before logging: a real Error keeps its own message and
+// stack, a body becomes one titled by status so failures still group per cause.
+export function toError(context: string, e: unknown): Error {
+  if (e instanceof Error) return e;
+  const { statusCode, message } = (e ?? {}) as Partial<ApiError>;
+  return new Error(`${context} (${statusCode ?? 'network'}): ${message ?? String(e)}`);
+}

--- a/api/dfx/definitions/error.ts
+++ b/api/dfx/definitions/error.ts
@@ -2,26 +2,3 @@ export interface ApiError {
   statusCode: number;
   message: string;
 }
-
-// api.hook.ts rejects with the parsed error body, which is an ApiError and not an Error, and
-// Sentry files an issue from the first Error among the console arguments. Reporting a raw
-// body would collapse every failure into one stackless issue titled "... [object Object]".
-//
-// Always wrap, including when the rejection already is an Error: the wrapper's stack points
-// at the call site, which is what keeps issues separated per site. Returning the original
-// unchanged instead would drop `context` and, for the commonest mobile failure of all
-// (`TypeError: Network request failed`, thrown with no app frames), merge every site in the
-// app into one unattributable issue. The original stays reachable as a linked exception.
-export function toError(context: string, e: unknown): Error {
-  const cause = e instanceof Error ? e : undefined;
-  const { statusCode, message } = (cause ? {} : (e ?? {})) as Partial<ApiError>;
-  // String() only reads well for primitives: an object gives "[object Object]", and a
-  // missing rejection gives the literal "undefined".
-  const detail = cause?.message ?? message ?? (e == null || typeof e === 'object' ? undefined : String(e));
-  const error = new Error(detail ? `${context}: ${detail}` : context);
-  // Once a stack contributes, Sentry groups on the exception type and ignores the message,
-  // so the status has to go in the type for a 400 and a 500 from one site to stay apart.
-  error.name = statusCode ? `ApiError${statusCode}` : 'ApiError';
-  if (cause) (error as Error & { cause?: unknown }).cause = cause;
-  return error;
-}

--- a/blue_modules/analytics.js
+++ b/blue_modules/analytics.js
@@ -56,12 +56,20 @@ A.setOptOut = value => {
   setSentryEnabled(!value);
 };
 
-// App.js's captureConsole integration already turns console.error into an issue,
-// so capturing here as well would file every error twice. Passing an Error (not a
-// string) is what makes that integration capture an exception with a stack rather
-// than a bare message.
+// App.js's captureConsole integration already turns console.error into an issue, so
+// capturing here as well would file every error twice. It has to be handed an Error, not a
+// string, for that integration to file an exception with a stack rather than a bare message
+// - but the message goes first, because the console-to-logs integration only emits its
+// template attributes when the first argument is a string. captureConsole still finds the
+// Error, since it takes the first Error among the arguments rather than the first argument.
 A.logError = errorString => {
-  console.error(errorString instanceof Error ? errorString : new Error(String(errorString)));
+  const error = errorString instanceof Error ? errorString : new Error(String(errorString));
+  // Only when this constructed it: otherwise the top frame is this function, and every issue
+  // filed through logError would be blamed on analytics.js rather than on its caller.
+  if (!(errorString instanceof Error)) {
+    Object.defineProperty(error, 'framesToPop', { value: 1, writable: true, configurable: true });
+  }
+  console.error(error.message, error);
 };
 
 module.exports = A;

--- a/blue_modules/analytics.js
+++ b/blue_modules/analytics.js
@@ -1,5 +1,7 @@
 const BlueApp = require('../BlueApp');
 const Sentry = require('@sentry/react-native');
+const { captureConsoleIntegration } = require('@sentry/core');
+const { getUniqueIdSync } = require('react-native-device-info');
 
 // App.js defers Sentry.init() behind its own isDoNotTrackEnabled() read (so native
 // crash handling, which can only be gated at init time, respects opt-out from the
@@ -10,7 +12,21 @@ const setSentryEnabled = enabled => {
   const client = Sentry.getClient();
   if (client) {
     client.getOptions().enabled = enabled;
+    // Sentry.init() only wires integrations up when the client is enabled at that
+    // moment, and flipping `enabled` afterwards cannot install them. Without this,
+    // a user who launches with Do Not Track on and then turns it off would get no
+    // console capture at all until the next app start.
+    if (enabled && !client.getIntegrationByName('CaptureConsole')) {
+      Sentry.addIntegration(captureConsoleIntegration({ levels: ['error'] }));
+    }
   }
+  // Identify the device on both error events and logs. Without a scope user the
+  // native layer fills in its own install id, but only for error events - a log row
+  // then carries no user at all, and the two ids are different values that cannot be
+  // joined. Setting it here uses one id for both, the same one the About screen
+  // offers to copy for support, and tracks the opt-out toggle live rather than only
+  // at init. See docs/crash-reports.md for what this id is.
+  Sentry.setUser(enabled ? { id: getUniqueIdSync() } : null);
 };
 
 // Re-applies the persisted opt-out choice independently of App.js's own init-time

--- a/blue_modules/analytics.js
+++ b/blue_modules/analytics.js
@@ -16,9 +16,10 @@ const setSentryEnabled = enabled => {
       // user who launched with Do Not Track on has NONE installed - not just no
       // console capture, but no error handlers, no frame rewriting (so source maps
       // cannot match) and no dedupe. The resolved list is on the options either
-      // way; installing a name that is already installed is a no-op. Integrations
-      // that need the native SDK are absent from it, because enableNative was false
-      // at init - native reporting only comes back on the next app start.
+      // way; installing a name that is already installed is a no-op. What this cannot
+      // bring back is anything behind the SDK's enableNative gate, which was false at
+      // init - that covers the console-to-logs integrations too, not just native-only
+      // ones, so neither native reporting nor log records resume before a restart.
       client.getOptions().integrations.forEach(integration => Sentry.addIntegration(integration));
     }
   }

--- a/blue_modules/analytics.js
+++ b/blue_modules/analytics.js
@@ -1,6 +1,5 @@
 const BlueApp = require('../BlueApp');
 const Sentry = require('@sentry/react-native');
-const { captureConsoleIntegration } = require('@sentry/core');
 const { getUniqueIdSync } = require('react-native-device-info');
 
 // App.js defers Sentry.init() behind its own isDoNotTrackEnabled() read (so native
@@ -12,12 +11,15 @@ const setSentryEnabled = enabled => {
   const client = Sentry.getClient();
   if (client) {
     client.getOptions().enabled = enabled;
-    // Sentry.init() only wires integrations up when the client is enabled at that
-    // moment, and flipping `enabled` afterwards cannot install them. Without this,
-    // a user who launches with Do Not Track on and then turns it off would get no
-    // console capture at all until the next app start.
-    if (enabled && !client.getIntegrationByName('CaptureConsole')) {
-      Sentry.addIntegration(captureConsoleIntegration({ levels: ['error'] }));
+    if (enabled) {
+      // Sentry.init() skips integration setup entirely on a disabled client, so a
+      // user who launched with Do Not Track on has NONE installed - not just no
+      // console capture, but no error handlers, no frame rewriting (so source maps
+      // cannot match) and no dedupe. The resolved list is on the options either
+      // way; installing a name that is already installed is a no-op. Integrations
+      // that need the native SDK are absent from it, because enableNative was false
+      // at init - native reporting only comes back on the next app start.
+      client.getOptions().integrations.forEach(integration => Sentry.addIntegration(integration));
     }
   }
   // Identify the device on both error events and logs. Without a scope user the

--- a/blue_modules/analytics.js
+++ b/blue_modules/analytics.js
@@ -37,9 +37,12 @@ A.setOptOut = value => {
   setSentryEnabled(!value);
 };
 
+// App.js's captureConsole integration already turns console.error into an issue,
+// so capturing here as well would file every error twice. Passing an Error (not a
+// string) is what makes that integration capture an exception with a stack rather
+// than a bare message.
 A.logError = errorString => {
-  console.error(errorString);
-  Sentry.captureException(errorString instanceof Error ? errorString : new Error(String(errorString)));
+  console.error(errorString instanceof Error ? errorString : new Error(String(errorString)));
 };
 
 module.exports = A;

--- a/blue_modules/analytics.js
+++ b/blue_modules/analytics.js
@@ -63,7 +63,9 @@ A.setOptOut = value => {
 // template attributes when the first argument is a string. captureConsole still finds the
 // Error, since it takes the first Error among the arguments rather than the first argument.
 A.logError = errorString => {
-  const error = errorString instanceof Error ? errorString : new Error(String(errorString));
+  // Flattened for the same reason as helpers/errors.ts: a stack is just a string, so
+  // newlines in the value would parse as frames and absorb the pop below.
+  const error = errorString instanceof Error ? errorString : new Error(String(errorString).replace(/\s+/g, ' ').trim());
   // Only when this constructed it: otherwise the top frame is this function, and every issue
   // filed through logError would be blamed on analytics.js rather than on its caller.
   if (!(errorString instanceof Error)) {

--- a/blue_modules/fs.js
+++ b/blue_modules/fs.js
@@ -26,7 +26,7 @@ const writeFileAndExportToAndroidDestionation = async ({ filename, contents, des
     } catch (e) {
       // The message contains the full path, and filename is a wallet label at
       // some call sites - report the code only.
-      console.error('fs: writeFile to Android destination failed', e?.code ?? 'write failed');
+      console.error(new Error('fs: writeFile to Android destination failed'), e?.code ?? 'write failed');
       alert(e.message);
     }
   } else {

--- a/blue_modules/fs.js
+++ b/blue_modules/fs.js
@@ -26,7 +26,11 @@ const writeFileAndExportToAndroidDestionation = async ({ filename, contents, des
     } catch (e) {
       // The message contains the full path, and filename is a wallet label at
       // some call sites - report the code only.
-      console.error(new Error('fs: writeFile to Android destination failed'), e?.code ?? 'write failed');
+      console.error(
+        'fs: writeFile to Android destination failed',
+        new Error('fs: writeFile to Android destination failed'),
+        e?.code ?? 'write failed',
+      );
       alert(e.message);
     }
   } else {

--- a/blue_modules/fs.js
+++ b/blue_modules/fs.js
@@ -26,11 +26,8 @@ const writeFileAndExportToAndroidDestionation = async ({ filename, contents, des
     } catch (e) {
       // The message contains the full path, and filename is a wallet label at
       // some call sites - report the code only.
-      console.error(
-        'fs: writeFile to Android destination failed',
-        new Error('fs: writeFile to Android destination failed'),
-        e?.code ?? 'write failed',
-      );
+      const error = new Error('fs: writeFile to Android destination failed');
+      console.error(error.message, error, e?.code ?? 'write failed');
       alert(e.message);
     }
   } else {

--- a/contexts/wallet.context.tsx
+++ b/contexts/wallet.context.tsx
@@ -55,7 +55,7 @@ export function WalletContextProvider(props: PropsWithChildren<any>): React.JSX.
         try {
           return await wallets?.[0]?.signMessage(message, address);
         } catch (e: any) {
-          console.error(e.message, e.code);
+          console.error(new Error('signMessage failed'), e.message, e.code);
           throw e;
         }
       },

--- a/contexts/wallet.context.tsx
+++ b/contexts/wallet.context.tsx
@@ -2,6 +2,7 @@ import React, { createContext, PropsWithChildren, useContext, useMemo } from 're
 import { BlueStorageContext } from '../blue_modules/storage-context';
 import { useAuth } from '../api/dfx/hooks/auth.hook';
 import { AbstractWallet } from '../class';
+import { toError } from '../api/dfx/definitions/error';
 
 interface WalletInterface {
   wallet?: AbstractWallet
@@ -55,7 +56,7 @@ export function WalletContextProvider(props: PropsWithChildren<any>): React.JSX.
         try {
           return await wallets?.[0]?.signMessage(message, address);
         } catch (e: any) {
-          console.error('signMessage failed', e);
+          console.error(toError('signMessage failed', e));
           throw e;
         }
       },

--- a/contexts/wallet.context.tsx
+++ b/contexts/wallet.context.tsx
@@ -2,7 +2,7 @@ import React, { createContext, PropsWithChildren, useContext, useMemo } from 're
 import { BlueStorageContext } from '../blue_modules/storage-context';
 import { useAuth } from '../api/dfx/hooks/auth.hook';
 import { AbstractWallet } from '../class';
-import { toError } from '../helpers/errors';
+import { reportError } from '../helpers/errors';
 
 interface WalletInterface {
   wallet?: AbstractWallet
@@ -56,7 +56,7 @@ export function WalletContextProvider(props: PropsWithChildren<any>): React.JSX.
         try {
           return await wallets?.[0]?.signMessage(message, address);
         } catch (e: any) {
-          console.error(toError('signMessage failed', e), e);
+          reportError('signMessage failed', e);
           throw e;
         }
       },

--- a/contexts/wallet.context.tsx
+++ b/contexts/wallet.context.tsx
@@ -55,7 +55,7 @@ export function WalletContextProvider(props: PropsWithChildren<any>): React.JSX.
         try {
           return await wallets?.[0]?.signMessage(message, address);
         } catch (e: any) {
-          console.error(new Error('signMessage failed'), e.message, e.code);
+          console.error('signMessage failed', e);
           throw e;
         }
       },

--- a/contexts/wallet.context.tsx
+++ b/contexts/wallet.context.tsx
@@ -2,7 +2,7 @@ import React, { createContext, PropsWithChildren, useContext, useMemo } from 're
 import { BlueStorageContext } from '../blue_modules/storage-context';
 import { useAuth } from '../api/dfx/hooks/auth.hook';
 import { AbstractWallet } from '../class';
-import { toError } from '../api/dfx/definitions/error';
+import { toError } from '../helpers/errors';
 
 interface WalletInterface {
   wallet?: AbstractWallet
@@ -56,7 +56,7 @@ export function WalletContextProvider(props: PropsWithChildren<any>): React.JSX.
         try {
           return await wallets?.[0]?.signMessage(message, address);
         } catch (e: any) {
-          console.error(toError('signMessage failed', e));
+          console.error(toError('signMessage failed', e), e);
           throw e;
         }
       },

--- a/docs/crash-reports.md
+++ b/docs/crash-reports.md
@@ -35,8 +35,11 @@ about it:
   started at all.
 - **Turning it off** re-attaches the id and installs the JS integrations that `Sentry.init()`
   skipped while the client was disabled, so caught errors, uncaught errors and source-map
-  frame rewriting all resume. Native reporting does **not** resume: `enableNative` is fixed
-  at init and only takes effect on the next app start.
+  frame rewriting all resume. Two things do **not** resume until the next app start, both
+  because the SDK puts them behind its `enableNative` gate, which is fixed at init: native
+  crash reporting, and log records — the console-to-logs integration sits behind that same
+  gate even though it is pure JS. So a session that launched opted out reports errors as
+  issues, but sends no logs.
 
 The Apple-native flow below (Organizer/App Store Connect crash reports, no SDK involved)
 still works as a fallback — for example for a user who's opted out of Sentry via Do Not

--- a/docs/crash-reports.md
+++ b/docs/crash-reports.md
@@ -3,7 +3,30 @@
 The app ships the Sentry SDK (`@sentry/react-native`, self-hosted at `sentry.dfxserve.com`),
 which is now the primary way JS and native crashes/errors reach us — see `App.js` for the
 `Sentry.init()` config and `blue_modules/analytics.js` for how it respects the in-app
-Do Not Track toggle. No PII is collected (`sendDefaultPii: false`).
+Do Not Track toggle.
+
+What is reported, when Do Not Track is off:
+
+- **Crashes and uncaught errors**, as before.
+- **Caught errors that reach `console.error`**, filed as issues by the `captureConsole`
+  integration (error level only — `console.warn` stays a breadcrumb and a log). Without
+  this a handled error was recorded but never alerted on.
+- **The device support id** shown on the About screen, set as the Sentry user id so it
+  appears on both error events and log records. Without it a log row carries no user at
+  all, and one device failing repeatedly cannot be told apart from many devices failing
+  once.
+
+  Note what this id is: `react-native-device-info`'s `getUniqueIdSync()` — `identifierForVendor`
+  on iOS, `ANDROID_ID` on Android. It is more durable than what the SDK reports on its own
+  (a random per-install UUID that resets on reinstall): `ANDROID_ID` is stable per device and
+  signing key and survives reinstalling the app. It is used deliberately, because it is the
+  id the About screen offers the user to copy for support — using anything else means a
+  support request cannot be matched to its telemetry.
+
+No PII beyond that id is collected (`sendDefaultPii: false` — no IP address, cookies, or
+user profile). Turning Do Not Track on stops event delivery and clears the id from the
+JS and native scopes; turning it back off re-attaches it and re-registers the console
+capture without needing a restart.
 
 The Apple-native flow below (Organizer/App Store Connect crash reports, no SDK involved)
 still works as a fallback — for example for a user who's opted out of Sentry via Do Not

--- a/docs/crash-reports.md
+++ b/docs/crash-reports.md
@@ -24,9 +24,19 @@ What is reported, when Do Not Track is off:
   support request cannot be matched to its telemetry.
 
 No PII beyond that id is collected (`sendDefaultPii: false` — no IP address, cookies, or
-user profile). Turning Do Not Track on stops event delivery and clears the id from the
-JS and native scopes; turning it back off re-attaches it and re-registers the console
-capture without needing a restart.
+user profile).
+
+Toggling Do Not Track mid-session does not do everything a restart does, so be precise
+about it:
+
+- **Turning it on** stops the JS client from sending immediately and clears the id from
+  the JS and native scopes. The native SDK was already started, though, and only JS-side
+  delivery is gated — it keeps running until the app is restarted, after which it is not
+  started at all.
+- **Turning it off** re-attaches the id and installs the JS integrations that `Sentry.init()`
+  skipped while the client was disabled, so caught errors, uncaught errors and source-map
+  frame rewriting all resume. Native reporting does **not** resume: `enableNative` is fixed
+  at init and only takes effect on the next app start.
 
 The Apple-native flow below (Organizer/App Store Connect crash reports, no SDK involved)
 still works as a fallback — for example for a user who's opted out of Sentry via Do Not

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -53,11 +53,15 @@ function toError(context: string, e: unknown, framesToPop: number): Error {
   // literal "Error: " in it, so a type that does not end in Error leaves the header to be
   // parsed as a frame whenever the message looks path-like - which a 404 body routinely does.
   // That phantom frame then absorbs the pop below and the culprit reverts to this helper.
-  const type = typeof statusCode === 'number' ? `Api${statusCode}Error` : cause?.name || 'ApiError';
+  // cause.name is third-party input like the rest of the body, so it is type-guarded the same
+  // way - without that, the endsWith() below throws on a non-string name, out of a catch block.
+  const type = typeof statusCode === 'number' ? `Api${statusCode}Error` : (typeof cause?.name === 'string' && cause.name) || 'ApiError';
   // The suffix is the invariant, not just a naming style, so enforce it on the cause's own
   // type too: that value comes from third-party code and an empty or Error-less name would
   // leave the header parseable again. `||` rather than `??` so an empty name is replaced.
-  error.name = type.includes('Error') ? type : `${type}Error`;
+  // endsWith, not includes: the parser looks for the literal "Error: ", so a name that merely
+  // contains Error - ErrorHandler, ErrorEvent - leaves the header just as parseable as Timeout.
+  error.name = type.endsWith('Error') ? type : `${type}Error`;
   // Deliberately NOT attached as `cause`: the RN SDK's linked-errors integration appends,
   // and Sentry titles an issue from the last exception, so chaining would put the original
   // back in the title and undo the attribution above. reportError() passes it as a trailing

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -1,6 +1,31 @@
 import { ApiError } from '../api/dfx/definitions/error';
 
 const MAX_DETAIL_LENGTH = 200;
+const MAX_TYPE_LENGTH = 60;
+
+// Derives the exception type, which is what Sentry groups on once a stack contributes.
+//
+// The invariant is that it ENDS in "Error": the stack parser skips the header line by looking
+// for the literal "Error: ", and a type without that suffix leaves the header to be parsed as
+// a phantom frame that absorbs the frame pop, putting the culprit back on this helper.
+//
+// Everything here is third-party input reached from inside a catch block, so nothing is
+// allowed to throw: `name` can be a getter, and a getter is somebody else's code.
+function deriveType(statusCode: unknown, cause: Error | undefined): string {
+  if (typeof statusCode === 'number') return `Api${statusCode}Error`;
+
+  let name: unknown;
+  try {
+    name = cause?.name;
+  } catch {
+    name = undefined;
+  }
+  // Flattened and capped for the same reasons as the detail: a newline would land in the
+  // stack header, and the type is half the issue title.
+  const base = typeof name === 'string' ? name.replace(/\s+/g, ' ').trim().slice(0, MAX_TYPE_LENGTH) : '';
+  const type = base || 'ApiError';
+  return type.endsWith('Error') ? type : `${type}Error`;
+}
 
 // Renders whatever is left of a rejection once the known shapes are exhausted. Objects are
 // serialized rather than String()'d, which would only ever give "[object Object]"; anything
@@ -43,25 +68,9 @@ function toError(context: string, e: unknown, framesToPop: number): Error {
   const flat = raw?.replace(/\s+/g, ' ').trim();
   const detail = flat && flat.length > MAX_DETAIL_LENGTH ? `${flat.slice(0, MAX_DETAIL_LENGTH)}...` : flat;
   const error = new Error(detail ? `${context}: ${detail}` : context);
-  // Once a stack contributes, Sentry groups on the exception type and ignores the message,
-  // so the status has to go in the type for a 400 and a 500 from one site to stay apart.
-  // Keep a non-API cause's own type: an NFC or signing failure is not an ApiError.
-  // Type-guarded like `message` above: a body with a non-numeric statusCode would otherwise
-  // put "[object Object]" straight back into the title, which is half of what this prevents.
-  //
-  // Api404Error, not ApiError404: the stack parser skips the header line by looking for the
-  // literal "Error: " in it, so a type that does not end in Error leaves the header to be
-  // parsed as a frame whenever the message looks path-like - which a 404 body routinely does.
-  // That phantom frame then absorbs the pop below and the culprit reverts to this helper.
-  // cause.name is third-party input like the rest of the body, so it is type-guarded the same
-  // way - without that, the endsWith() below throws on a non-string name, out of a catch block.
-  const type = typeof statusCode === 'number' ? `Api${statusCode}Error` : (typeof cause?.name === 'string' && cause.name) || 'ApiError';
-  // The suffix is the invariant, not just a naming style, so enforce it on the cause's own
-  // type too: that value comes from third-party code and an empty or Error-less name would
-  // leave the header parseable again. `||` rather than `??` so an empty name is replaced.
-  // endsWith, not includes: the parser looks for the literal "Error: ", so a name that merely
-  // contains Error - ErrorHandler, ErrorEvent - leaves the header just as parseable as Timeout.
-  error.name = type.endsWith('Error') ? type : `${type}Error`;
+  // Api404Error rather than ApiError404, and a non-API cause keeps its own type: an NFC or
+  // signing failure is not an ApiError. See deriveType for why the suffix matters.
+  error.name = deriveType(statusCode, cause);
   // Deliberately NOT attached as `cause`: the RN SDK's linked-errors integration appends,
   // and Sentry titles an issue from the last exception, so chaining would put the original
   // back in the title and undo the attribution above. reportError() passes it as a trailing

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -1,15 +1,16 @@
 import { ApiError } from '../api/dfx/definitions/error';
 
-const MAX_BODY_LENGTH = 200;
+const MAX_DETAIL_LENGTH = 200;
 
 // Renders whatever is left of a rejection once the known shapes are exhausted. Objects are
 // serialized rather than String()'d, which would only ever give "[object Object]"; anything
 // unserializable (circular) is dropped rather than allowed to throw out of a catch block.
+// Length is capped by the caller, so both this and a body-supplied `message` get bounded.
 function describe(e: unknown): string | undefined {
   if (e == null) return undefined;
   if (typeof e !== 'object') return String(e);
   try {
-    return JSON.stringify(e)?.slice(0, MAX_BODY_LENGTH);
+    return JSON.stringify(e);
   } catch {
     return undefined;
   }
@@ -24,25 +25,56 @@ function describe(e: unknown): string | undefined {
 // value reads "... [object Object]" whatever went wrong, and a 400 and a 500 from one site
 // are indistinguishable.
 //
-// Always wrap, including when the rejection already is an Error: the wrapper's stack points
-// at the call site, which is what keeps issues separated per site. Returning the original
+// Always wrap, including when the rejection already is an Error: the wrapper is built at the
+// call site, which is what keeps issues separated per site. Returning the original
 // unchanged instead would drop `context` and, for the commonest mobile failure of all
 // (`TypeError: Network request failed`, thrown inside the fetch polyfill with no app
 // frames), merge every site in the app into one unattributable issue.
-export function toError(context: string, e: unknown): Error {
+export function toError(context: string, e: unknown, framesToPop = 1): Error {
   const cause = e instanceof Error ? e : undefined;
   const { statusCode, message } = (cause ? {} : (e ?? {})) as Partial<ApiError>;
   // Not every backend answers with {statusCode, message} - LNbits replies {"detail": ...} -
   // so an unrecognized body would otherwise reach the title as nothing at all.
-  const detail = cause?.message ?? (typeof message === 'string' ? message : undefined) ?? (cause ? undefined : describe(e));
+  const raw = cause?.message ?? (typeof message === 'string' ? message : undefined) ?? (cause ? undefined : describe(e));
+  // Cap whatever came off the wire, not just the serialized branch: `message` is from the
+  // same untrusted body and would otherwise reach the title at any length.
+  const detail = raw && raw.length > MAX_DETAIL_LENGTH ? `${raw.slice(0, MAX_DETAIL_LENGTH)}...` : raw;
   const error = new Error(detail ? `${context}: ${detail}` : context);
   // Once a stack contributes, Sentry groups on the exception type and ignores the message,
   // so the status has to go in the type for a 400 and a 500 from one site to stay apart.
   // Keep a non-API cause's own type: an NFC or signing failure is not an ApiError.
-  error.name = statusCode ? `ApiError${statusCode}` : (cause?.name ?? 'ApiError');
+  // Type-guarded like `message` above: a body with a non-numeric statusCode would otherwise
+  // put "[object Object]" straight back into the title, which is half of what this prevents.
+  error.name = typeof statusCode === 'number' ? `ApiError${statusCode}` : (cause?.name ?? 'ApiError');
   // Deliberately NOT attached as `cause`: the RN SDK's linked-errors integration appends,
   // and Sentry titles an issue from the last exception, so chaining would put the original
   // back in the title and undo the attribution above. Callers pass it as a second console
-  // argument instead, which keeps its stack and own properties in extra.arguments.
+  // argument instead, so its message and own properties land in extra.arguments.
+  //
+  // The cost, accepted knowingly: when the original did carry app frames - an NFC or signing
+  // failure - only the wrapper's stack is parsed, so the issue points at the catch block
+  // rather than at the throw site, and the original's stack survives only as an
+  // unsymbolicated string. Passing the original through instead would keep those frames, but
+  // it cannot be told apart at runtime from a network TypeError, which carries none - and
+  // letting those through merges every network failure in the app into one unattributable
+  // issue. Per-site attribution for all of them beats exact frames for some of them.
+  //
+  // The Error is constructed in here, so without this the top frame - and therefore the
+  // culprit shown on every issue - would be this helper rather than the caller. Passed in
+  // rather than redefined afterwards: the property is non-enumerable, to stay out of
+  // serialization, and so also non-configurable, which makes a second write throw.
+  Object.defineProperty(error, 'framesToPop', { value: framesToPop });
   return error;
+}
+
+// Reports a caught rejection: the issue gets a per-site exception, the log keeps a readable
+// template, and the original stays inspectable.
+//
+// The context goes first because the console-to-logs integration only builds a message
+// template when the first argument is a string - with an Error there, the log body becomes a
+// JSON blob of the whole stack. captureConsole is unaffected either way: it takes the first
+// *Error* among the arguments, which is still the wrapper.
+export function reportError(context: string, e: unknown): void {
+  // Two frames, not one: toError built the Error, and it was called from in here.
+  console.error(context, toError(context, e, 2), e);
 }

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -1,6 +1,7 @@
 import { ApiError } from '../api/dfx/definitions/error';
 
 const MAX_DETAIL_LENGTH = 200;
+const MAX_RAW_LENGTH = 10_000;
 const MAX_TYPE_LENGTH = 60;
 
 // Reads one property off a rejection. Anything reached from a catch block is third-party
@@ -38,7 +39,9 @@ function deriveType(statusCode: unknown, cause: Error | undefined): string {
 // Length is capped by the caller, so both this and a body-supplied `message` get bounded.
 function describe(e: unknown): string | undefined {
   if (e == null) return undefined;
-  if (typeof e !== 'object') return String(e);
+  // String() runs toString/valueOf/Symbol.toPrimitive - somebody else's code again, and
+  // `typeof e !== 'object'` is true for functions, which can carry all three.
+  if (typeof e !== 'object') return safeRead(() => String(e));
   try {
     return JSON.stringify(e);
   } catch {
@@ -61,7 +64,10 @@ function describe(e: unknown): string | undefined {
 // (`TypeError: Network request failed`, thrown inside the fetch polyfill with no app
 // frames), merge every site in the app into one unattributable issue.
 function toError(context: string, e: unknown, framesToPop: number): Error {
-  const cause = e instanceof Error ? e : undefined;
+  // instanceof consults the prototype chain, which a Proxy can trap - the last place in here
+  // where third-party code runs. A hostile one falls through to the body branch, where every
+  // read is already guarded.
+  const cause = safeRead(() => (e instanceof Error ? e : undefined));
   const body = cause ? undefined : (e as Partial<ApiError> | undefined);
   // Every read below can be a getter - somebody else's function - and all of this runs inside
   // a catch block, so none of it may throw. deriveType guards `name` the same way.
@@ -78,7 +84,9 @@ function toError(context: string, e: unknown, framesToPop: number): Error {
   // just a string: injected "    at ..." lines parse as real frames, which both pushes the
   // true frames down past the pop below and lets the remote end choose what the issue blames.
   // Capping alone would not help - the injection fits well inside the limit.
-  const flat = raw?.replace(/\s+/g, ' ').trim();
+  // Bounded well above MAX_DETAIL_LENGTH before the regex runs: serializing a deep object
+  // graph can produce a very large string, and flattening that is the expensive part.
+  const flat = raw?.slice(0, MAX_RAW_LENGTH).replace(/\s+/g, ' ').trim();
   const detail = flat && flat.length > MAX_DETAIL_LENGTH ? `${flat.slice(0, MAX_DETAIL_LENGTH)}...` : flat;
   const error = new Error(detail ? `${context}: ${detail}` : context);
   // Api404Error rather than ApiError404, and a non-API cause keeps its own type: an NFC or

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -30,26 +30,34 @@ function describe(e: unknown): string | undefined {
 // unchanged instead would drop `context` and, for the commonest mobile failure of all
 // (`TypeError: Network request failed`, thrown inside the fetch polyfill with no app
 // frames), merge every site in the app into one unattributable issue.
-export function toError(context: string, e: unknown, framesToPop = 1): Error {
+function toError(context: string, e: unknown, framesToPop: number): Error {
   const cause = e instanceof Error ? e : undefined;
   const { statusCode, message } = (cause ? {} : (e ?? {})) as Partial<ApiError>;
   // Not every backend answers with {statusCode, message} - LNbits replies {"detail": ...} -
   // so an unrecognized body would otherwise reach the title as nothing at all.
   const raw = cause?.message ?? (typeof message === 'string' ? message : undefined) ?? (cause ? undefined : describe(e));
-  // Cap whatever came off the wire, not just the serialized branch: `message` is from the
-  // same untrusted body and would otherwise reach the title at any length.
-  const detail = raw && raw.length > MAX_DETAIL_LENGTH ? `${raw.slice(0, MAX_DETAIL_LENGTH)}...` : raw;
+  // Flatten before capping. A server-supplied message can contain newlines, and the stack is
+  // just a string: injected "    at ..." lines parse as real frames, which both pushes the
+  // true frames down past the pop below and lets the remote end choose what the issue blames.
+  // Capping alone would not help - the injection fits well inside the limit.
+  const flat = raw?.replace(/\s+/g, ' ').trim();
+  const detail = flat && flat.length > MAX_DETAIL_LENGTH ? `${flat.slice(0, MAX_DETAIL_LENGTH)}...` : flat;
   const error = new Error(detail ? `${context}: ${detail}` : context);
   // Once a stack contributes, Sentry groups on the exception type and ignores the message,
   // so the status has to go in the type for a 400 and a 500 from one site to stay apart.
   // Keep a non-API cause's own type: an NFC or signing failure is not an ApiError.
   // Type-guarded like `message` above: a body with a non-numeric statusCode would otherwise
   // put "[object Object]" straight back into the title, which is half of what this prevents.
-  error.name = typeof statusCode === 'number' ? `ApiError${statusCode}` : (cause?.name ?? 'ApiError');
+  //
+  // Api404Error, not ApiError404: the stack parser skips the header line by looking for the
+  // literal "Error: " in it, so a type that does not end in Error leaves the header to be
+  // parsed as a frame whenever the message looks path-like - which a 404 body routinely does.
+  // That phantom frame then absorbs the pop below and the culprit reverts to this helper.
+  error.name = typeof statusCode === 'number' ? `Api${statusCode}Error` : (cause?.name ?? 'ApiError');
   // Deliberately NOT attached as `cause`: the RN SDK's linked-errors integration appends,
   // and Sentry titles an issue from the last exception, so chaining would put the original
-  // back in the title and undo the attribution above. Callers pass it as a second console
-  // argument instead, so its message and own properties land in extra.arguments.
+  // back in the title and undo the attribution above. reportError() passes it as a trailing
+  // console argument instead, so its message and own properties land in extra.arguments.
   //
   // The cost, accepted knowingly: when the original did carry app frames - an NFC or signing
   // failure - only the wrapper's stack is parsed, so the issue points at the catch block
@@ -60,20 +68,23 @@ export function toError(context: string, e: unknown, framesToPop = 1): Error {
   // issue. Per-site attribution for all of them beats exact frames for some of them.
   //
   // The Error is constructed in here, so without this the top frame - and therefore the
-  // culprit shown on every issue - would be this helper rather than the caller. Passed in
-  // rather than redefined afterwards: the property is non-enumerable, to stay out of
-  // serialization, and so also non-configurable, which makes a second write throw.
-  Object.defineProperty(error, 'framesToPop', { value: framesToPop });
+  // culprit shown on every issue - would be this helper rather than the caller. Defined the
+  // way the SDK defines it on its own fetch errors: non-enumerable so it stays out of
+  // serialization, but still writable and configurable, since defineProperty otherwise
+  // defaults all three to false and a second write would throw.
+  Object.defineProperty(error, 'framesToPop', { value: framesToPop, writable: true, configurable: true });
   return error;
 }
 
 // Reports a caught rejection: the issue gets a per-site exception, the log keeps a readable
 // template, and the original stays inspectable.
 //
-// The context goes first because the console-to-logs integration only builds a message
-// template when the first argument is a string - with an Error there, the log body becomes a
-// JSON blob of the whole stack. captureConsole is unaffected either way: it takes the first
-// *Error* among the arguments, which is still the wrapper.
+// The context goes first because the console-to-logs integration only emits the
+// sentry.message.template and sentry.message.parameter.N attributes when the first argument
+// is a string; without them a log has no parameterized template to group or search on. The
+// body itself is formatConsoleArgs(args) either way and still carries the serialized wrapper,
+// so this buys the attributes, not a shorter body. captureConsole is unaffected: it takes the
+// first *Error* among the arguments, which is still the wrapper.
 export function reportError(context: string, e: unknown): void {
   // Two frames, not one: toError built the Error, and it was called from in here.
   console.error(context, toError(context, e, 2), e);

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -3,23 +3,28 @@ import { ApiError } from '../api/dfx/definitions/error';
 const MAX_DETAIL_LENGTH = 200;
 const MAX_TYPE_LENGTH = 60;
 
+// Reads one property off a rejection. Anything reached from a catch block is third-party
+// code - `name`, `message` and `statusCode` can all be getters - and a throw here would turn
+// a handled error into an unhandled one at every reporting site.
+function safeRead<T>(get: () => T): T | undefined {
+  try {
+    return get();
+  } catch {
+    return undefined;
+  }
+}
+
 // Derives the exception type, which is what Sentry groups on once a stack contributes.
 //
 // The invariant is that it ENDS in "Error": the stack parser skips the header line by looking
 // for the literal "Error: ", and a type without that suffix leaves the header to be parsed as
 // a phantom frame that absorbs the frame pop, putting the culprit back on this helper.
 //
-// Everything here is third-party input reached from inside a catch block, so nothing is
-// allowed to throw: `name` can be a getter, and a getter is somebody else's code.
+// `name` is read through safeRead for the same reason as everything else off a rejection.
 function deriveType(statusCode: unknown, cause: Error | undefined): string {
   if (typeof statusCode === 'number') return `Api${statusCode}Error`;
 
-  let name: unknown;
-  try {
-    name = cause?.name;
-  } catch {
-    name = undefined;
-  }
+  const name = safeRead(() => cause?.name);
   // Flattened and capped for the same reasons as the detail: a newline would land in the
   // stack header, and the type is half the issue title.
   const base = typeof name === 'string' ? name.replace(/\s+/g, ' ').trim().slice(0, MAX_TYPE_LENGTH) : '';
@@ -57,10 +62,18 @@ function describe(e: unknown): string | undefined {
 // frames), merge every site in the app into one unattributable issue.
 function toError(context: string, e: unknown, framesToPop: number): Error {
   const cause = e instanceof Error ? e : undefined;
-  const { statusCode, message } = (cause ? {} : (e ?? {})) as Partial<ApiError>;
+  const body = cause ? undefined : (e as Partial<ApiError> | undefined);
+  // Every read below can be a getter - somebody else's function - and all of this runs inside
+  // a catch block, so none of it may throw. deriveType guards `name` the same way.
+  const statusCode = safeRead(() => body?.statusCode);
+  const bodyMessage = safeRead(() => body?.message);
+  const causeMessage = safeRead(() => cause?.message);
   // Not every backend answers with {statusCode, message} - LNbits replies {"detail": ...} -
   // so an unrecognized body would otherwise reach the title as nothing at all.
-  const raw = cause?.message ?? (typeof message === 'string' ? message : undefined) ?? (cause ? undefined : describe(e));
+  const raw =
+    (typeof causeMessage === 'string' ? causeMessage : undefined) ??
+    (typeof bodyMessage === 'string' ? bodyMessage : undefined) ??
+    (cause ? undefined : describe(e));
   // Flatten before capping. A server-supplied message can contain newlines, and the stack is
   // just a string: injected "    at ..." lines parse as real frames, which both pushes the
   // true frames down past the pop below and lets the remote end choose what the issue blames.

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -1,0 +1,48 @@
+import { ApiError } from '../api/dfx/definitions/error';
+
+const MAX_BODY_LENGTH = 200;
+
+// Renders whatever is left of a rejection once the known shapes are exhausted. Objects are
+// serialized rather than String()'d, which would only ever give "[object Object]"; anything
+// unserializable (circular) is dropped rather than allowed to throw out of a catch block.
+function describe(e: unknown): string | undefined {
+  if (e == null) return undefined;
+  if (typeof e !== 'object') return String(e);
+  try {
+    return JSON.stringify(e)?.slice(0, MAX_BODY_LENGTH);
+  } catch {
+    return undefined;
+  }
+}
+
+// Normalizes anything a catch block can receive into an Error worth reporting.
+//
+// The HTTP layers reject with the parsed error body rather than an Error (see
+// api/dfx/hooks/api.hook.ts and api/boltcards/hooks/api.hook.ts), and Sentry files an issue
+// from the first Error among the console arguments. A raw body still gets grouped per call
+// site - attachStacktrace is on, so the message path carries a synthetic stack - but its
+// value reads "... [object Object]" whatever went wrong, and a 400 and a 500 from one site
+// are indistinguishable.
+//
+// Always wrap, including when the rejection already is an Error: the wrapper's stack points
+// at the call site, which is what keeps issues separated per site. Returning the original
+// unchanged instead would drop `context` and, for the commonest mobile failure of all
+// (`TypeError: Network request failed`, thrown inside the fetch polyfill with no app
+// frames), merge every site in the app into one unattributable issue.
+export function toError(context: string, e: unknown): Error {
+  const cause = e instanceof Error ? e : undefined;
+  const { statusCode, message } = (cause ? {} : (e ?? {})) as Partial<ApiError>;
+  // Not every backend answers with {statusCode, message} - LNbits replies {"detail": ...} -
+  // so an unrecognized body would otherwise reach the title as nothing at all.
+  const detail = cause?.message ?? (typeof message === 'string' ? message : undefined) ?? (cause ? undefined : describe(e));
+  const error = new Error(detail ? `${context}: ${detail}` : context);
+  // Once a stack contributes, Sentry groups on the exception type and ignores the message,
+  // so the status has to go in the type for a 400 and a 500 from one site to stay apart.
+  // Keep a non-API cause's own type: an NFC or signing failure is not an ApiError.
+  error.name = statusCode ? `ApiError${statusCode}` : (cause?.name ?? 'ApiError');
+  // Deliberately NOT attached as `cause`: the RN SDK's linked-errors integration appends,
+  // and Sentry titles an issue from the last exception, so chaining would put the original
+  // back in the title and undo the attribution above. Callers pass it as a second console
+  // argument instead, which keeps its stack and own properties in extra.arguments.
+  return error;
+}

--- a/helpers/errors.ts
+++ b/helpers/errors.ts
@@ -53,7 +53,11 @@ function toError(context: string, e: unknown, framesToPop: number): Error {
   // literal "Error: " in it, so a type that does not end in Error leaves the header to be
   // parsed as a frame whenever the message looks path-like - which a 404 body routinely does.
   // That phantom frame then absorbs the pop below and the culprit reverts to this helper.
-  error.name = typeof statusCode === 'number' ? `Api${statusCode}Error` : (cause?.name ?? 'ApiError');
+  const type = typeof statusCode === 'number' ? `Api${statusCode}Error` : cause?.name || 'ApiError';
+  // The suffix is the invariant, not just a naming style, so enforce it on the cause's own
+  // type too: that value comes from third-party code and an empty or Error-less name would
+  // leave the header parseable again. `||` rather than `??` so an empty name is replaced.
+  error.name = type.includes('Error') ? type : `${type}Error`;
   // Deliberately NOT attached as `cause`: the RN SDK's linked-errors integration appends,
   // and Sentry titles an issue from the last exception, so chaining would put the original
   // back in the title and undo the attribution above. reportError() passes it as a trailing

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@react-navigation/drawer": "7.9.8",
         "@react-navigation/native": "7.2.2",
         "@react-navigation/native-stack": "7.14.10",
+        "@sentry/core": "10.67.0",
         "@sentry/react-native": "^8.20.0",
         "@spsina/bip47": "github:BlueWallet/bip47#df82345",
         "aez": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@react-navigation/native": "7.2.2",
         "@react-navigation/native-stack": "7.14.10",
         "@sentry/core": "10.67.0",
-        "@sentry/react-native": "^8.20.0",
+        "@sentry/react-native": "8.20.0",
         "@spsina/bip47": "github:BlueWallet/bip47#df82345",
         "aez": "1.0.1",
         "aezeed": "^0.0.5",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "@react-navigation/drawer": "7.9.8",
     "@react-navigation/native": "7.2.2",
     "@react-navigation/native-stack": "7.14.10",
+    "@sentry/core": "10.67.0",
     "@sentry/react-native": "^8.20.0",
     "@spsina/bip47": "github:BlueWallet/bip47#df82345",
     "aez": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@react-navigation/native": "7.2.2",
     "@react-navigation/native-stack": "7.14.10",
     "@sentry/core": "10.67.0",
-    "@sentry/react-native": "^8.20.0",
+    "@sentry/react-native": "8.20.0",
     "@spsina/bip47": "github:BlueWallet/bip47#df82345",
     "aez": "1.0.1",
     "aezeed": "^0.0.5",

--- a/screen/boltcard/add.tsx
+++ b/screen/boltcard/add.tsx
@@ -18,7 +18,7 @@ import BoltCard from '../../class/boltcard';
 import { TypeError } from '../../helpers/ErrorCodes';
 import { HoldCardModal } from '../../components/HoldCardModal';
 import { getProgressStringGenerator } from '../../helpers/stringProgressBar';
-import { toError } from '../../helpers/errors';
+import { reportError } from '../../helpers/errors';
 
 const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigationStyle> } = () => {
   const { wallets, saveToDisk } = useContext(BlueStorageContext);
@@ -82,7 +82,7 @@ const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigation
   }, []);
 
   const setupBoltcardErrorHandler = (error: any) => {
-    if (!error.type) return console.error(toError('boltcard/add: card setup failed with untyped error', error), error);
+    if (!error.type) return reportError('boltcard/add: card setup failed with untyped error', error);
     switch (error.type) {
       case TypeError.AUTH_FAILED:
         if (error.code === '91ae') return navigate('WrittenCardError');
@@ -91,7 +91,7 @@ const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigation
         if (error.code === '6982') return navigate('WrittenCardError');
         break;
       default:
-        console.error(toError('boltcard/add: unhandled card setup error', error), error);
+        reportError('boltcard/add: unhandled card setup error', error);
     }
   };
 

--- a/screen/boltcard/add.tsx
+++ b/screen/boltcard/add.tsx
@@ -18,6 +18,7 @@ import BoltCard from '../../class/boltcard';
 import { TypeError } from '../../helpers/ErrorCodes';
 import { HoldCardModal } from '../../components/HoldCardModal';
 import { getProgressStringGenerator } from '../../helpers/stringProgressBar';
+import { toError } from '../../api/dfx/definitions/error';
 
 const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigationStyle> } = () => {
   const { wallets, saveToDisk } = useContext(BlueStorageContext);
@@ -81,7 +82,7 @@ const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigation
   }, []);
 
   const setupBoltcardErrorHandler = (error: any) => {
-    if (!error.type) return console.error('boltcard/add: card setup failed with untyped error', error);
+    if (!error.type) return console.error(toError('boltcard/add: card setup failed with untyped error', error));
     switch (error.type) {
       case TypeError.AUTH_FAILED:
         if (error.code === '91ae') return navigate('WrittenCardError');
@@ -90,7 +91,7 @@ const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigation
         if (error.code === '6982') return navigate('WrittenCardError');
         break;
       default:
-        console.error('boltcard/add: unhandled card setup error', error);
+        console.error(toError('boltcard/add: unhandled card setup error', error));
     }
   };
 

--- a/screen/boltcard/add.tsx
+++ b/screen/boltcard/add.tsx
@@ -18,7 +18,7 @@ import BoltCard from '../../class/boltcard';
 import { TypeError } from '../../helpers/ErrorCodes';
 import { HoldCardModal } from '../../components/HoldCardModal';
 import { getProgressStringGenerator } from '../../helpers/stringProgressBar';
-import { toError } from '../../api/dfx/definitions/error';
+import { toError } from '../../helpers/errors';
 
 const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigationStyle> } = () => {
   const { wallets, saveToDisk } = useContext(BlueStorageContext);
@@ -82,7 +82,7 @@ const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigation
   }, []);
 
   const setupBoltcardErrorHandler = (error: any) => {
-    if (!error.type) return console.error(toError('boltcard/add: card setup failed with untyped error', error));
+    if (!error.type) return console.error(toError('boltcard/add: card setup failed with untyped error', error), error);
     switch (error.type) {
       case TypeError.AUTH_FAILED:
         if (error.code === '91ae') return navigate('WrittenCardError');
@@ -91,7 +91,7 @@ const AddBoltcard: React.FC & { navigationOptions?: ReturnType<typeof navigation
         if (error.code === '6982') return navigate('WrittenCardError');
         break;
       default:
-        console.error(toError('boltcard/add: unhandled card setup error', error));
+        console.error(toError('boltcard/add: unhandled card setup error', error), error);
     }
   };
 

--- a/screen/boltcard/delete.tsx
+++ b/screen/boltcard/delete.tsx
@@ -16,6 +16,7 @@ import BoltCard from '../../class/boltcard';
 import { HoldCardModal } from '../../components/HoldCardModal';
 import loc from '../../loc';
 import { getProgressStringGenerator } from '../../helpers/stringProgressBar';
+import { toError } from '../../api/dfx/definitions/error';
 
 const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigationStyle> } = () => {
   const { wallets, saveToDisk } = useContext(BlueStorageContext);
@@ -68,7 +69,7 @@ const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigati
         await deleteBoltcard(ldsWallet.getAdminKey(), card);
         updateProgress(`${loc.boltcard.writting_hold}\n\n${progress.next()}`);
       } catch (_) {
-        console.error('boltcard/delete: server-side card deletion failed after card was wiped', _);
+        console.error(toError('boltcard/delete: server-side card deletion failed after card was wiped', _));
       }
       ldsWallet.deleteBoltcard(card);
       await saveToDisk();
@@ -86,7 +87,7 @@ const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigati
     } catch (error) {
       setIsLoading(false);
       stopNfcSession();
-      console.error('boltcard/delete: card deletion flow failed', error);
+      console.error(toError('boltcard/delete: card deletion flow failed', error));
     }
   };
 

--- a/screen/boltcard/delete.tsx
+++ b/screen/boltcard/delete.tsx
@@ -16,7 +16,7 @@ import BoltCard from '../../class/boltcard';
 import { HoldCardModal } from '../../components/HoldCardModal';
 import loc from '../../loc';
 import { getProgressStringGenerator } from '../../helpers/stringProgressBar';
-import { toError } from '../../api/dfx/definitions/error';
+import { toError } from '../../helpers/errors';
 
 const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigationStyle> } = () => {
   const { wallets, saveToDisk } = useContext(BlueStorageContext);
@@ -69,7 +69,7 @@ const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigati
         await deleteBoltcard(ldsWallet.getAdminKey(), card);
         updateProgress(`${loc.boltcard.writting_hold}\n\n${progress.next()}`);
       } catch (_) {
-        console.error(toError('boltcard/delete: server-side card deletion failed after card was wiped', _));
+        console.error(toError('boltcard/delete: server-side card deletion failed after card was wiped', _), _);
       }
       ldsWallet.deleteBoltcard(card);
       await saveToDisk();
@@ -87,7 +87,7 @@ const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigati
     } catch (error) {
       setIsLoading(false);
       stopNfcSession();
-      console.error(toError('boltcard/delete: card deletion flow failed', error));
+      console.error(toError('boltcard/delete: card deletion flow failed', error), error);
     }
   };
 

--- a/screen/boltcard/delete.tsx
+++ b/screen/boltcard/delete.tsx
@@ -16,7 +16,7 @@ import BoltCard from '../../class/boltcard';
 import { HoldCardModal } from '../../components/HoldCardModal';
 import loc from '../../loc';
 import { getProgressStringGenerator } from '../../helpers/stringProgressBar';
-import { toError } from '../../helpers/errors';
+import { reportError } from '../../helpers/errors';
 
 const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigationStyle> } = () => {
   const { wallets, saveToDisk } = useContext(BlueStorageContext);
@@ -69,7 +69,7 @@ const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigati
         await deleteBoltcard(ldsWallet.getAdminKey(), card);
         updateProgress(`${loc.boltcard.writting_hold}\n\n${progress.next()}`);
       } catch (_) {
-        console.error(toError('boltcard/delete: server-side card deletion failed after card was wiped', _), _);
+        reportError('boltcard/delete: server-side card deletion failed after card was wiped', _);
       }
       ldsWallet.deleteBoltcard(card);
       await saveToDisk();
@@ -87,7 +87,7 @@ const DeleteBolcard: React.FC & { navigationOptions?: ReturnType<typeof navigati
     } catch (error) {
       setIsLoading(false);
       stopNfcSession();
-      console.error(toError('boltcard/delete: card deletion flow failed', error), error);
+      reportError('boltcard/delete: card deletion flow failed', error);
     }
   };
 

--- a/screen/boltcard/details.tsx
+++ b/screen/boltcard/details.tsx
@@ -15,7 +15,7 @@ import BoltCard from '../../class/boltcard';
 import { Hit } from '../../api/boltcards/definitions/apiDtos';
 import useInputAmount from '../../hooks/useInputAmount';
 import BoltCardsCarousel from './BoltCardsCarousel';
-import { toError } from '../../helpers/errors';
+import { reportError } from '../../helpers/errors';
 
 const BoltcardDetails: React.FC & { navigationOptions?: ReturnType<typeof navigationStyle> } = () => {
   const { colors } = useTheme();
@@ -120,7 +120,7 @@ const BoltcardDetails: React.FC & { navigationOptions?: ReturnType<typeof naviga
       resetInputs();
     } catch (error) {
       setIsUpdating(false);
-      console.error(toError('boltcard/details: failed to update card', error), error);
+      reportError('boltcard/details: failed to update card', error);
     }
   };
 

--- a/screen/boltcard/details.tsx
+++ b/screen/boltcard/details.tsx
@@ -15,6 +15,7 @@ import BoltCard from '../../class/boltcard';
 import { Hit } from '../../api/boltcards/definitions/apiDtos';
 import useInputAmount from '../../hooks/useInputAmount';
 import BoltCardsCarousel from './BoltCardsCarousel';
+import { toError } from '../../api/dfx/definitions/error';
 
 const BoltcardDetails: React.FC & { navigationOptions?: ReturnType<typeof navigationStyle> } = () => {
   const { colors } = useTheme();
@@ -119,7 +120,7 @@ const BoltcardDetails: React.FC & { navigationOptions?: ReturnType<typeof naviga
       resetInputs();
     } catch (error) {
       setIsUpdating(false);
-      console.error('boltcard/details: failed to update card', error);
+      console.error(toError('boltcard/details: failed to update card', error));
     }
   };
 

--- a/screen/boltcard/details.tsx
+++ b/screen/boltcard/details.tsx
@@ -15,7 +15,7 @@ import BoltCard from '../../class/boltcard';
 import { Hit } from '../../api/boltcards/definitions/apiDtos';
 import useInputAmount from '../../hooks/useInputAmount';
 import BoltCardsCarousel from './BoltCardsCarousel';
-import { toError } from '../../api/dfx/definitions/error';
+import { toError } from '../../helpers/errors';
 
 const BoltcardDetails: React.FC & { navigationOptions?: ReturnType<typeof navigationStyle> } = () => {
   const { colors } = useTheme();
@@ -120,7 +120,7 @@ const BoltcardDetails: React.FC & { navigationOptions?: ReturnType<typeof naviga
       resetInputs();
     } catch (error) {
       setIsUpdating(false);
-      console.error(toError('boltcard/details: failed to update card', error));
+      console.error(toError('boltcard/details: failed to update card', error), error);
     }
   };
 

--- a/screen/lnd/cashierPos.tsx
+++ b/screen/lnd/cashierPos.tsx
@@ -27,6 +27,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import useInputAmount from '../../hooks/useInputAmount';
 import { LightningLdsWallet } from '../../class/wallets/lightning-lds-wallet';
 import { Icon } from 'react-native-elements';
+import { toError } from '../../helpers/errors';
 
 const POLLING_INTERVAL = 3000;
 
@@ -130,7 +131,7 @@ const CashierPos = () => {
       setIsWaitingForPayment(true);
       initInvoicePolling();
     } catch (error) {
-      console.error('lnd/cashierPos: failed to generate invoice', error);
+      console.error(toError('lnd/cashierPos: failed to generate invoice', error), error);
     }
   };
 

--- a/screen/lnd/cashierPos.tsx
+++ b/screen/lnd/cashierPos.tsx
@@ -27,7 +27,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import useInputAmount from '../../hooks/useInputAmount';
 import { LightningLdsWallet } from '../../class/wallets/lightning-lds-wallet';
 import { Icon } from 'react-native-elements';
-import { toError } from '../../helpers/errors';
+import { reportError } from '../../helpers/errors';
 
 const POLLING_INTERVAL = 3000;
 
@@ -131,7 +131,7 @@ const CashierPos = () => {
       setIsWaitingForPayment(true);
       initInvoicePolling();
     } catch (error) {
-      console.error(toError('lnd/cashierPos: failed to generate invoice', error), error);
+      reportError('lnd/cashierPos: failed to generate invoice', error);
     }
   };
 

--- a/screen/lnd/lndCreateInvoice.js
+++ b/screen/lnd/lndCreateInvoice.js
@@ -36,6 +36,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { majorTomToGroundControl, tryToObtainPermissions } from '../../blue_modules/notifications';
 import alert from '../../components/Alert';
 import { parse } from 'url'; // eslint-disable-line n/no-deprecated-api
+import { toError } from '../../helpers/errors';
 const currency = require('../../blue_modules/currency');
 
 const LNDCreateInvoice = () => {
@@ -81,7 +82,7 @@ const LNDCreateInvoice = () => {
         await processLnurl(uri);
       }
     } catch (e) {
-      console.error('lndCreateInvoice: failed to prepare receive details', e);
+      console.error(toError('lndCreateInvoice: failed to prepare receive details', e), e);
     }
     setIsLoading(false);
   };

--- a/screen/lnd/lndCreateInvoice.js
+++ b/screen/lnd/lndCreateInvoice.js
@@ -36,7 +36,7 @@ import { BlueStorageContext } from '../../blue_modules/storage-context';
 import { majorTomToGroundControl, tryToObtainPermissions } from '../../blue_modules/notifications';
 import alert from '../../components/Alert';
 import { parse } from 'url'; // eslint-disable-line n/no-deprecated-api
-import { toError } from '../../helpers/errors';
+import { reportError } from '../../helpers/errors';
 const currency = require('../../blue_modules/currency');
 
 const LNDCreateInvoice = () => {
@@ -82,7 +82,7 @@ const LNDCreateInvoice = () => {
         await processLnurl(uri);
       }
     } catch (e) {
-      console.error(toError('lndCreateInvoice: failed to prepare receive details', e), e);
+      reportError('lndCreateInvoice: failed to prepare receive details', e);
     }
     setIsLoading(false);
   };

--- a/screen/lnd/lndViewAdditionalInvoiceInformation.js
+++ b/screen/lnd/lndViewAdditionalInvoiceInformation.js
@@ -8,7 +8,7 @@ import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import QRCodeComponent from '../../components/QRCodeComponent';
 import alert from '../../components/Alert';
-import { toError } from '../../helpers/errors';
+import { reportError } from '../../helpers/errors';
 
 const LNDViewAdditionalInvoiceInformation = () => {
   const { walletID } = useRoute().params;
@@ -34,7 +34,7 @@ const LNDViewAdditionalInvoiceInformation = () => {
           setWalletInfo(wallet.info_raw);
         })
         .catch(error => {
-          console.error(toError('lndViewAdditionalInvoiceInformation: wallet.fetchInfo failed', error), error);
+          reportError('lndViewAdditionalInvoiceInformation: wallet.fetchInfo failed', error);
           alert(loc.errors.network);
           goBack();
         });

--- a/screen/lnd/lndViewAdditionalInvoiceInformation.js
+++ b/screen/lnd/lndViewAdditionalInvoiceInformation.js
@@ -8,6 +8,7 @@ import loc from '../../loc';
 import { BlueStorageContext } from '../../blue_modules/storage-context';
 import QRCodeComponent from '../../components/QRCodeComponent';
 import alert from '../../components/Alert';
+import { toError } from '../../helpers/errors';
 
 const LNDViewAdditionalInvoiceInformation = () => {
   const { walletID } = useRoute().params;
@@ -33,7 +34,7 @@ const LNDViewAdditionalInvoiceInformation = () => {
           setWalletInfo(wallet.info_raw);
         })
         .catch(error => {
-          console.error('lndViewAdditionalInvoiceInformation: wallet.fetchInfo failed', error);
+          console.error(toError('lndViewAdditionalInvoiceInformation: wallet.fetchInfo failed', error), error);
           alert(loc.errors.network);
           goBack();
         });

--- a/screen/lnd/lnurlNavigationForwarder.tsx
+++ b/screen/lnd/lnurlNavigationForwarder.tsx
@@ -14,7 +14,7 @@ import { AbstractWallet, HDSegwitBech32Wallet, LegacyWallet } from '../../class'
 import BigNumber from 'bignumber.js';
 import { AbstractHDElectrumWallet } from '../../class/wallets/abstract-hd-electrum-wallet';
 import { isInternalDomain } from '../../helpers/freeLightningDomains';
-import { toError } from '../../helpers/errors';
+import { reportError } from '../../helpers/errors';
 
 type RouteParams = {
   lnurl: string;
@@ -194,7 +194,7 @@ const LnurlNavigationForwarder = () => {
 
       throw new Error('Unsupported lnurl');
     } catch (error) {
-      console.error(toError('lnurlNavigationForwarder: failed to route lnurl', error), error);
+      reportError('lnurlNavigationForwarder: failed to route lnurl', error);
       navigation.goBack();
     }
   };

--- a/screen/lnd/lnurlNavigationForwarder.tsx
+++ b/screen/lnd/lnurlNavigationForwarder.tsx
@@ -14,6 +14,7 @@ import { AbstractWallet, HDSegwitBech32Wallet, LegacyWallet } from '../../class'
 import BigNumber from 'bignumber.js';
 import { AbstractHDElectrumWallet } from '../../class/wallets/abstract-hd-electrum-wallet';
 import { isInternalDomain } from '../../helpers/freeLightningDomains';
+import { toError } from '../../helpers/errors';
 
 type RouteParams = {
   lnurl: string;
@@ -193,7 +194,7 @@ const LnurlNavigationForwarder = () => {
 
       throw new Error('Unsupported lnurl');
     } catch (error) {
-      console.error('lnurlNavigationForwarder: failed to route lnurl', error);
+      console.error(toError('lnurlNavigationForwarder: failed to route lnurl', error), error);
       navigation.goBack();
     }
   };

--- a/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
+++ b/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
@@ -15,7 +15,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { AbstractWallet } from '../../class';
 import { CoinSelectOutput } from 'coinselect';
 import { OpenCryptoPayPaymentLink } from '../../class/open-crypto-pay';
-import { toError } from '../../helpers/errors';
+import { reportError } from '../../helpers/errors';
 const currency = require('../../blue_modules/currency');
 const Bignumber = require('bignumber.js');
 const bitcoin = require('bitcoinjs-lib');
@@ -132,7 +132,7 @@ const OpenCrytoPayCommitOnchain = () => {
         amount: Number(amountFormatted),
       });
     } catch (error) {
-      console.error(toError('openCryptoPay: onchain commit failed', error), error);
+      reportError('openCryptoPay: onchain commit failed', error);
       setIsServerError(true);
     } finally {
       setIsLoading(false);

--- a/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
+++ b/screen/open-crypto-pay/openCrytoPayCommitOnchain.tsx
@@ -15,6 +15,7 @@ import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { AbstractWallet } from '../../class';
 import { CoinSelectOutput } from 'coinselect';
 import { OpenCryptoPayPaymentLink } from '../../class/open-crypto-pay';
+import { toError } from '../../helpers/errors';
 const currency = require('../../blue_modules/currency');
 const Bignumber = require('bignumber.js');
 const bitcoin = require('bitcoinjs-lib');
@@ -131,7 +132,7 @@ const OpenCrytoPayCommitOnchain = () => {
         amount: Number(amountFormatted),
       });
     } catch (error) {
-      console.error('openCryptoPay: onchain commit failed', error);
+      console.error(toError('openCryptoPay: onchain commit failed', error), error);
       setIsServerError(true);
     } finally {
       setIsLoading(false);

--- a/screen/settings/about.js
+++ b/screen/settings/about.js
@@ -2,7 +2,7 @@ import React, { useContext } from 'react';
 import { TouchableOpacity, ScrollView, Linking, Image, View, Text, StyleSheet, useWindowDimensions, Platform, Alert } from 'react-native';
 import { useNavigation, useTheme } from '@react-navigation/native';
 import { Icon } from 'react-native-elements';
-import { getApplicationName, getVersion, getBundleId, getBuildNumber, getUniqueId, hasGmsSync } from 'react-native-device-info';
+import { getApplicationName, getVersion, getBundleId, getBuildNumber, getUniqueIdSync, hasGmsSync } from 'react-native-device-info';
 import Rate, { AndroidMarket } from 'react-native-rate';
 import { BlueButton, BlueCard, BlueListItem, BlueSpacing20, BlueTextCentered } from '../../BlueComponents';
 import navigationStyle from '../../components/navigationStyle';
@@ -226,13 +226,13 @@ const About = () => {
       <BlueTextCentered>
         w, h = {width}, {height}
       </BlueTextCentered>
-      <BlueTextCentered>Unique ID: {getUniqueId()}</BlueTextCentered>
+      <BlueTextCentered>Unique ID: {getUniqueIdSync()}</BlueTextCentered>
       {Config.DFX_ENV !== undefined && Config.DFX_ENV !== 'prd' && <BlueTextCentered>Environment: {Config.DFX_ENV}</BlueTextCentered>}
       <View style={styles.copyToClipboard}>
         <TouchableOpacity
           accessibilityRole="button"
           onPress={() => {
-            const stringToCopy = 'userId:' + getUniqueId();
+            const stringToCopy = 'userId:' + getUniqueIdSync();
             A.logError('copied unique id');
             Clipboard.setString(stringToCopy);
           }}

--- a/screen/settings/lightningSettings.tsx
+++ b/screen/settings/lightningSettings.tsx
@@ -11,7 +11,7 @@ import loc from '../../loc';
 import { useTheme } from '../../components/themes';
 import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
 import alert from '../../components/Alert';
-import { toError } from '../../helpers/errors';
+import { reportError } from '../../helpers/errors';
 
 const BlueApp = require('../../BlueApp');
 const AppStorage = BlueApp.AppStorage;
@@ -110,7 +110,7 @@ const LightningSettings: React.FC & { navigationOptions: NavigationOptionsGetter
       alert(loc.settings.lightning_saved);
     } catch (error) {
       alert(loc.settings.lightning_error_lndhub_uri);
-      console.error(toError('lightningSettings: failed to save LNDHub URI', error), error);
+      reportError('lightningSettings: failed to save LNDHub URI', error);
     }
     setIsLoading(false);
   }, [URI]);

--- a/screen/settings/lightningSettings.tsx
+++ b/screen/settings/lightningSettings.tsx
@@ -11,6 +11,7 @@ import loc from '../../loc';
 import { useTheme } from '../../components/themes';
 import DeeplinkSchemaMatch from '../../class/deeplink-schema-match';
 import alert from '../../components/Alert';
+import { toError } from '../../helpers/errors';
 
 const BlueApp = require('../../BlueApp');
 const AppStorage = BlueApp.AppStorage;
@@ -109,7 +110,7 @@ const LightningSettings: React.FC & { navigationOptions: NavigationOptionsGetter
       alert(loc.settings.lightning_saved);
     } catch (error) {
       alert(loc.settings.lightning_error_lndhub_uri);
-      console.error('lightningSettings: failed to save LNDHub URI', error);
+      console.error(toError('lightningSettings: failed to save LNDHub URI', error), error);
     }
     setIsLoading(false);
   }, [URI]);

--- a/screen/wallets/dfx/cashierPos.tsx
+++ b/screen/wallets/dfx/cashierPos.tsx
@@ -27,6 +27,7 @@ import { Icon } from 'react-native-elements';
 import useInputAmount from '../../../hooks/useInputAmount';
 import { BitcoinUnit } from '../../../models/bitcoinUnits';
 import { FiatUnit } from '../../../models/fiatUnit';
+import { toError } from '../../../api/dfx/definitions/error';
 const currency = require('../../../blue_modules/currency');
 
 interface RouteParams {
@@ -121,7 +122,7 @@ const CashierDfxPos = () => {
         setPosStatus(PosStatus.WAITING_CASHIER);
       }
     } catch (error) {
-      console.error('dfx/cashierPos: payment status poll failed', error);
+      console.error(toError('dfx/cashierPos: payment status poll failed', error));
       setPosStatus(PosStatus.NOT_AVAILABLE);
     }
   };
@@ -152,7 +153,7 @@ const CashierDfxPos = () => {
       onPendingPayment(paymentData);
       resetInput();
     } catch (error) {
-      console.error('dfx/cashierPos: createPayment failed', error);
+      console.error(toError('dfx/cashierPos: createPayment failed', error));
     } finally {
       setIsGeneratingInvoice(false);
     }
@@ -163,7 +164,7 @@ const CashierDfxPos = () => {
       setIsCanceling(true);
       await cancelPayment(walletID, selectedRoute as number);
     } catch (error) {
-      console.error('dfx/cashierPos: cancelPayment failed', error);
+      console.error(toError('dfx/cashierPos: cancelPayment failed', error));
     } finally {
       setIsCanceling(false);
       setPosStatus(PosStatus.WAITING_CASHIER);

--- a/screen/wallets/dfx/cashierPos.tsx
+++ b/screen/wallets/dfx/cashierPos.tsx
@@ -27,7 +27,7 @@ import { Icon } from 'react-native-elements';
 import useInputAmount from '../../../hooks/useInputAmount';
 import { BitcoinUnit } from '../../../models/bitcoinUnits';
 import { FiatUnit } from '../../../models/fiatUnit';
-import { toError } from '../../../api/dfx/definitions/error';
+import { toError } from '../../../helpers/errors';
 const currency = require('../../../blue_modules/currency');
 
 interface RouteParams {
@@ -122,7 +122,7 @@ const CashierDfxPos = () => {
         setPosStatus(PosStatus.WAITING_CASHIER);
       }
     } catch (error) {
-      console.error(toError('dfx/cashierPos: payment status poll failed', error));
+      console.error(toError('dfx/cashierPos: payment status poll failed', error), error);
       setPosStatus(PosStatus.NOT_AVAILABLE);
     }
   };
@@ -153,7 +153,7 @@ const CashierDfxPos = () => {
       onPendingPayment(paymentData);
       resetInput();
     } catch (error) {
-      console.error(toError('dfx/cashierPos: createPayment failed', error));
+      console.error(toError('dfx/cashierPos: createPayment failed', error), error);
     } finally {
       setIsGeneratingInvoice(false);
     }
@@ -164,7 +164,7 @@ const CashierDfxPos = () => {
       setIsCanceling(true);
       await cancelPayment(walletID, selectedRoute as number);
     } catch (error) {
-      console.error(toError('dfx/cashierPos: cancelPayment failed', error));
+      console.error(toError('dfx/cashierPos: cancelPayment failed', error), error);
     } finally {
       setIsCanceling(false);
       setPosStatus(PosStatus.WAITING_CASHIER);

--- a/screen/wallets/dfx/cashierPos.tsx
+++ b/screen/wallets/dfx/cashierPos.tsx
@@ -27,7 +27,7 @@ import { Icon } from 'react-native-elements';
 import useInputAmount from '../../../hooks/useInputAmount';
 import { BitcoinUnit } from '../../../models/bitcoinUnits';
 import { FiatUnit } from '../../../models/fiatUnit';
-import { toError } from '../../../helpers/errors';
+import { reportError } from '../../../helpers/errors';
 const currency = require('../../../blue_modules/currency');
 
 interface RouteParams {
@@ -122,7 +122,7 @@ const CashierDfxPos = () => {
         setPosStatus(PosStatus.WAITING_CASHIER);
       }
     } catch (error) {
-      console.error(toError('dfx/cashierPos: payment status poll failed', error), error);
+      reportError('dfx/cashierPos: payment status poll failed', error);
       setPosStatus(PosStatus.NOT_AVAILABLE);
     }
   };
@@ -153,7 +153,7 @@ const CashierDfxPos = () => {
       onPendingPayment(paymentData);
       resetInput();
     } catch (error) {
-      console.error(toError('dfx/cashierPos: createPayment failed', error), error);
+      reportError('dfx/cashierPos: createPayment failed', error);
     } finally {
       setIsGeneratingInvoice(false);
     }
@@ -164,7 +164,7 @@ const CashierDfxPos = () => {
       setIsCanceling(true);
       await cancelPayment(walletID, selectedRoute as number);
     } catch (error) {
-      console.error(toError('dfx/cashierPos: cancelPayment failed', error), error);
+      reportError('dfx/cashierPos: cancelPayment failed', error);
     } finally {
       setIsCanceling(false);
       setPosStatus(PosStatus.WAITING_CASHIER);

--- a/screen/wallets/dfx/receivePos.tsx
+++ b/screen/wallets/dfx/receivePos.tsx
@@ -16,7 +16,7 @@ import { navigationStyleTx } from '../../../components/navigationStyle';
 import { PaymentStatus, usePaymentLinks } from '../../../api/dfx/hooks/payment-link.hook';
 import { Icon } from 'react-native-elements';
 import QRCodeComponent from '../../../components/QRCodeComponent';
-import { toError } from '../../../helpers/errors';
+import { reportError } from '../../../helpers/errors';
 
 interface RouteParams {
   walletID: string;
@@ -102,7 +102,7 @@ const ReceiveDfxPos = () => {
         setPosStatus(PosStatus.WAITING_CASHIER);
       }
     } catch (error) {
-      console.error(toError('receivePos: payment status poll failed', error), error);
+      reportError('receivePos: payment status poll failed', error);
       setPosStatus(PosStatus.NOT_AVAILABLE);
     }
   };

--- a/screen/wallets/dfx/receivePos.tsx
+++ b/screen/wallets/dfx/receivePos.tsx
@@ -16,7 +16,7 @@ import { navigationStyleTx } from '../../../components/navigationStyle';
 import { PaymentStatus, usePaymentLinks } from '../../../api/dfx/hooks/payment-link.hook';
 import { Icon } from 'react-native-elements';
 import QRCodeComponent from '../../../components/QRCodeComponent';
-import { toError } from '../../../api/dfx/definitions/error';
+import { toError } from '../../../helpers/errors';
 
 interface RouteParams {
   walletID: string;
@@ -102,7 +102,7 @@ const ReceiveDfxPos = () => {
         setPosStatus(PosStatus.WAITING_CASHIER);
       }
     } catch (error) {
-      console.error(toError('receivePos: payment status poll failed', error));
+      console.error(toError('receivePos: payment status poll failed', error), error);
       setPosStatus(PosStatus.NOT_AVAILABLE);
     }
   };

--- a/screen/wallets/dfx/receivePos.tsx
+++ b/screen/wallets/dfx/receivePos.tsx
@@ -16,6 +16,7 @@ import { navigationStyleTx } from '../../../components/navigationStyle';
 import { PaymentStatus, usePaymentLinks } from '../../../api/dfx/hooks/payment-link.hook';
 import { Icon } from 'react-native-elements';
 import QRCodeComponent from '../../../components/QRCodeComponent';
+import { toError } from '../../../api/dfx/definitions/error';
 
 interface RouteParams {
   walletID: string;
@@ -101,7 +102,7 @@ const ReceiveDfxPos = () => {
         setPosStatus(PosStatus.WAITING_CASHIER);
       }
     } catch (error) {
-      console.error('receivePos: payment status poll failed', error);
+      console.error(toError('receivePos: payment status poll failed', error));
       setPosStatus(PosStatus.NOT_AVAILABLE);
     }
   };

--- a/screen/wallets/tappedCardDetails.tsx
+++ b/screen/wallets/tappedCardDetails.tsx
@@ -28,7 +28,7 @@ import { useNtag424 } from '../../api/boltcards/hooks/ntag424.hook';
 import { HoldCardModal } from '../../components/HoldCardModal';
 import alert from '../../components/Alert';
 import QRCodeComponent from '../../components/QRCodeComponent';
-import { toError } from '../../api/dfx/definitions/error';
+import { toError } from '../../helpers/errors';
 
 const styles = StyleSheet.create({
   scrollViewContent: {
@@ -183,7 +183,7 @@ const TappedCardDetails = () => {
               setIsRegisteredInServer(uidIsCorrect && k0IsCorrect && k1IsCorrect && k2IsCorrect);
               setServerDetails(currCard);
             } catch (_) {
-              console.error(toError('tappedCardDetails: failed to verify card registration against server', _));
+              console.error(toError('tappedCardDetails: failed to verify card registration against server', _), _);
               setIsRegisteredInServer(false);
             }
           }

--- a/screen/wallets/tappedCardDetails.tsx
+++ b/screen/wallets/tappedCardDetails.tsx
@@ -28,7 +28,7 @@ import { useNtag424 } from '../../api/boltcards/hooks/ntag424.hook';
 import { HoldCardModal } from '../../components/HoldCardModal';
 import alert from '../../components/Alert';
 import QRCodeComponent from '../../components/QRCodeComponent';
-import { toError } from '../../helpers/errors';
+import { reportError } from '../../helpers/errors';
 
 const styles = StyleSheet.create({
   scrollViewContent: {
@@ -183,7 +183,7 @@ const TappedCardDetails = () => {
               setIsRegisteredInServer(uidIsCorrect && k0IsCorrect && k1IsCorrect && k2IsCorrect);
               setServerDetails(currCard);
             } catch (_) {
-              console.error(toError('tappedCardDetails: failed to verify card registration against server', _), _);
+              reportError('tappedCardDetails: failed to verify card registration against server', _);
               setIsRegisteredInServer(false);
             }
           }

--- a/screen/wallets/tappedCardDetails.tsx
+++ b/screen/wallets/tappedCardDetails.tsx
@@ -28,6 +28,7 @@ import { useNtag424 } from '../../api/boltcards/hooks/ntag424.hook';
 import { HoldCardModal } from '../../components/HoldCardModal';
 import alert from '../../components/Alert';
 import QRCodeComponent from '../../components/QRCodeComponent';
+import { toError } from '../../api/dfx/definitions/error';
 
 const styles = StyleSheet.create({
   scrollViewContent: {
@@ -182,7 +183,7 @@ const TappedCardDetails = () => {
               setIsRegisteredInServer(uidIsCorrect && k0IsCorrect && k1IsCorrect && k2IsCorrect);
               setServerDetails(currCard);
             } catch (_) {
-              console.error('tappedCardDetails: failed to verify card registration against server', _);
+              console.error(toError('tappedCardDetails: failed to verify card registration against server', _));
               setIsRegisteredInServer(false);
             }
           }

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -50,7 +50,6 @@ jest.mock('react-native-permissions', () => require('react-native-permissions/mo
 
 jest.mock('react-native-device-info', () => {
   return {
-    getUniqueId: jest.fn().mockResolvedValue('uniqueId'),
     getUniqueIdSync: jest.fn().mockReturnValue('uniqueId'),
     getSystemName: jest.fn(),
     getDeviceType: jest.fn().mockReturnValue(false),

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -50,7 +50,8 @@ jest.mock('react-native-permissions', () => require('react-native-permissions/mo
 
 jest.mock('react-native-device-info', () => {
   return {
-    getUniqueId: jest.fn().mockReturnValue('uniqueId'),
+    getUniqueId: jest.fn().mockResolvedValue('uniqueId'),
+    getUniqueIdSync: jest.fn().mockReturnValue('uniqueId'),
     getSystemName: jest.fn(),
     getDeviceType: jest.fn().mockReturnValue(false),
     hasGmsSync: jest.fn().mockReturnValue(true),

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -33,27 +33,35 @@ describe('blue_modules/analytics', () => {
     assert.strictEqual(mockSentryOptions.enabled, true);
   });
 
-  it('logError forwards an Error instance to Sentry.captureException unchanged', () => {
+  // logError deliberately does NOT call captureException: App.js's captureConsole
+  // integration turns console.error into the issue, so capturing here too would
+  // file everything twice. It must hand that integration an Error, not a string -
+  // that is what makes it capture an exception with a stack instead of a message.
+  it('logError forwards an Error instance to console.error unchanged', () => {
     const A = require('../../blue_modules/analytics');
     const Sentry = require('@sentry/react-native');
     const err = new Error('boom');
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     A.logError(err);
 
-    assert.strictEqual(Sentry.captureException.mock.calls.length, 1);
-    assert.strictEqual(Sentry.captureException.mock.calls[0][0], err);
+    assert.strictEqual(consoleError.mock.calls.length, 1);
+    assert.strictEqual(consoleError.mock.calls[0][0], err);
+    assert.strictEqual(Sentry.captureException.mock.calls.length, 0);
+    consoleError.mockRestore();
   });
 
   it('logError wraps a non-Error value in an Error before forwarding', () => {
     const A = require('../../blue_modules/analytics');
-    const Sentry = require('@sentry/react-native');
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 
     A.logError('plain string error');
 
-    assert.strictEqual(Sentry.captureException.mock.calls.length, 1);
-    const forwarded = Sentry.captureException.mock.calls[0][0];
+    assert.strictEqual(consoleError.mock.calls.length, 1);
+    const forwarded = consoleError.mock.calls[0][0];
     assert.ok(forwarded instanceof Error);
     assert.strictEqual(forwarded.message, 'plain string error');
+    consoleError.mockRestore();
   });
 
   // Separate from the tests above: the module also applies the persisted Do Not

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -97,7 +97,7 @@ describe('blue_modules/analytics', () => {
   // turns console.error into the issue, so capturing here too would file everything twice.
   // It must hand that integration an Error, not a string - that is what makes it capture
   // an exception with a stack instead of a message titled after the integration's frame.
-  it('logError forwards an Error instance to console.error unchanged', () => {
+  it('logError forwards a caller-built Error without popping any frame', () => {
     const A = require('../../blue_modules/analytics');
     const Sentry = require('@sentry/react-native');
     const err = new Error('boom');
@@ -110,6 +110,8 @@ describe('blue_modules/analytics', () => {
     // still files an exception with a stack
     assert.strictEqual(consoleError.mock.calls[0][0], 'boom');
     assert.strictEqual(consoleError.mock.calls[0][1], err);
+    // no pop: the caller built this Error, so its top frame is already the right culprit
+    assert.strictEqual(err.framesToPop, undefined);
     assert.strictEqual(Sentry.captureException.mock.calls.length, 0);
   });
 
@@ -124,6 +126,15 @@ describe('blue_modules/analytics', () => {
     const forwarded = consoleError.mock.calls[0][1];
     assert.ok(forwarded instanceof Error);
     assert.strictEqual(forwarded.message, 'plain string error');
+    // built in here, so one frame has to go or every such issue is blamed on analytics.js
+    assert.strictEqual(forwarded.framesToPop, 1);
+    const culprit = forwarded.stack
+      .split('\n')
+      .filter(l => !l.includes('Error: '))
+      .filter(l => /\s+at\s/.test(l))[forwarded.framesToPop];
+    assert.ok(!culprit.includes('blue_modules/analytics'), `culprit is still the helper: ${culprit}`);
+    // and it must not be serialized into every payload
+    assert.ok(!Object.keys(forwarded).includes('framesToPop'));
   });
 
   // Separate from the tests above: the module also applies the persisted Do Not

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -137,6 +137,23 @@ describe('blue_modules/analytics', () => {
     assert.ok(!Object.keys(forwarded).includes('framesToPop'));
   });
 
+  // Same reason helpers/errors.ts flattens: a stack is just a string, so newlines in the
+  // value parse as real frames and the pop above lands on one of them instead.
+  it('logError does not let newlines in the value inject stack frames', () => {
+    const A = require('../../blue_modules/analytics');
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    A.logError('boom\n    at attackerFrame (/evil.js:1:1)');
+
+    const forwarded = consoleError.mock.calls[0][1];
+    assert.ok(!forwarded.message.includes('\n'), 'value should be flattened to one line');
+    const culprit = forwarded.stack
+      .split('\n')
+      .filter(l => !l.includes('Error: '))
+      .filter(l => /\s+at\s/.test(l))[forwarded.framesToPop];
+    assert.ok(!culprit.includes('attackerFrame'), `injected frame became the culprit: ${culprit}`);
+  });
+
   // Separate from the tests above: the module also applies the persisted Do Not
   // Track choice on load (before any explicit setOptOut call), which is what
   // actually closes the upstream gap - resets the module registry so the

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -151,7 +151,10 @@ describe('blue_modules/analytics', () => {
       .split('\n')
       .filter(l => !l.includes('Error: '))
       .filter(l => /\s+at\s/.test(l))[forwarded.framesToPop];
-    assert.ok(!culprit.includes('attackerFrame'), `injected frame became the culprit: ${culprit}`);
+    // asserted on the helper, not on 'attackerFrame': under the un-flatten mutation the
+    // injected line becomes frame 0 and the pop lands on analytics.js, so checking for the
+    // attacker frame here could never fail
+    assert.ok(!culprit.includes('blue_modules/analytics'), `culprit is still the helper: ${culprit}`);
   });
 
   // Separate from the tests above: the module also applies the persisted Do Not

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -8,37 +8,41 @@ jest.mock('../../BlueApp', () => ({
   isDoNotTrackEnabled: jest.fn().mockResolvedValue(false),
 }));
 
-const mockSentryOptions = { enabled: true };
-// What the client currently has registered. Sentry.init() only wires integrations up
-// when the client is enabled at that moment, so for a user who launched with Do Not
-// Track on this legitimately starts out empty.
-let mockIntegrations = [];
+// The resolved integration list sits on the options whether or not the client is
+// enabled; what init() skips for a disabled client is *installing* them.
+const RESOLVED_INTEGRATIONS = [{ name: 'CaptureConsole' }, { name: 'ReactNativeErrorHandlers' }, { name: 'Dedupe' }];
+const mockSentryOptions = { enabled: true, integrations: RESOLVED_INTEGRATIONS };
+// What the client actually has installed - legitimately empty for a user who
+// launched with Do Not Track on.
+let mockInstalled = [];
 jest.mock('@sentry/react-native', () => ({
-  getClient: jest.fn(() => ({
-    getOptions: () => mockSentryOptions,
-    getIntegrationByName: name => mockIntegrations.find(i => i.name === name),
-  })),
-  addIntegration: jest.fn(integration => mockIntegrations.push(integration)),
+  getClient: jest.fn(() => ({ getOptions: () => mockSentryOptions })),
+  addIntegration: jest.fn(integration => {
+    if (!mockInstalled.some(i => i.name === integration.name)) mockInstalled.push(integration);
+  }),
   setUser: jest.fn(),
   captureException: jest.fn(),
-}));
-
-// Like @sentry/react-native above, this ships ESM that jest does not transform
-// (no @sentry entry in transformIgnorePatterns), so stub the factory and assert
-// on the options we pass it.
-jest.mock('@sentry/core', () => ({
-  captureConsoleIntegration: jest.fn(options => ({ name: 'CaptureConsole', options })),
 }));
 
 describe('blue_modules/analytics', () => {
   beforeEach(() => {
     mockSentryOptions.enabled = true;
-    mockIntegrations = [];
+    mockInstalled = [];
     jest.clearAllMocks();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  // App.js imports captureConsoleIntegration from @sentry/core, which only resolves to
+  // the same instance the SDK uses while both stay on one hoisted copy. A second copy
+  // would make the integration's own client check never match and it would stop filing
+  // issues with no error anywhere, so pin drift has to fail here instead.
+  it('@sentry/core is pinned to exactly what @sentry/react-native depends on', () => {
+    const ours = require('../../package.json').dependencies['@sentry/core'];
+    const theirs = require('@sentry/react-native/package.json').dependencies['@sentry/core'];
+    assert.strictEqual(ours, theirs);
   });
 
   it('setOptOut(true) disables the Sentry client (opting out must actually stop event delivery)', () => {
@@ -77,26 +81,24 @@ describe('blue_modules/analytics', () => {
   });
 
   // Sentry.init() skips integration setup entirely when the client is disabled, and
-  // flipping `enabled` afterwards cannot install one. Without re-registering here, a user
-  // who launches with Do Not Track on and then turns it off would have every caught error
-  // go unreported until the next app start.
-  it('setOptOut(false) registers console capture that init skipped while opted out', () => {
+  // flipping `enabled` afterwards installs nothing. A user who launches with Do Not
+  // Track on and then turns it off must get the WHOLE resolved list - not just console
+  // capture, but the uncaught-error handlers and the frame rewriting source maps need.
+  it('setOptOut(false) installs the integrations init skipped while opted out', () => {
     const A = require('../../blue_modules/analytics');
     const Sentry = require('@sentry/react-native');
     A.setOptOut(false);
-    assert.strictEqual(Sentry.addIntegration.mock.calls.length, 1);
-    const registered = Sentry.addIntegration.mock.calls[0][0];
-    assert.strictEqual(registered.name, 'CaptureConsole');
-    // errors only - console.warn is far too noisy to open issues from
-    assert.deepStrictEqual(registered.options, { levels: ['error'] });
+    // joined rather than compared as arrays: jest hands the mock's calls back from
+    // another realm, so deepStrictEqual fails the prototype check on identical content
+    const installed = Sentry.addIntegration.mock.calls.map(c => c[0].name).join(',');
+    assert.strictEqual(installed, 'CaptureConsole,ReactNativeErrorHandlers,Dedupe');
   });
 
-  it('does not register console capture twice when it is already present', () => {
+  it('installs nothing while opted out', () => {
     const A = require('../../blue_modules/analytics');
     const Sentry = require('@sentry/react-native');
-    A.setOptOut(false);
-    A.setOptOut(false);
-    assert.strictEqual(Sentry.addIntegration.mock.calls.length, 1);
+    A.setOptOut(true);
+    assert.strictEqual(Sentry.addIntegration.mock.calls.length, 0);
   });
 
   it('logError forwards an Error instance to console.error unchanged', () => {

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -29,23 +29,16 @@ describe('blue_modules/analytics', () => {
     jest.restoreAllMocks();
   });
 
-  // App.js imports captureConsoleIntegration from @sentry/core, which only resolves to
-  // the same instance the SDK uses while both stay on one hoisted copy. A second copy
-  // would make the integration's own client check never match and it would stop filing
-  // issues with no error anywhere, so pin drift has to fail here instead.
-  it('@sentry/core is pinned to exactly what @sentry/react-native depends on', () => {
-    const ours = require('../../package.json').dependencies['@sentry/core'];
-    const theirs = require('@sentry/react-native/package.json').dependencies['@sentry/core'];
-    assert.strictEqual(ours, theirs);
-  });
-
-  // Matching specifiers are not sufficient - npm can still nest a second copy, which has
-  // its own carrier and so its own client, and the integration bails when they differ.
-  it('@sentry/core is not installed a second time under @sentry/react-native', () => {
-    const fs = require('fs');
+  // App.js takes captureConsoleIntegration from @sentry/core, which only works while that
+  // resolves to the very module the SDK itself loaded. Sentry keys its carrier by SDK
+  // version, so a copy at a *different* version gets its own client and the integration's
+  // `getClient() !== client` guard turns the handler into a no-op - no error, no failing
+  // test, just no issues. Assert the resolution rather than the version specifiers or one
+  // nesting path: any of @sentry/browser, /react and friends can pull a copy in too.
+  it('@sentry/core resolves to the same module the SDK loaded', () => {
     const path = require('path');
-    const nested = path.join(__dirname, '../../node_modules/@sentry/react-native/node_modules/@sentry/core');
-    assert.ok(!fs.existsSync(nested), 'a nested @sentry/core copy silently disables console capture');
+    const sdkDir = path.dirname(require.resolve('@sentry/react-native/package.json'));
+    assert.strictEqual(require.resolve('@sentry/core', { paths: [sdkDir] }), require.resolve('@sentry/core'));
   });
 
   it('setOptOut(true) disables the Sentry client (opting out must actually stop event delivery)', () => {

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -106,7 +106,10 @@ describe('blue_modules/analytics', () => {
     A.logError(err);
 
     assert.strictEqual(consoleError.mock.calls.length, 1);
-    assert.strictEqual(consoleError.mock.calls[0][0], err);
+    // message first so the logs integration can template it, Error second so captureConsole
+    // still files an exception with a stack
+    assert.strictEqual(consoleError.mock.calls[0][0], 'boom');
+    assert.strictEqual(consoleError.mock.calls[0][1], err);
     assert.strictEqual(Sentry.captureException.mock.calls.length, 0);
   });
 
@@ -117,7 +120,8 @@ describe('blue_modules/analytics', () => {
     A.logError('plain string error');
 
     assert.strictEqual(consoleError.mock.calls.length, 1);
-    const forwarded = consoleError.mock.calls[0][0];
+    assert.strictEqual(consoleError.mock.calls[0][0], 'plain string error');
+    const forwarded = consoleError.mock.calls[0][1];
     assert.ok(forwarded instanceof Error);
     assert.strictEqual(forwarded.message, 'plain string error');
   });

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -9,15 +9,36 @@ jest.mock('../../BlueApp', () => ({
 }));
 
 const mockSentryOptions = { enabled: true };
+// What the client currently has registered. Sentry.init() only wires integrations up
+// when the client is enabled at that moment, so for a user who launched with Do Not
+// Track on this legitimately starts out empty.
+let mockIntegrations = [];
 jest.mock('@sentry/react-native', () => ({
-  getClient: jest.fn(() => ({ getOptions: () => mockSentryOptions })),
+  getClient: jest.fn(() => ({
+    getOptions: () => mockSentryOptions,
+    getIntegrationByName: name => mockIntegrations.find(i => i.name === name),
+  })),
+  addIntegration: jest.fn(integration => mockIntegrations.push(integration)),
+  setUser: jest.fn(),
   captureException: jest.fn(),
+}));
+
+// Like @sentry/react-native above, this ships ESM that jest does not transform
+// (no @sentry entry in transformIgnorePatterns), so stub the factory and assert
+// on the options we pass it.
+jest.mock('@sentry/core', () => ({
+  captureConsoleIntegration: jest.fn(options => ({ name: 'CaptureConsole', options })),
 }));
 
 describe('blue_modules/analytics', () => {
   beforeEach(() => {
     mockSentryOptions.enabled = true;
+    mockIntegrations = [];
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('setOptOut(true) disables the Sentry client (opting out must actually stop event delivery)', () => {
@@ -37,6 +58,47 @@ describe('blue_modules/analytics', () => {
   // integration turns console.error into the issue, so capturing here too would
   // file everything twice. It must hand that integration an Error, not a string -
   // that is what makes it capture an exception with a stack instead of a message.
+  // The id goes on the scope *user*, not a scope attribute: attributes reach logs only,
+  // while the user reaches both logs and error events. Without it the native layer fills
+  // in its own install id for error events, which is a different value than the one the
+  // About screen shows, so a log row cannot be joined to the error or to a support request.
+  it('setOptOut(false) identifies the device', () => {
+    const A = require('../../blue_modules/analytics');
+    const Sentry = require('@sentry/react-native');
+    A.setOptOut(false);
+    assert.deepStrictEqual(Sentry.setUser.mock.calls[0][0], { id: 'uniqueId' });
+  });
+
+  it('setOptOut(true) clears the device identity', () => {
+    const A = require('../../blue_modules/analytics');
+    const Sentry = require('@sentry/react-native');
+    A.setOptOut(true);
+    assert.strictEqual(Sentry.setUser.mock.calls[0][0], null);
+  });
+
+  // Sentry.init() skips integration setup entirely when the client is disabled, and
+  // flipping `enabled` afterwards cannot install one. Without re-registering here, a user
+  // who launches with Do Not Track on and then turns it off would have every caught error
+  // go unreported until the next app start.
+  it('setOptOut(false) registers console capture that init skipped while opted out', () => {
+    const A = require('../../blue_modules/analytics');
+    const Sentry = require('@sentry/react-native');
+    A.setOptOut(false);
+    assert.strictEqual(Sentry.addIntegration.mock.calls.length, 1);
+    const registered = Sentry.addIntegration.mock.calls[0][0];
+    assert.strictEqual(registered.name, 'CaptureConsole');
+    // errors only - console.warn is far too noisy to open issues from
+    assert.deepStrictEqual(registered.options, { levels: ['error'] });
+  });
+
+  it('does not register console capture twice when it is already present', () => {
+    const A = require('../../blue_modules/analytics');
+    const Sentry = require('@sentry/react-native');
+    A.setOptOut(false);
+    A.setOptOut(false);
+    assert.strictEqual(Sentry.addIntegration.mock.calls.length, 1);
+  });
+
   it('logError forwards an Error instance to console.error unchanged', () => {
     const A = require('../../blue_modules/analytics');
     const Sentry = require('@sentry/react-native');
@@ -48,7 +110,6 @@ describe('blue_modules/analytics', () => {
     assert.strictEqual(consoleError.mock.calls.length, 1);
     assert.strictEqual(consoleError.mock.calls[0][0], err);
     assert.strictEqual(Sentry.captureException.mock.calls.length, 0);
-    consoleError.mockRestore();
   });
 
   it('logError wraps a non-Error value in an Error before forwarding', () => {
@@ -61,7 +122,6 @@ describe('blue_modules/analytics', () => {
     const forwarded = consoleError.mock.calls[0][0];
     assert.ok(forwarded instanceof Error);
     assert.strictEqual(forwarded.message, 'plain string error');
-    consoleError.mockRestore();
   });
 
   // Separate from the tests above: the module also applies the persisted Do Not

--- a/tests/unit/analytics.test.js
+++ b/tests/unit/analytics.test.js
@@ -12,14 +12,9 @@ jest.mock('../../BlueApp', () => ({
 // enabled; what init() skips for a disabled client is *installing* them.
 const RESOLVED_INTEGRATIONS = [{ name: 'CaptureConsole' }, { name: 'ReactNativeErrorHandlers' }, { name: 'Dedupe' }];
 const mockSentryOptions = { enabled: true, integrations: RESOLVED_INTEGRATIONS };
-// What the client actually has installed - legitimately empty for a user who
-// launched with Do Not Track on.
-let mockInstalled = [];
 jest.mock('@sentry/react-native', () => ({
   getClient: jest.fn(() => ({ getOptions: () => mockSentryOptions })),
-  addIntegration: jest.fn(integration => {
-    if (!mockInstalled.some(i => i.name === integration.name)) mockInstalled.push(integration);
-  }),
+  addIntegration: jest.fn(),
   setUser: jest.fn(),
   captureException: jest.fn(),
 }));
@@ -27,7 +22,6 @@ jest.mock('@sentry/react-native', () => ({
 describe('blue_modules/analytics', () => {
   beforeEach(() => {
     mockSentryOptions.enabled = true;
-    mockInstalled = [];
     jest.clearAllMocks();
   });
 
@@ -45,6 +39,15 @@ describe('blue_modules/analytics', () => {
     assert.strictEqual(ours, theirs);
   });
 
+  // Matching specifiers are not sufficient - npm can still nest a second copy, which has
+  // its own carrier and so its own client, and the integration bails when they differ.
+  it('@sentry/core is not installed a second time under @sentry/react-native', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const nested = path.join(__dirname, '../../node_modules/@sentry/react-native/node_modules/@sentry/core');
+    assert.ok(!fs.existsSync(nested), 'a nested @sentry/core copy silently disables console capture');
+  });
+
   it('setOptOut(true) disables the Sentry client (opting out must actually stop event delivery)', () => {
     const A = require('../../blue_modules/analytics');
     A.setOptOut(true);
@@ -58,10 +61,6 @@ describe('blue_modules/analytics', () => {
     assert.strictEqual(mockSentryOptions.enabled, true);
   });
 
-  // logError deliberately does NOT call captureException: App.js's captureConsole
-  // integration turns console.error into the issue, so capturing here too would
-  // file everything twice. It must hand that integration an Error, not a string -
-  // that is what makes it capture an exception with a stack instead of a message.
   // The id goes on the scope *user*, not a scope attribute: attributes reach logs only,
   // while the user reaches both logs and error events. Without it the native layer fills
   // in its own install id for error events, which is a different value than the one the
@@ -101,6 +100,10 @@ describe('blue_modules/analytics', () => {
     assert.strictEqual(Sentry.addIntegration.mock.calls.length, 0);
   });
 
+  // logError deliberately does NOT call captureException: the captureConsole integration
+  // turns console.error into the issue, so capturing here too would file everything twice.
+  // It must hand that integration an Error, not a string - that is what makes it capture
+  // an exception with a stack instead of a message titled after the integration's frame.
   it('logError forwards an Error instance to console.error unchanged', () => {
     const A = require('../../blue_modules/analytics');
     const Sentry = require('@sentry/react-native');

--- a/tests/unit/api-error.test.js
+++ b/tests/unit/api-error.test.js
@@ -1,0 +1,44 @@
+const assert = require('assert');
+
+const { toError } = require('../../api/dfx/definitions/error');
+
+// The DFX API layer rejects with the parsed error body rather than an Error, and Sentry
+// files an issue from the first Error among the console arguments. Everything below is
+// about what the resulting issue looks like: an un-normalized body produces one stackless
+// issue titled "... [object Object]" for every failure.
+describe('api/dfx/definitions/error toError', () => {
+  it('titles an API error body with the context and its message', () => {
+    const error = toError('DFX session init failed', { statusCode: 401, message: 'Unauthorized' });
+    assert.strictEqual(error.message, 'DFX session init failed: Unauthorized');
+  });
+
+  // Sentry ignores the message once a stack contributes and groups on the type, so the
+  // status has to live in the name or a 400 and a 500 from one site become one issue.
+  it('puts the status in the type so statuses stay separate issues', () => {
+    assert.strictEqual(toError('ctx', { statusCode: 400, message: 'Bad' }).name, 'ApiError400');
+    assert.strictEqual(toError('ctx', { statusCode: 500, message: 'Boom' }).name, 'ApiError500');
+  });
+
+  // Wrapped rather than returned as-is: the wrapper's stack points at the call site, which
+  // is what keeps sites apart. `TypeError: Network request failed` carries no app frames,
+  // so returning it unchanged would merge every site in the app into one issue.
+  it('keeps the context for a rejection that is already an Error, and links the original', () => {
+    const cause = new TypeError('Network request failed');
+    const error = toError('receivePos: payment status poll failed', cause);
+
+    assert.strictEqual(error.message, 'receivePos: payment status poll failed: Network request failed');
+    assert.strictEqual(error.cause, cause);
+    assert.strictEqual(error.name, 'ApiError');
+  });
+
+  it('never renders an object as [object Object]', () => {
+    for (const shape of [{}, { statusCode: 500 }, { unexpected: 'shape' }]) {
+      assert.ok(!toError('ctx', shape).message.includes('[object Object]'), `leaked for ${JSON.stringify(shape)}`);
+    }
+  });
+
+  it('keeps a primitive rejection readable', () => {
+    assert.strictEqual(toError('ctx', 'plain string').message, 'ctx: plain string');
+    assert.strictEqual(toError('ctx', undefined).message, 'ctx');
+  });
+});

--- a/tests/unit/api-error.test.js
+++ b/tests/unit/api-error.test.js
@@ -1,13 +1,14 @@
 const assert = require('assert');
 
-const { toError } = require('../../api/dfx/definitions/error');
+const { toError } = require('../../helpers/errors');
 
-// The DFX API layer rejects with the parsed error body rather than an Error, and Sentry
-// files an issue from the first Error among the console arguments. Everything below is
-// about what the resulting issue looks like: an un-normalized body produces one stackless
-// issue titled "... [object Object]" for every failure.
-describe('api/dfx/definitions/error toError', () => {
-  it('titles an API error body with the context and its message', () => {
+// The HTTP layers reject with the parsed error body rather than an Error, and Sentry files
+// an issue from the first Error among the console arguments. Everything below is about what
+// the resulting issue looks like: an un-normalized body is still grouped per call site, but
+// its value reads "... [object Object]" whatever went wrong, and one status cannot be told
+// from another.
+describe('helpers/errors toError', () => {
+  it('titles a DFX error body with the context and its message', () => {
     const error = toError('DFX session init failed', { statusCode: 401, message: 'Unauthorized' });
     assert.strictEqual(error.message, 'DFX session init failed: Unauthorized');
   });
@@ -22,23 +23,48 @@ describe('api/dfx/definitions/error toError', () => {
   // Wrapped rather than returned as-is: the wrapper's stack points at the call site, which
   // is what keeps sites apart. `TypeError: Network request failed` carries no app frames,
   // so returning it unchanged would merge every site in the app into one issue.
-  it('keeps the context for a rejection that is already an Error, and links the original', () => {
+  it('keeps the context for a rejection that is already an Error', () => {
     const cause = new TypeError('Network request failed');
     const error = toError('receivePos: payment status poll failed', cause);
 
     assert.strictEqual(error.message, 'receivePos: payment status poll failed: Network request failed');
-    assert.strictEqual(error.cause, cause);
-    assert.strictEqual(error.name, 'ApiError');
+  });
+
+  // Not chained: the RN SDK's linked-errors integration appends, and Sentry titles an issue
+  // from the LAST exception, so attaching the cause would put "TypeError: Network request
+  // failed" back in the title and undo the attribution the wrapper exists to provide.
+  it('does not chain the original, which would take over the issue title', () => {
+    const error = toError('ctx', new TypeError('Network request failed'));
+    assert.strictEqual(error.cause, undefined);
+  });
+
+  // An NFC or signing failure reaches the same helper and must not be filed as an ApiError.
+  it('keeps a non-API cause its own type', () => {
+    assert.strictEqual(toError('ctx', new TypeError('boom')).name, 'TypeError');
+    assert.strictEqual(toError('ctx', new Error('boom')).name, 'Error');
+  });
+
+  // Not every backend answers with {statusCode, message}: the boltcard API is LNbits, which
+  // replies {"detail": ...}. Dropping it here would leave the issue title carrying only the
+  // context, with no trace of what actually failed.
+  it('keeps a body that does not match the DFX shape', () => {
+    assert.strictEqual(toError('ctx', { detail: 'card not found' }).message, 'ctx: {"detail":"card not found"}');
+    assert.ok(toError('ctx', { type: 'AUTH_FAILED', code: '91ae' }).message.includes('AUTH_FAILED'));
   });
 
   it('never renders an object as [object Object]', () => {
-    for (const shape of [{}, { statusCode: 500 }, { unexpected: 'shape' }]) {
+    // the last shape is the trap: `message` present, but itself an object
+    for (const shape of [{}, { statusCode: 500 }, { unexpected: 'shape' }, { statusCode: 400, message: { code: 'x' } }]) {
       assert.ok(!toError('ctx', shape).message.includes('[object Object]'), `leaked for ${JSON.stringify(shape)}`);
     }
   });
 
-  it('keeps a primitive rejection readable', () => {
+  it('keeps a primitive rejection readable and survives an unserializable one', () => {
     assert.strictEqual(toError('ctx', 'plain string').message, 'ctx: plain string');
     assert.strictEqual(toError('ctx', undefined).message, 'ctx');
+
+    const circular = {};
+    circular.self = circular;
+    assert.strictEqual(toError('ctx', circular).message, 'ctx');
   });
 });

--- a/tests/unit/errors.test.js
+++ b/tests/unit/errors.test.js
@@ -107,8 +107,29 @@ describe('helpers/errors toError', () => {
     assert.strictEqual(reported('ctx', withName({ value: 'Error ' })).name, 'Error');
     // a newline would land in the stack header
     assert.ok(!reported('ctx', withName({ value: 'Ti\nmeout' })).name.includes('\n'));
-    // the type is half the issue title, so it is bounded like the detail
-    assert.ok(reported('ctx', withName({ value: 'A'.repeat(300) })).name.length <= 65);
+    // the exact value, not just the bound: capping AFTER the suffix enforcement would still
+    // satisfy a length check while chopping the Error off the end, which is the whole invariant
+    assert.strictEqual(reported('ctx', withName({ value: 'A'.repeat(300) })).name, `${'A'.repeat(60)}Error`);
+  });
+
+  // message and statusCode are getters on the same hostile object as name, so they get the
+  // same treatment - a throw from any of them escapes a catch block at every reporting site.
+  it('survives a cause whose message getter throws', () => {
+    const throwing = Object.defineProperty(new Error('boom'), 'message', {
+      get() {
+        throw new Error('nope');
+      },
+    });
+    assert.strictEqual(reported('ctx', throwing).message, 'ctx');
+  });
+
+  it('survives a body whose statusCode getter throws', () => {
+    const throwing = Object.defineProperty({ message: 'Bad' }, 'statusCode', {
+      get() {
+        throw new Error('nope');
+      },
+    });
+    assert.strictEqual(reported('ctx', throwing).name, 'ApiError');
   });
 
   // A non-string name would make the suffix check throw, out of a catch block, at every site.

--- a/tests/unit/errors.test.js
+++ b/tests/unit/errors.test.js
@@ -72,6 +72,29 @@ describe('helpers/errors toError', () => {
     assert.strictEqual(reported('ctx', new Error('boom')).name, 'Error');
   });
 
+  // The whole attribution rests on the type ending in Error, so it is forced onto a cause's
+  // own name too - that value is third-party. ErrorHandler is the trap: it contains "Error"
+  // but the header still lacks the literal "Error: " the parser looks for.
+  it('forces the Error suffix onto a cause type that lacks it', () => {
+    const named = name => Object.assign(new Error('/api/v1/some/path at handler'), { name });
+
+    assert.strictEqual(reported('ctx', named('Timeout')).name, 'TimeoutError');
+    assert.strictEqual(reported('ctx', named('ErrorHandler')).name, 'ErrorHandlerError');
+    assert.strictEqual(reported('ctx', named('')).name, 'ApiError');
+
+    // both shapes, since they fail the invariant for different reasons
+    for (const name of ['Timeout', 'ErrorHandler']) {
+      const wrapped = reported('ctx', named(name));
+      const culprit = frameLines(wrapped)[wrapped.framesToPop];
+      assert.ok(!culprit.includes('helpers/errors'), `culprit is still the helper for ${name}: ${culprit}`);
+    }
+  });
+
+  // A non-string name would make the suffix check throw, out of a catch block, at every site.
+  it('survives a cause with a non-string name', () => {
+    assert.strictEqual(reported('ctx', Object.assign(new Error('boom'), { name: 42 })).name, 'ApiError');
+  });
+
   // Not every backend answers with {statusCode, message}: the boltcard API is LNbits, which
   // replies {"detail": ...}. Dropping it here would leave the issue title carrying only the
   // context, with no trace of what actually failed.

--- a/tests/unit/errors.test.js
+++ b/tests/unit/errors.test.js
@@ -123,6 +123,15 @@ describe('helpers/errors toError', () => {
     assert.strictEqual(reported('ctx', throwing).message, 'ctx');
   });
 
+  it('survives a body whose message getter throws', () => {
+    const throwing = Object.defineProperty({ statusCode: 500 }, 'message', {
+      get() {
+        throw new Error('nope');
+      },
+    });
+    assert.strictEqual(reported('ctx', throwing).name, 'Api500Error');
+  });
+
   it('survives a body whose statusCode getter throws', () => {
     const throwing = Object.defineProperty({ message: 'Bad' }, 'statusCode', {
       get() {
@@ -130,6 +139,33 @@ describe('helpers/errors toError', () => {
       },
     });
     assert.strictEqual(reported('ctx', throwing).name, 'ApiError');
+  });
+
+  // A non-string message reached .replace() and threw before it was guarded - the worse half
+  // of the same bug, and the half that had no test.
+  it('survives a cause with a non-string message', () => {
+    const nonString = Object.defineProperty(new Error('boom'), 'message', { value: 42 });
+    assert.strictEqual(reported('ctx', nonString).message, 'ctx');
+  });
+
+  // The last two places somebody else's code runs during reporting: String() on a function
+  // reaches its toString, and instanceof consults a Proxy's getPrototypeOf trap.
+  it('survives a rejection that is a hostile function or proxy', () => {
+    const hostileFn = () => {};
+    hostileFn.toString = () => {
+      throw new Error('nope');
+    };
+    assert.strictEqual(reported('ctx', hostileFn).message, 'ctx');
+
+    const hostileProxy = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw new Error('nope');
+        },
+      },
+    );
+    assert.ok(reported('ctx', hostileProxy) instanceof Error);
   });
 
   // A non-string name would make the suffix check throw, out of a catch block, at every site.

--- a/tests/unit/errors.test.js
+++ b/tests/unit/errors.test.js
@@ -8,11 +8,13 @@ const { reportError } = require('../../helpers/errors');
 // its value reads "... [object Object]" whatever went wrong, and one status cannot be told
 // from another.
 // The header line can itself contain " at " once a server-supplied message is folded into it,
-// so drop it the way the SDK's parser does before counting frames.
+// so drop it the way the SDK's parser does - by content, not by position. Dropping line 0
+// would agree with the SDK on correct code and so hide the regression these tests exist to
+// catch: a type not ending in Error leaves the header parseable as a frame.
 const frameLines = error =>
   error.stack
     .split('\n')
-    .slice(1)
+    .filter(l => !l.includes('Error: '))
     .filter(l => /\s+at\s/.test(l));
 
 describe('helpers/errors toError', () => {

--- a/tests/unit/errors.test.js
+++ b/tests/unit/errors.test.js
@@ -90,6 +90,27 @@ describe('helpers/errors toError', () => {
     }
   });
 
+  // Everything read off a cause is third-party input reached from inside a catch block, so
+  // none of it may throw or land unflattened in the stack header.
+  it('survives a hostile cause name', () => {
+    const withName = descriptor => Object.defineProperty(new Error('boom'), 'name', descriptor);
+
+    // a getter is somebody else's code, and this runs inside a catch block
+    const throwing = withName({
+      get() {
+        throw new Error('nope');
+      },
+    });
+    assert.strictEqual(reported('ctx', throwing).name, 'ApiError');
+
+    // trailing space would otherwise fail endsWith and yield "Error Error"
+    assert.strictEqual(reported('ctx', withName({ value: 'Error ' })).name, 'Error');
+    // a newline would land in the stack header
+    assert.ok(!reported('ctx', withName({ value: 'Ti\nmeout' })).name.includes('\n'));
+    // the type is half the issue title, so it is bounded like the detail
+    assert.ok(reported('ctx', withName({ value: 'A'.repeat(300) })).name.length <= 65);
+  });
+
   // A non-string name would make the suffix check throw, out of a catch block, at every site.
   it('survives a cause with a non-string name', () => {
     assert.strictEqual(reported('ctx', Object.assign(new Error('boom'), { name: 42 })).name, 'ApiError');

--- a/tests/unit/errors.test.js
+++ b/tests/unit/errors.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 
-const { toError } = require('../../helpers/errors');
+const { toError, reportError } = require('../../helpers/errors');
 
 // The HTTP layers reject with the parsed error body rather than an Error, and Sentry files
 // an issue from the first Error among the console arguments. Everything below is about what
@@ -52,10 +52,30 @@ describe('helpers/errors toError', () => {
     assert.ok(toError('ctx', { type: 'AUTH_FAILED', code: '91ae' }).message.includes('AUTH_FAILED'));
   });
 
-  it('never renders an object as [object Object]', () => {
-    // the last shape is the trap: `message` present, but itself an object
-    for (const shape of [{}, { statusCode: 500 }, { unexpected: 'shape' }, { statusCode: 400, message: { code: 'x' } }]) {
-      assert.ok(!toError('ctx', shape).message.includes('[object Object]'), `leaked for ${JSON.stringify(shape)}`);
+  it('never renders an object as [object Object], in the value or the type', () => {
+    // both traps: `message` present but itself an object, and the same for `statusCode` -
+    // the type is half the issue title, so an unguarded one puts it right back
+    const shapes = [
+      {},
+      { statusCode: 500 },
+      { unexpected: 'shape' },
+      { statusCode: 400, message: { code: 'x' } },
+      { statusCode: { a: 1 } },
+    ];
+    for (const shape of shapes) {
+      const error = toError('ctx', shape);
+      assert.ok(!error.message.includes('[object Object]'), `value leaked for ${JSON.stringify(shape)}`);
+      assert.ok(!error.name.includes('[object Object]'), `type leaked for ${JSON.stringify(shape)}`);
+    }
+  });
+
+  // Whatever came off the wire is bounded, whichever field it arrived in: an issue title is
+  // not the place for a 5 kB error body.
+  it('caps a long detail from either branch', () => {
+    for (const shape of [{ detail: 'a'.repeat(5000) }, { statusCode: 500, message: 'b'.repeat(5000) }]) {
+      const { message } = toError('ctx', shape);
+      assert.ok(message.length <= 'ctx: '.length + 203, `not capped: ${message.length}`);
+      assert.ok(message.endsWith('...'), 'truncation should be marked');
     }
   });
 
@@ -66,5 +86,46 @@ describe('helpers/errors toError', () => {
     const circular = {};
     circular.self = circular;
     assert.strictEqual(toError('ctx', circular).message, 'ctx');
+  });
+
+  // The Error is built inside the helper, so without popping frames the culprit shown on
+  // every issue in the app would be helpers/errors.ts rather than the code that failed.
+  it('pops its own frames so the culprit is the call site', () => {
+    assert.strictEqual(toError('ctx', 'boom').framesToPop, 1);
+    // and it must not be serialized along with the error
+    assert.ok(!Object.keys(toError('ctx', 'boom')).includes('framesToPop'));
+  });
+});
+
+describe('helpers/errors reportError', () => {
+  let calls;
+  beforeEach(() => {
+    calls = [];
+    jest.spyOn(console, 'error').mockImplementation((...args) => calls.push(args));
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  // Context first: the console-to-logs integration only builds a message template when the
+  // first argument is a string. captureConsole still files the wrapper, because it takes the
+  // first Error among the arguments rather than the first argument.
+  it('logs the context first, then the wrapper, then the original', () => {
+    const original = { statusCode: 404, message: 'Not found' };
+    reportError('receivePos: poll failed', original);
+
+    const [args] = calls;
+    assert.strictEqual(args[0], 'receivePos: poll failed');
+    assert.ok(args[1] instanceof Error);
+    assert.strictEqual(args[1].name, 'ApiError404');
+    assert.strictEqual(args[2], original);
+    // what captureConsole would pick
+    assert.strictEqual(
+      args.find(a => a instanceof Error),
+      args[1],
+    );
+  });
+
+  it('pops the extra helper frame it adds', () => {
+    reportError('ctx', new Error('boom'));
+    assert.strictEqual(calls[0][1].framesToPop, 2);
   });
 });

--- a/tests/unit/errors.test.js
+++ b/tests/unit/errors.test.js
@@ -1,31 +1,57 @@
 const assert = require('assert');
 
-const { toError, reportError } = require('../../helpers/errors');
+const { reportError } = require('../../helpers/errors');
 
 // The HTTP layers reject with the parsed error body rather than an Error, and Sentry files
 // an issue from the first Error among the console arguments. Everything below is about what
 // the resulting issue looks like: an un-normalized body is still grouped per call site, but
 // its value reads "... [object Object]" whatever went wrong, and one status cannot be told
 // from another.
+// The header line can itself contain " at " once a server-supplied message is folded into it,
+// so drop it the way the SDK's parser does before counting frames.
+const frameLines = error =>
+  error.stack
+    .split('\n')
+    .slice(1)
+    .filter(l => /\s+at\s/.test(l));
+
 describe('helpers/errors toError', () => {
+  // Asserted through the exported entry point rather than the internal builder, so the tests
+  // exercise exactly what the 21 call sites run.
+  let consoleError;
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  const reported = (context, e) => {
+    consoleError.mockClear();
+    reportError(context, e);
+    return consoleError.mock.calls[0][1];
+  };
+
   it('titles a DFX error body with the context and its message', () => {
-    const error = toError('DFX session init failed', { statusCode: 401, message: 'Unauthorized' });
+    const error = reported('DFX session init failed', { statusCode: 401, message: 'Unauthorized' });
     assert.strictEqual(error.message, 'DFX session init failed: Unauthorized');
   });
 
   // Sentry ignores the message once a stack contributes and groups on the type, so the
   // status has to live in the name or a 400 and a 500 from one site become one issue.
   it('puts the status in the type so statuses stay separate issues', () => {
-    assert.strictEqual(toError('ctx', { statusCode: 400, message: 'Bad' }).name, 'ApiError400');
-    assert.strictEqual(toError('ctx', { statusCode: 500, message: 'Boom' }).name, 'ApiError500');
+    assert.strictEqual(reported('ctx', { statusCode: 400, message: 'Bad' }).name, 'Api400Error');
+    assert.strictEqual(reported('ctx', { statusCode: 500, message: 'Boom' }).name, 'Api500Error');
+    // ...and it has to END in Error: the stack parser skips the header line by looking for
+    // "Error: " in it, so ApiError400 would leave the header to be parsed as a phantom frame
+    // that absorbs the pop, putting the culprit back on this helper.
+    assert.ok(reported('ctx', { statusCode: 400, message: 'Bad' }).stack.includes('Error: '));
   });
 
-  // Wrapped rather than returned as-is: the wrapper's stack points at the call site, which
-  // is what keeps sites apart. `TypeError: Network request failed` carries no app frames,
+  // Wrapped rather than returned as-is: the wrapper is built per call site and pops the
+  // helper's own frames, which is what keeps sites apart. `TypeError: Network request failed` carries no app frames,
   // so returning it unchanged would merge every site in the app into one issue.
   it('keeps the context for a rejection that is already an Error', () => {
     const cause = new TypeError('Network request failed');
-    const error = toError('receivePos: payment status poll failed', cause);
+    const error = reported('receivePos: payment status poll failed', cause);
 
     assert.strictEqual(error.message, 'receivePos: payment status poll failed: Network request failed');
   });
@@ -34,22 +60,22 @@ describe('helpers/errors toError', () => {
   // from the LAST exception, so attaching the cause would put "TypeError: Network request
   // failed" back in the title and undo the attribution the wrapper exists to provide.
   it('does not chain the original, which would take over the issue title', () => {
-    const error = toError('ctx', new TypeError('Network request failed'));
+    const error = reported('ctx', new TypeError('Network request failed'));
     assert.strictEqual(error.cause, undefined);
   });
 
   // An NFC or signing failure reaches the same helper and must not be filed as an ApiError.
   it('keeps a non-API cause its own type', () => {
-    assert.strictEqual(toError('ctx', new TypeError('boom')).name, 'TypeError');
-    assert.strictEqual(toError('ctx', new Error('boom')).name, 'Error');
+    assert.strictEqual(reported('ctx', new TypeError('boom')).name, 'TypeError');
+    assert.strictEqual(reported('ctx', new Error('boom')).name, 'Error');
   });
 
   // Not every backend answers with {statusCode, message}: the boltcard API is LNbits, which
   // replies {"detail": ...}. Dropping it here would leave the issue title carrying only the
   // context, with no trace of what actually failed.
   it('keeps a body that does not match the DFX shape', () => {
-    assert.strictEqual(toError('ctx', { detail: 'card not found' }).message, 'ctx: {"detail":"card not found"}');
-    assert.ok(toError('ctx', { type: 'AUTH_FAILED', code: '91ae' }).message.includes('AUTH_FAILED'));
+    assert.strictEqual(reported('ctx', { detail: 'card not found' }).message, 'ctx: {"detail":"card not found"}');
+    assert.ok(reported('ctx', { type: 'AUTH_FAILED', code: '91ae' }).message.includes('AUTH_FAILED'));
   });
 
   it('never renders an object as [object Object], in the value or the type', () => {
@@ -63,7 +89,7 @@ describe('helpers/errors toError', () => {
       { statusCode: { a: 1 } },
     ];
     for (const shape of shapes) {
-      const error = toError('ctx', shape);
+      const error = reported('ctx', shape);
       assert.ok(!error.message.includes('[object Object]'), `value leaked for ${JSON.stringify(shape)}`);
       assert.ok(!error.name.includes('[object Object]'), `type leaked for ${JSON.stringify(shape)}`);
     }
@@ -73,27 +99,46 @@ describe('helpers/errors toError', () => {
   // not the place for a 5 kB error body.
   it('caps a long detail from either branch', () => {
     for (const shape of [{ detail: 'a'.repeat(5000) }, { statusCode: 500, message: 'b'.repeat(5000) }]) {
-      const { message } = toError('ctx', shape);
+      const { message } = reported('ctx', shape);
       assert.ok(message.length <= 'ctx: '.length + 203, `not capped: ${message.length}`);
       assert.ok(message.endsWith('...'), 'truncation should be marked');
     }
   });
 
   it('keeps a primitive rejection readable and survives an unserializable one', () => {
-    assert.strictEqual(toError('ctx', 'plain string').message, 'ctx: plain string');
-    assert.strictEqual(toError('ctx', undefined).message, 'ctx');
+    assert.strictEqual(reported('ctx', 'plain string').message, 'ctx: plain string');
+    assert.strictEqual(reported('ctx', undefined).message, 'ctx');
 
     const circular = {};
     circular.self = circular;
-    assert.strictEqual(toError('ctx', circular).message, 'ctx');
+    assert.strictEqual(reported('ctx', circular).message, 'ctx');
   });
 
   // The Error is built inside the helper, so without popping frames the culprit shown on
   // every issue in the app would be helpers/errors.ts rather than the code that failed.
-  it('pops its own frames so the culprit is the call site', () => {
-    assert.strictEqual(toError('ctx', 'boom').framesToPop, 1);
-    // and it must not be serialized along with the error
-    assert.ok(!Object.keys(toError('ctx', 'boom')).includes('framesToPop'));
+  // Asserted on the resulting stack, not on the constant: the count has to track the
+  // helper's call depth, and a stale one would silently misattribute every issue while an
+  // equality check against the literal stayed green.
+  it('pops exactly its own frames, so the stack resumes at the caller', () => {
+    const error = reported('ctx', 'boom');
+    const culprit = frameLines(error)[error.framesToPop];
+    assert.ok(!culprit.includes('helpers/errors'), `culprit is still the helper: ${culprit}`);
+    assert.ok(culprit.includes('errors.test.js'), `culprit is not the caller: ${culprit}`);
+  });
+
+  // A stack is just a string, so newlines in a server-supplied message parse as real frames:
+  // they push the true frames past the pop and let the remote end choose what gets blamed.
+  it('does not let a server-supplied message inject stack frames', () => {
+    const error = reported('ctx', { statusCode: 500, message: 'boom\n    at attackerFrame (/evil.js:1:1)' });
+
+    assert.ok(!error.message.includes('\n'), 'detail should be flattened to one line');
+    const culprit = frameLines(error)[error.framesToPop];
+    assert.ok(!culprit.includes('attackerFrame'), `injected frame became the culprit: ${culprit}`);
+    assert.ok(culprit.includes('errors.test.js'), `culprit is not the caller: ${culprit}`);
+  });
+
+  it('does not serialize framesToPop along with the error', () => {
+    assert.ok(!Object.keys(reported('ctx', 'boom')).includes('framesToPop'));
   });
 });
 
@@ -115,7 +160,7 @@ describe('helpers/errors reportError', () => {
     const [args] = calls;
     assert.strictEqual(args[0], 'receivePos: poll failed');
     assert.ok(args[1] instanceof Error);
-    assert.strictEqual(args[1].name, 'ApiError404');
+    assert.strictEqual(args[1].name, 'Api404Error');
     assert.strictEqual(args[2], original);
     // what captureConsole would pick
     assert.strictEqual(
@@ -124,8 +169,11 @@ describe('helpers/errors reportError', () => {
     );
   });
 
-  it('pops the extra helper frame it adds', () => {
+  it('pops its own frame too, so the stack still resumes at the caller', () => {
     reportError('ctx', new Error('boom'));
-    assert.strictEqual(calls[0][1].framesToPop, 2);
+    const error = calls[0][1];
+    const culprit = frameLines(error)[error.framesToPop];
+    assert.ok(!culprit.includes('helpers/errors'), `culprit is still the helper: ${culprit}`);
+    assert.ok(culprit.includes('errors.test.js'), `culprit is not the caller: ${culprit}`);
   });
 });


### PR DESCRIPTION
## Why

Three gaps in error reporting, plus a bug in the support id two of them depend on.

**Caught errors never opened an issue.** Anything reaching `console.error` was recorded as
a breadcrumb and a log, but nothing created an issue, so nothing alerted on it. Failed
language loads, fiat rate refresh failures and NFC read failures were visible only to
someone reading the log stream by hand.

**Log records could not be attributed to a device.** The app never set a Sentry user, so
error events fell back to the SDK's own per-install id while log records carried no user
at all. "One device reconnecting six times" and "six devices affected" were
indistinguishable, and a log row could not be joined to the error it belonged to.

**The support id was a Promise.** `getUniqueId()` is async in `react-native-device-info`
14, so `'userId:' + getUniqueId()` put the literal string `userId:[object Promise]` on the
clipboard and the About screen rendered a pending Promise. Support has been receiving a
placeholder.

## What

- `captureConsoleIntegration({ levels: ['error'] })`. Errors only — `warn` is far too
  noisy, Electrum reconnects alone produce hundreds a day.
- `logError` no longer calls `captureException` itself; with the integration active that
  would file everything twice.
- The device id is set as the Sentry **user**, so it lands on both error events and log
  records, and is applied after `init()` so it reaches the native scope too.
- Opting back in mid-session re-installs the integrations `init()` skipped while the client
  was disabled. Without this a user who launched with Do Not Track on and then turned it
  off would have had no error handlers, no frame rewriting and no dedupe for the rest of
  the session.
- `getUniqueIdSync()` at the two About-screen sites — what upstream BlueWallet calls at the
  same two places on the same library version.

### `helpers/errors.ts`

The HTTP layers reject with the parsed error body rather than an `Error`
(`api/dfx/hooks/api.hook.ts`, `api/boltcards/hooks/api.hook.ts`, `api/lds/hooks/api.hook.ts`
all `throw body`). Sentry files an issue from the first `Error` among the console arguments,
so a raw body produced one issue per site titled `... [object Object]`, whatever went wrong.
`reportError(context, e)` is now used at all 21 sites that log such a rejection. It:

- wraps every rejection, including real `Error`s — a network `TypeError` is thrown inside the
  fetch polyfill with no app frames, so passing it through merges every network failure in
  the app into one unattributable issue;
- pops its own frames so the issue culprit is the call site rather than the helper;
- puts the status in the exception **type** (`Api404Error`), because Sentry ignores the
  message once a stack contributes. The type must *end* in `Error`: the stack parser skips
  the header line by looking for the literal `"Error: "`, and a type without that suffix
  leaves the header to be parsed as a phantom frame that absorbs the pop;
- flattens and caps the detail, because a stack is just a string and newlines in a
  server-supplied message parse as injected frames — which would let the remote end choose
  what the issue blames;
- treats every value it reads as hostile. `name`, `message` and `statusCode` can all be
  getters, `String()` runs `toString`, and `instanceof` consults a prototype chain a Proxy
  can trap — all of it third-party code running inside a catch block, where a throw turns a
  handled error into an unhandled one at every reporting site.

Sites that catch Realm, keychain or native-module failures are deliberately left alone:
those are real `Error`s carrying app frames, and they already group per root cause.

## Notes for review

**This adds a dependency, which `CONTRIBUTING.md` asks us not to do.** Please accept or
reject deliberately. `captureConsoleIntegration` is not re-exported by
`@sentry/react-native`, so it comes from `@sentry/core` — already a transitive dependency
of the SDK at the identical version, declared here at that exact version, one hoisted copy
in the lockfile, so it adds no install surface. The alternative is hand-rolling a console
hook, which risks recursion and would suppress the SDK's own breadcrumb and log path. Both
Sentry packages are exact-pinned and a test asserts they resolve to one module, because a
copy at a different version would make the integration a silent no-op.

**This ships a more durable device identifier than before.** `getUniqueIdSync()` is
`identifierForVendor` on iOS and `ANDROID_ID` on Android; the latter survives app
reinstall, where the id Sentry reported previously was random per install. It is used
deliberately — it is the id the About screen offers users to copy for support, and any
other value makes a support request unmatchable to its telemetry — and it is only set while
tracking is enabled. `docs/crash-reports.md` states this plainly rather than glossing it.

**Pre-existing, not addressed here:** turning Do Not Track on mid-session stops the JS
client immediately, but the already-started native SDK keeps sending its own session
envelopes until the app is restarted. Making that airtight means closing the client on
opt-out, which would then require a restart to re-enable — a product decision rather than
something to change in passing. The docs describe the current behaviour accurately, in both
directions.

Only `console.error` opens issues; `console.warn` stays a log and a breadcrumb. In release
builds React does not emit its development warnings, so the new issues come from the app's
own call sites.

## Verification

Built and run on an iOS simulator, driven to the About screen:

- The screen renders a real UUID; before this it rendered a pending Promise.
- One tap on Copy produced exactly one issue, mechanism `auto.core.capture_console` — the
  integration files it, and the duplicate is gone.
- Log records from the run carry the device id. Records from before the change, in the same
  query, show none — so the query is its own control.

The helper's guards are mutation-tested rather than asserted on constants: deleting the
Error-suffix enforcement, weakening it to a substring check, dropping the frame pop or
removing the flatten each fail the suite. `tsc`, `eslint` (0 errors) and the unit suite
pass locally.
