### PR TITLE
fix(lnurl): unblock lnurl-pay to services that omit description_hash

### DIFF
--- a/class/lnurl.js
+++ b/class/lnurl.js
@@ -169,7 +169,7 @@ export default class Lnurl {
     const decoded = this.decodeInvoice(this._lnurlPayServiceBolt11Payload.pr);
     const metadataHash = createHash('sha256').update(this._lnurlPayServicePayload.metadata).digest('hex');
     if (metadataHash !== decoded.description_hash) {
-      throw new Error(`Invoice description_hash doesn't match metadata.`);
+      console.log(`Invoice description_hash doesn't match metadata.`);
     }
     if (parseInt(decoded.num_satoshis, 10) !== Math.round(amountSat)) {
       throw new Error(`Invoice doesn't match specified amount, got ${decoded.num_satoshis}, expected ${Math.round(amountSat)}`);
@@ -180,7 +180,9 @@ export default class Lnurl {
 
   async callLnurlPayService() {
     if (!this._lnurl) throw new Error('this._lnurl is not set');
-    const url = Lnurl.getUrlFromLnurl(this._lnurl).replace('lightning:', '').replace('lightning=', '').replace('lnurlp://', 'https://');
+    const lnurlUrl = Lnurl.getUrlFromLnurl(this._lnurl);
+    if (!lnurlUrl) throw new Error('Invalid LNURL');
+    const url = lnurlUrl.replace('lightning:', '').replace('lightning=', '').replace('lnurlp://', 'https://');
     // calling the url
     const reply = await this.fetchGet(url);
 
@@ -208,8 +210,8 @@ export default class Lnurl {
     }
 
     // setting the payment screen with the parameters
-    const min = Math.ceil((data.minSendable || 0) / 1000);
-    const max = Math.floor(data.maxSendable / 1000);
+    const min = Math.ceil((data.minSendable ?? 0) / 1000);
+    const max = Math.floor((data.maxSendable ?? 0) / 1000);
 
     this._lnurlPayServicePayload = {
       callback: data.callback,
@@ -322,7 +324,11 @@ export default class Lnurl {
     return new Promise((resolve, reject) => {
       if (!this._lnurl) throw new Error('this._lnurl is not set');
 
-      const url = parse(Lnurl.getUrlFromLnurl(this._lnurl), true);
+      const url = parse(Lnurl.getUrlFromLnurl(this._lnurl) || '', true);
+
+      if (!url.hostname) {
+        throw new Error('Invalid URL: hostname is null');
+      }
 
       const hmac = createHmac('sha256', secret);
       hmac.on('readable', async () => {

--- a/tests/unit/lnurl.test.js
+++ b/tests/unit/lnurl.test.js
@@ -208,7 +208,7 @@ describe('LNURL', function () {
     const payload = await LN.callLnurlPayService();
     assert.strictEqual(payload.max, 0);
     // an undefined max used to produce NaN, which silently disabled the upper amount bound
-    await assert.rejects(LN.requestBolt11FromLnurlPayService(100));
+    await assert.rejects(LN.requestBolt11FromLnurlPayService(100), /The specified amount is invalid/);
   });
 
   it('can callLnurlPayService() and requestBolt11FromLnurlPayService() with comment', async () => {

--- a/tests/unit/lnurl.test.js
+++ b/tests/unit/lnurl.test.js
@@ -154,6 +154,63 @@ describe('LNURL', function () {
     assert.strictEqual(LN.getCommentAllowed(), false);
   });
 
+  it('can requestBolt11FromLnurlPayService() when the invoice has no description_hash', async () => {
+    // some services (e.g. Wallet of Satoshi) return an invoice with a plain `description` tag
+    // instead of the `description_hash` LUD-06 asks for. that must not block the payment.
+    const LN = new Lnurl('testuser@example.com');
+
+    LN.fetchGet = () => {
+      return {
+        status: 'OK',
+        callback: 'https://example.com/api/v1/lnurl/payreq/00000000-0000-0000-0000-000000000000',
+        tag: 'payRequest',
+        maxSendable: 1000000000,
+        minSendable: 1000,
+        metadata: '[["text/plain","Pay to Wallet of Satoshi user: testuser"],["text/identifier","testuser@example.com"]]',
+      };
+    };
+    await LN.callLnurlPayService();
+
+    LN.fetchGet = () => {
+      return {
+        status: 'OK',
+        pr: 'lnbc20n1pj48ugqpp5qqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqqqsyqcyq5rqwzqfqypqdpl2pshjgr5dus9wctvd3jhggr0vcs9xct5daeks6fqw4ek2u36yp6x2um5w4ek2usxqrrsscqpfsapyhslrges8uppeeqv8l3v3yq74j9ny70pf0aa039mxp7pvu7hqr0guqg5rxcgy9h7ux9je9hq5w6yj45wx2xwxdr4ncj809lxq49qq6pumnl',
+        routes: [],
+      };
+    };
+
+    const rez = await LN.requestBolt11FromLnurlPayService(2);
+    assert.strictEqual(rez.status, 'OK');
+    assert.strictEqual(LN.decodeInvoice(rez.pr).description_hash, undefined);
+  });
+
+  it('rejects callLnurlPayService() with a clear error when the lnurl is not parseable', async () => {
+    const LN = new Lnurl('bs');
+    await assert.rejects(LN.callLnurlPayService(), err => {
+      assert.strictEqual(err.message, 'Invalid LNURL');
+      return true;
+    });
+  });
+
+  it('defaults max to 0 when the service omits maxSendable', async () => {
+    const LN = new Lnurl('testuser@example.com');
+
+    LN.fetchGet = () => {
+      return {
+        status: 'OK',
+        callback: 'https://example.com/api/v1/lnurl/payreq/00000000-0000-0000-0000-000000000000',
+        tag: 'payRequest',
+        minSendable: 1000,
+        metadata: '[["text/plain","Pay to testuser"]]',
+      };
+    };
+
+    const payload = await LN.callLnurlPayService();
+    assert.strictEqual(payload.max, 0);
+    // an undefined max used to produce NaN, which silently disabled the upper amount bound
+    await assert.rejects(LN.requestBolt11FromLnurlPayService(100));
+  });
+
   it('can callLnurlPayService() and requestBolt11FromLnurlPayService() with comment', async () => {
     const LN = new Lnurl('lnurl1dp68gurn8ghj7cmgv96zucnvd9u8gampd3kx2apwvdhk6tmpwp5j7um9dejz6ar90p6q3eqkzd');
 
@@ -260,6 +317,14 @@ describe('lightning address', function () {
       requestedUri,
       'https://lightninglogin.live/login?k1=2191be568cfe6d2a8e8a90ce04c15edf70fdcae6c1b9faff684acab6f400fa0d&tag=login&sig=304502210093ab4ead8dd619f2ddb3d52bd4bb01725badcb2a3daa3870fb41a38096f9a37d0220464a32e94e13dcec20ea94b94df0fa52f45cd88b01d7247042136ad0c71752d2&key=03e7b61e57efff1925ab9082625400cae2c8ad88a984e7aa4987abb77818570018',
     );
+  });
+
+  it('rejects authenticate() with a clear error when the lnurl is not parseable', async () => {
+    const LN = new Lnurl('bs');
+    await assert.rejects(LN.authenticate('lndhub://dc56b8cf8ef3b60060cf:94eac57510de2738451d'), err => {
+      assert.strictEqual(err.message, 'Invalid URL: hostname is null');
+      return true;
+    });
   });
 
   it('returns the server error response as the reject error from lnurl-auth', async () => {


### PR DESCRIPTION
## Problem

Paying a Wallet of Satoshi lightning address always failed with `Invoice description_hash doesn't match metadata.`, regardless of amount.

Reproduced live against a WoS address:

```
metadata raw       : [["text/plain","Pay to Wallet of Satoshi user: <user>"],["text/identifier","<user>@walletofsatoshi.com"]]
sha256(metadata)   : <32 bytes, non-zero>
invoice desc_hash  : undefined        ← no `h` tag on the invoice
invoice description: "Pay to Wallet of Satoshi user: <user>"
```

WoS returns a bolt11 carrying a plain `description` (`d`) tag instead of the `description_hash` (`h`) tag LUD-06 asks for. So `decoded.description_hash` is `undefined`, the equality check against `sha256(metadata)` can never hold, and every payment to such a service is rejected.

## Changes

**1. Downgrade the description_hash mismatch to a log** — ports upstream BlueWallet [`3da1a3339`](https://github.com/BlueWallet/BlueWallet/commit/3da1a3339) ("FIX: remove the LNURLp metadata validation"), which fixed the same report there in Jan 2024.

On what this gives up: the check bound the invoice to the metadata shown to the user. An attacker who controls the callback host *and* a Lightning node can mint an invoice with the correct `description_hash` anyway, so it never protected against that. What it did still catch is a callback relaying an invoice minted by an unrelated third party — note the callback host is not validated against the payRequest host, and the domain shown to the user is derived from the callback itself (`class/lnurl.js:221`), so "same server" is not guaranteed.

The narrower alternative — skip only when `description_hash` is absent, keep enforcing when present-but-mismatched — was considered and deliberately not taken. Upstream chose full removal with far broader exposure than this fork, and we only have evidence for the absent case; enforcing on mismatch would ship an untested hard-failure path in the payment flow for any service that deviates for a benign reason (metadata re-serialisation, LUD-18 payerData). Being unable to pay is the more likely harm here than the residual relay scenario.

The amount check directly below it, which prevents paying a different amount than displayed, is unchanged.

**2. Guard `getUrlFromLnurl()` returning `false`** — `callLnurlPayService()` called `.replace()` and `authenticate()` called `parse()` on the result, which is `false` for input it cannot parse. Unparseable input surfaced a raw `TypeError` instead of a readable message. The `Invalid LNURL` guard and the `|| ''` fallback port upstream [`a61f8fcb2`](https://github.com/BlueWallet/BlueWallet/commit/a61f8fcb2); the `url.hostname` guard ports [`8ae04cadb`](https://github.com/BlueWallet/BlueWallet/commit/8ae04cadb).

**3. Default `maxSendable`** — it was read without a default, so a service omitting it yielded `max = NaN`. Every `amountSat > max` comparison is then false, silently disabling the upper amount bound. The `min` side already had a default; this makes the two symmetric. The `?? 0` ports upstream [`a61f8fcb2`](https://github.com/BlueWallet/BlueWallet/commit/a61f8fcb2), in the form it was left by [`4a3068308`](https://github.com/BlueWallet/BlueWallet/commit/4a3068308) (which dropped the optional chaining).

Note this cuts the other way from change #1: a service that omits `maxSendable` goes from unbounded to `max = 0`, i.e. unpayable rather than payable-without-an-upper-bound. That is deliberate and matches upstream — `maxSendable` is required by LUD-06, so a payload omitting it is malformed, and failing closed on an amount bound in a wallet is the safe direction.

## Verification

- New regression test per fix. Each was mutation-checked: reverting a fix fails exactly its own test and no other.
- Full local CI green — `tsc`, `eslint` (changed files clean; repo-wide warning count unchanged from base), `find-unused-loc`, and the unit suite at 34 suites, 260 passed / 1 skipped.
- The description_hash test uses a synthetic signed invoice with a `description` tag and no `description_hash`, not a captured third-party invoice.

## Known follow-ups (deliberately not in this PR)

- The downgraded log line is kept byte-identical to upstream, so it cannot distinguish the benign case (hash absent, e.g. Wallet of Satoshi) from the residual risk described above (hash present but mismatched), and it carries no domain. Worth enriching, but not on the one line this PR exists to port 1:1.
- This file is ~2.5 years behind upstream. Upstream routes LNURL calls through a fetch wrapper with a 20s abort ([`238ee798a`](https://github.com/BlueWallet/BlueWallet/commit/238ee798a)); ours uses bare `fetch`, so an unresponsive LNURL server hangs the send screen indefinitely. Left out to keep this PR scoped — it needs a new `util/fetch` module.

## Note for the merger

The first commit's message contains a sentence claiming "the same server serves both the metadata and the invoice over TLS, so it could always make the two agree". That is not accurate for this codebase — the callback host is not validated against the payRequest host — and the analysis above supersedes it. It was left in place because amending an already-pushed commit is not allowed here; please drop that sentence if this is squash-merged.