### PR TITLE
bf63a821 - test: failing regression gates for the sell/swap Max amount defect

### DIFF
--- a/tests/unit/dfx-sell-max.test.js
+++ b/tests/unit/dfx-sell-max.test.js
@@ -16,6 +16,10 @@
  * Regression gates (tests 3–5) encode the REQUIRED post-fix behaviour; they FAIL today
  * on purpose so CI stays red until the sell-Max defect is fixed.
  *
+ * Note: the unit gate runs with jest -b (bail), so while the gates are red, suites
+ * scheduled after this one are skipped in that run. This is a known, temporary
+ * side effect until the fix lands.
+ *
  * No network, no AsyncStorage — pure wallet/coinselect math with injected UTXOs/balances.
  */
 
@@ -149,16 +153,11 @@ describe('DFX sell flow: Max amount handling', () => {
   it('sell confirm must not fail when part of the balance is frozen', () => {
     const w = makeWallet({ freeze: true });
     const amount = apiFloor5(launchBalancesParam(w, 3));
-    const amountSats = currency.btcToSatoshi(amount);
 
-    // Defect precondition: launch amount exceeds spendable (non-frozen) utxo sum
-    assert.ok(
-      amountSats > SPENDABLE_WHEN_FROZEN,
-      `precondition: launch amount (${amountSats} sats) must exceed spendable non-frozen sum (${SPENDABLE_WHEN_FROZEN}); ` +
-        'getBalance() includes the frozen UTXO while getUtxo() does not — that gap is the defect',
-    );
-
-    // Must not throw ("Not enough balance…" is the current broken outcome)
+    // With the current launch mirror the amount (~1,749,400 sats) exceeds the spendable
+    // non-frozen sum (1,500,000): getBalance() includes the frozen UTXO while getUtxo()
+    // does not — that gap is the defect. A launch-side fix shrinks the amount, a
+    // confirm-side fix absorbs it; either way the confirm below must build a tx.
     const { tx, outputs, fee } = sellConfirm(w, amount, 3);
 
     assert.ok(tx, 'expected a transaction');
@@ -167,10 +166,17 @@ describe('DFX sell flow: Max amount handling', () => {
       'expected deposit address in outputs',
     );
     const depositOut = outputs.find(o => o.address === DEPOSIT_ADDR);
-    // A correct fix may reduce the sent amount send-max-style or clamp it — both acceptable
+    // A correct fix may reduce the sent amount send-max-style or clamp it — both acceptable.
+    // Upper bound: must not spend frozen funds. Lower bound: must still be a genuine
+    // Max-sell (a token 1-sat deposit output would not fix anything).
     assert.ok(
       depositOut.value + fee <= SPENDABLE_WHEN_FROZEN,
       `output value (${depositOut.value}) + fee (${fee}) must not exceed spendable ${SPENDABLE_WHEN_FROZEN}`,
+    );
+    assert.ok(
+      depositOut.value + fee >= SPENDABLE_WHEN_FROZEN - 5000,
+      `output value (${depositOut.value}) + fee (${fee}) must stay within 5000 sats of spendable ${SPENDABLE_WHEN_FROZEN} — ` +
+        'a Max sell must move essentially the whole spendable balance',
     );
   });
 
@@ -191,6 +197,11 @@ describe('DFX sell flow: Max amount handling', () => {
     assert.ok(
       depositOut.value + fee <= TOTAL_BALANCE,
       `output value (${depositOut.value}) + fee (${fee}) must not exceed spendable ${TOTAL_BALANCE}`,
+    );
+    // Lower bound: the fix must still move essentially the whole balance (no token output)
+    assert.ok(
+      depositOut.value + fee >= TOTAL_BALANCE - 5000,
+      `output value (${depositOut.value}) + fee (${fee}) must stay within 5000 sats of spendable ${TOTAL_BALANCE}`,
     );
   });
 

--- a/tests/unit/dfx-sell-max.test.js
+++ b/tests/unit/dfx-sell-max.test.js
@@ -307,8 +307,8 @@ describe('DFX sell flow: Max amount handling', () => {
       `output value (${depositOut.value}) + fee (${fee}) must not exceed spendable ${SPENDABLE_WHEN_FROZEN}`,
     );
     assert.ok(
-      depositOut.value + fee >= SPENDABLE_WHEN_FROZEN - 5000,
-      `output value (${depositOut.value}) + fee (${fee}) must stay within 5000 sats of spendable ${SPENDABLE_WHEN_FROZEN} — ` +
+      depositOut.value + fee >= SPENDABLE_WHEN_FROZEN - 1000,
+      `output value (${depositOut.value}) + fee (${fee}) must stay within 1000 sats of spendable ${SPENDABLE_WHEN_FROZEN} — ` +
         'a Max sell must move essentially the whole spendable balance',
     );
   });
@@ -333,9 +333,12 @@ describe('DFX sell flow: Max amount handling', () => {
     );
     // Lower bound: the fix must still move essentially the whole balance (no token output)
     assert.ok(
-      depositOut.value + fee >= TOTAL_BALANCE - 5000,
-      `output value (${depositOut.value}) + fee (${fee}) must stay within 5000 sats of spendable ${TOTAL_BALANCE}`,
+      depositOut.value + fee >= TOTAL_BALANCE - 1000,
+      `output value (${depositOut.value}) + fee (${fee}) must stay within 1000 sats of spendable ${TOTAL_BALANCE}`,
     );
+    // The confirm-time rate must actually be honored: a "fix" that retries at the stale
+    // launch rate 3 would also build — catch it via the effective fee rate.
+    assert.ok(fee >= tx.virtualSize() * 4, `fee (${fee}) must cover the confirm-time rate of 4 sat/vB over ${tx.virtualSize()} vB`);
   });
 
   // FAILS until the sell-Max defect is fixed; this is the regression gate
@@ -359,9 +362,9 @@ describe('DFX sell flow: Max amount handling', () => {
     assert.ok(tx, 'expected a transaction');
     const depositOut = outputs.find(o => o.address === DEPOSIT_ADDR);
     assert.ok(depositOut, 'expected deposit address in outputs');
-    // 1234 or 1235 both acceptable (floor or round of 1234.5)
+    // Exactly the floor: rounding 1234.5 UP would send more than the user confirmed
     assert.ok(Number.isInteger(depositOut.value), `output value must be an integer number of satoshis, got ${depositOut.value}`);
-    assert.ok(depositOut.value >= 1234 && depositOut.value <= 1235, `output value must be 1234 or 1235, got ${depositOut.value}`);
+    assert.strictEqual(depositOut.value, 1234, `output value must be the floored 1234 sats, got ${depositOut.value}`);
   });
 
   // FAILS until the sell-Max defect is fixed; this is the regression gate
@@ -374,13 +377,15 @@ describe('DFX sell flow: Max amount handling', () => {
     const w = makeWallet();
     const amount = apiFloor5(launchBalancesParam(w, 3));
 
-    const { tx, outputs } = await sellConfirmViaFeeCache(w, amount);
+    const { tx, outputs, fee } = await sellConfirmViaFeeCache(w, amount);
 
     assert.ok(tx, 'expected a transaction');
     assert.ok(
       outputs.some(o => o.address === DEPOSIT_ADDR),
       'expected deposit address in outputs',
     );
-    // No fee-band assertion — any sane fee is fine for this gate
+    // The fallback must be a real fee, not zero: at least 1 sat/vB (the wallet's own
+    // floor elsewhere) — a zero-fee fallback would build an unrelayable transaction.
+    assert.ok(fee >= tx.virtualSize(), `fallback fee (${fee}) must be at least 1 sat/vB over ${tx.virtualSize()} vB`);
   });
 });

--- a/tests/unit/dfx-sell-max.test.js
+++ b/tests/unit/dfx-sell-max.test.js
@@ -11,21 +11,29 @@
  *      are not spendable at confirm → coinselect throws "Not enough balance…".
  *   4. Related gaps: fee-rate rise between launch and confirm, and fractional satoshis
  *      from btcToSatoshi on >8-decimal strings, also trip the fixed-value path.
+ *   5. Fee-cache gap: sell confirm reads AsyncStorage NetworkTransactionFee.StorageKey and
+ *      does Number(JSON.parse(res).fastestFee) with no empty-cache guard — reachable via
+ *      an external dfxtaro://sell deeplink that never ran the launch path that writes the cache.
  *
- * Controls (tests 1–2) document behaviour that already works and must stay green.
- * Regression gates (tests 3–5) encode the REQUIRED post-fix behaviour; they FAIL today
+ * Controls (tests 1–2, C3–C5) document behaviour that already works and must stay green.
+ * Regression gates (tests 3–5, G6) encode the REQUIRED post-fix behaviour; they FAIL today
  * on purpose so CI stays red until the sell-Max defect is fixed.
  *
  * Note: the unit gate runs with jest -b (bail), so while the gates are red, suites
  * scheduled after this one are skipped in that run. This is a known, temporary
  * side effect until the fix lands.
  *
- * No network, no AsyncStorage — pure wallet/coinselect math with injected UTXOs/balances.
+ * No network — pure wallet/coinselect math with injected UTXOs/balances.
+ * G6 uses the AsyncStorage jest mock only to exercise the empty fee-cache path.
  */
 
 import assert from 'assert';
 import BigNumber from 'bignumber.js';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { HDSegwitBech32Wallet } from '../../class';
+import { NetworkTransactionFee } from '../../models/networkTransactionFees';
+
+jest.mock('@react-native-async-storage/async-storage', () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'));
 
 const currency = require('../../blue_modules/currency');
 
@@ -46,6 +54,14 @@ const TOTAL_BALANCE = VAL0 + VAL1 + VAL2; // 1,750,000
 const TXID0 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const TXID1 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 const TXID2 = 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+// Dust utxos for C4 (addresses 3..7)
+const TXID_DUST = [
+  'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+  'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+  'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff',
+  '1111111111111111111111111111111111111111111111111111111111111111',
+  '2222222222222222222222222222222222222222222222222222222222222222',
+];
 
 // Backend sell deposit address (P2SH)
 const DEPOSIT_ADDR = '3HoYu1UhmuZe33puQtkt9Q21y7kyi4adiC';
@@ -74,6 +90,48 @@ function makeWallet({ freeze } = {}) {
 
   if (freeze) {
     w.setUTXOMetadata(TXID2, 0, { frozen: true });
+  }
+
+  return w;
+}
+
+/**
+ * Flexible wallet builder for robustness controls (C3–C5). Does NOT replace makeWallet —
+ * the original five tests keep using makeWallet unchanged.
+ *
+ * Each spec: { index, value, txid, unconfirmed?, confirmations?, frozen? }
+ * Address is derived from the wallet via _getExternalAddressByIndex(index).
+ */
+function makeWalletWith(utxoSpecs) {
+  const w = new HDSegwitBech32Wallet();
+  w.setSecret(SEED);
+
+  w._utxo = utxoSpecs.map(spec => {
+    const address = w._getExternalAddressByIndex(spec.index);
+    const entry = {
+      value: spec.value,
+      address,
+      txId: spec.txid,
+      vout: 0,
+      txid: spec.txid,
+      amount: spec.value,
+      wif: '-',
+    };
+    if (spec.confirmations !== undefined) {
+      entry.confirmations = spec.confirmations;
+    }
+    return entry;
+  });
+
+  for (const spec of utxoSpecs) {
+    if (spec.unconfirmed) {
+      w._balances_by_external_index[spec.index] = { c: 0, u: spec.value };
+    } else {
+      w._balances_by_external_index[spec.index] = { c: spec.value, u: 0 };
+    }
+    if (spec.frozen) {
+      w.setUTXOMetadata(spec.txid, 0, { frozen: true });
+    }
   }
 
   return w;
@@ -119,6 +177,22 @@ function sellConfirm(w, amountString, feeRate) {
   return w.createTransaction(w.getUtxo(), targets, feeRate, changeAddress(w), HDSegwitBech32Wallet.defaultRBFSequence);
 }
 
+/**
+ * mirrors screen/dfx/sell.tsx:75-89 INCLUDING the fee-cache read — update this mirror
+ * together with the production flow when fixing; the assertions define the required behaviour
+ *
+ * Production (sell.tsx:75-80):
+ *   AsyncStorage.getItem(NetworkTransactionFee.StorageKey).then(res => JSON.parse(res as string))
+ *   then Number(networkTransactionFees.fastestFee)
+ * Empty cache: getItem → null → JSON.parse(null) → null → .fastestFee TypeError.
+ */
+async function sellConfirmViaFeeCache(w, amountString) {
+  const networkTransactionFees = await AsyncStorage.getItem(NetworkTransactionFee.StorageKey).then(res => JSON.parse(res));
+  const requestedSatPerByte = Number(networkTransactionFees.fastestFee);
+  const targets = [{ address: DEPOSIT_ADDR, value: currency.btcToSatoshi(amountString) }];
+  return w.createTransaction(w.getUtxo(), targets, requestedSatPerByte, changeAddress(w), HDSegwitBech32Wallet.defaultRBFSequence);
+}
+
 describe('DFX sell flow: Max amount handling', () => {
   it('control: in-wallet Max (send-max target) builds a tx even with a frozen UTXO', () => {
     const w = makeWallet({ freeze: true });
@@ -138,6 +212,65 @@ describe('DFX sell flow: Max amount handling', () => {
 
   it('control: sell confirm builds a tx in the clean case (same fee rate, nothing frozen)', () => {
     const w = makeWallet();
+    const amount = apiFloor5(launchBalancesParam(w, 3));
+    const { tx, outputs, fee } = sellConfirm(w, amount, 3);
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(
+      outputs.some(o => o.address === DEPOSIT_ADDR),
+      'expected deposit address in outputs',
+    );
+    assert.ok(fee > 0, 'expected a positive fee');
+  });
+
+  it('control: sell confirm builds in the clean case with a single-utxo wallet', () => {
+    const w = makeWalletWith([{ index: 0, value: VAL0, txid: TXID0 }]);
+    const amount = apiFloor5(launchBalancesParam(w, 3));
+    const { tx, outputs, fee } = sellConfirm(w, amount, 3);
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(
+      outputs.some(o => o.address === DEPOSIT_ADDR),
+      'expected deposit address in outputs',
+    );
+    assert.ok(fee > 0, 'expected a positive fee');
+  });
+
+  it('control: sell confirm builds when the wallet also holds detrimental dust utxos', () => {
+    // Three standard utxos PLUS five 150-sat dust utxos on external indexes 3..7.
+    // At fee rate 3 a P2WPKH input costs ~204 sats — more than each dust contributes —
+    // so launch's send-max fee estimate still walks getUtxo() (includes dust) while
+    // confirm's coinselect can skip the uneconomic inputs. That asymmetry must not
+    // prevent confirm from building.
+    const specs = [
+      { index: 0, value: VAL0, txid: TXID0 },
+      { index: 1, value: VAL1, txid: TXID1 },
+      { index: 2, value: VAL2, txid: TXID2 },
+    ];
+    for (let i = 0; i < 5; i++) {
+      specs.push({ index: 3 + i, value: 150, txid: TXID_DUST[i] });
+    }
+    const w = makeWalletWith(specs);
+    const amount = apiFloor5(launchBalancesParam(w, 3));
+    const { tx, outputs, fee } = sellConfirm(w, amount, 3);
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(
+      outputs.some(o => o.address === DEPOSIT_ADDR),
+      'expected deposit address in outputs',
+    );
+    assert.ok(fee > 0, 'expected a positive fee');
+  });
+
+  it('control: sell confirm builds when part of the balance is unconfirmed', () => {
+    // Standard three utxos, but the 250,000-sat one is unconfirmed: balances {c:0,u:VAL2}
+    // and utxo confirmations: 0. Launch counts it (getBalance includes u); getUtxo also
+    // carries it — consistent end-to-end, so confirm must build.
+    const w = makeWalletWith([
+      { index: 0, value: VAL0, txid: TXID0 },
+      { index: 1, value: VAL1, txid: TXID1 },
+      { index: 2, value: VAL2, txid: TXID2, unconfirmed: true, confirmations: 0 },
+    ]);
     const amount = apiFloor5(launchBalancesParam(w, 3));
     const { tx, outputs, fee } = sellConfirm(w, amount, 3);
 
@@ -229,5 +362,25 @@ describe('DFX sell flow: Max amount handling', () => {
     // 1234 or 1235 both acceptable (floor or round of 1234.5)
     assert.ok(Number.isInteger(depositOut.value), `output value must be an integer number of satoshis, got ${depositOut.value}`);
     assert.ok(depositOut.value >= 1234 && depositOut.value <= 1235, `output value must be 1234 or 1235, got ${depositOut.value}`);
+  });
+
+  // FAILS until the sell-Max defect is fixed; this is the regression gate
+  it('sell confirm must not depend on a pre-populated network fee cache', async () => {
+    // Empty cache: do not seed NetworkTransactionFee.StorageKey.
+    // Rationale: the sell screen is reachable via an external dfxtaro://sell deeplink
+    // without the launch path (DfxServicesButtons.getEstimatedOnChainFee) ever having
+    // written the cache. Required behaviour: a sane fallback fee so confirm still builds.
+    // Today: JSON.parse(null) → null → .fastestFee TypeError.
+    const w = makeWallet();
+    const amount = apiFloor5(launchBalancesParam(w, 3));
+
+    const { tx, outputs } = await sellConfirmViaFeeCache(w, amount);
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(
+      outputs.some(o => o.address === DEPOSIT_ADDR),
+      'expected deposit address in outputs',
+    );
+    // No fee-band assertion — any sane fee is fine for this gate
   });
 });

--- a/tests/unit/dfx-sell-max.test.js
+++ b/tests/unit/dfx-sell-max.test.js
@@ -1,0 +1,222 @@
+/**
+ * DFX sell-flow Max-amount regression suite.
+ *
+ * Defect chain (why sell confirm can throw while in-wallet Max never does):
+ *   1. Launch (DfxServicesButtons) computes Max from getBalance() — includes frozen
+ *      and unconfirmed sats — minus a fee estimated over getUtxo() (excludes frozen).
+ *   2. That BTC amount is handed to the web app as the Max balance, then floored by the
+ *      backend to 5 significant digits, then returned via deeplink as a fixed amount.
+ *   3. Sell confirm (screen/dfx/sell) builds a FIXED-value target via btcToSatoshi(amount)
+ *      and coinselects over getUtxo() only — so frozen/unconfirmed funds counted at launch
+ *      are not spendable at confirm → coinselect throws "Not enough balance…".
+ *   4. Related gaps: fee-rate rise between launch and confirm, and fractional satoshis
+ *      from btcToSatoshi on >8-decimal strings, also trip the fixed-value path.
+ *
+ * Controls (tests 1–2) document behaviour that already works and must stay green.
+ * Regression gates (tests 3–5) encode the REQUIRED post-fix behaviour; they FAIL today
+ * on purpose so CI stays red until the sell-Max defect is fixed.
+ *
+ * No network, no AsyncStorage — pure wallet/coinselect math with injected UTXOs/balances.
+ */
+
+import assert from 'assert';
+import BigNumber from 'bignumber.js';
+import { HDSegwitBech32Wallet } from '../../class';
+
+const currency = require('../../blue_modules/currency');
+
+const SEED = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+// External addresses of SEED (BIP84)
+const ADDR0 = 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'; // 1,000,000 sats
+const ADDR1 = 'bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g'; // 500,000 sats
+const ADDR2 = 'bc1qp59yckz4ae5c4efgw2s5wfyvrz0ala7rgvuz8z'; // 250,000 sats (frozen in freeze cases)
+
+const VAL0 = 1000000;
+const VAL1 = 500000;
+const VAL2 = 250000;
+const SPENDABLE_WHEN_FROZEN = VAL0 + VAL1; // 1,500,000
+const TOTAL_BALANCE = VAL0 + VAL1 + VAL2; // 1,750,000
+
+// Distinct fake 64-hex txids (one per utxo)
+const TXID0 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const TXID1 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const TXID2 = 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+// Backend sell deposit address (P2SH)
+const DEPOSIT_ADDR = '3HoYu1UhmuZe33puQtkt9Q21y7kyi4adiC';
+// Fee-estimate dust address (verbatim from DfxServicesButtons)
+const DUST_ADDR = '36JxaUrpDzkEerkTf1FzwHNE1Hb7cCjgJV';
+
+/**
+ * Build an HDSegwitBech32Wallet with deterministic injected UTXOs + balances.
+ * mirrors abstract-hd-electrum-wallet getBalance/getUtxo structure — update this mirror
+ * together with the production flow when fixing; the assertions define the required behaviour
+ */
+function makeWallet({ freeze } = {}) {
+  const w = new HDSegwitBech32Wallet();
+  w.setSecret(SEED);
+
+  w._utxo = [
+    { value: VAL0, address: ADDR0, txId: TXID0, vout: 0, txid: TXID0, amount: VAL0, wif: '-' },
+    { value: VAL1, address: ADDR1, txId: TXID1, vout: 0, txid: TXID1, amount: VAL1, wif: '-' },
+    { value: VAL2, address: ADDR2, txId: TXID2, vout: 0, txid: TXID2, amount: VAL2, wif: '-' },
+  ];
+
+  // Exactly the structure a real electrum fetch fills — so getBalance() behaves like production
+  w._balances_by_external_index[0] = { c: VAL0, u: 0 };
+  w._balances_by_external_index[1] = { c: VAL1, u: 0 };
+  w._balances_by_external_index[2] = { c: VAL2, u: 0 };
+
+  if (freeze) {
+    w.setUTXOMetadata(TXID2, 0, { frozen: true });
+  }
+
+  return w;
+}
+
+/**
+ * mirrors screen/dfx/sell.tsx change-address resolution — update this mirror together with
+ * the production flow when fixing; the assertions define the required behaviour
+ */
+function changeAddress(w) {
+  return w._getInternalAddressByIndex(w.getNextFreeChangeAddressIndex());
+}
+
+/**
+ * mirrors components/DfxServicesButtons.tsx:89-117 — update this mirror together with the
+ * production flow when fixing; the assertions define the required behaviour
+ *
+ * Launch Max: fee from dust send-max over getUtxo(), then getBalance() - fee (balance includes
+ * frozen/unconfirmed; utxo path does not).
+ */
+function launchBalancesParam(w, feeRate) {
+  const { fee } = w.createTransaction(w.getUtxo(), [{ address: DUST_ADDR }], feeRate, changeAddress(w), false);
+  return new BigNumber(currency.satoshiToBTC(w.getBalance() - fee)).toString();
+}
+
+/**
+ * mirrors the backend's asset floor (5 significant digits, BigNumber.ROUND_FLOOR) — update
+ * this mirror together with the production flow when fixing; the assertions define the
+ * required behaviour
+ */
+function apiFloor5(amountStr) {
+  return new BigNumber(amountStr).precision(5, BigNumber.ROUND_FLOOR).toString();
+}
+
+/**
+ * mirrors screen/dfx/sell.tsx:75-89 — update this mirror together with the production flow
+ * when fixing; the assertions define the required behaviour
+ *
+ * Confirm: fixed-value target from the deeplink amount, coinselect over getUtxo().
+ */
+function sellConfirm(w, amountString, feeRate) {
+  const targets = [{ address: DEPOSIT_ADDR, value: currency.btcToSatoshi(amountString) }];
+  return w.createTransaction(w.getUtxo(), targets, feeRate, changeAddress(w), HDSegwitBech32Wallet.defaultRBFSequence);
+}
+
+describe('DFX sell flow: Max amount handling', () => {
+  it('control: in-wallet Max (send-max target) builds a tx even with a frozen UTXO', () => {
+    const w = makeWallet({ freeze: true });
+    // Target WITHOUT value = internal Max path (cf. screen/send/details.js:440-443)
+    const { tx, psbt, fee } = w.createTransaction(
+      w.getUtxo(),
+      [{ address: DEPOSIT_ADDR }],
+      3,
+      changeAddress(w),
+      HDSegwitBech32Wallet.defaultRBFSequence,
+    );
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(psbt, 'expected a psbt');
+    assert.ok(fee > 0, 'expected a positive fee');
+  });
+
+  it('control: sell confirm builds a tx in the clean case (same fee rate, nothing frozen)', () => {
+    const w = makeWallet();
+    const amount = apiFloor5(launchBalancesParam(w, 3));
+    const { tx, outputs, fee } = sellConfirm(w, amount, 3);
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(
+      outputs.some(o => o.address === DEPOSIT_ADDR),
+      'expected deposit address in outputs',
+    );
+    assert.ok(fee > 0, 'expected a positive fee');
+  });
+
+  // FAILS until the sell-Max defect is fixed; this is the regression gate
+  it('sell confirm must not fail when part of the balance is frozen', () => {
+    const w = makeWallet({ freeze: true });
+    const amount = apiFloor5(launchBalancesParam(w, 3));
+    const amountSats = currency.btcToSatoshi(amount);
+
+    // Defect precondition: launch amount exceeds spendable (non-frozen) utxo sum
+    assert.ok(
+      amountSats > SPENDABLE_WHEN_FROZEN,
+      `precondition: launch amount (${amountSats} sats) must exceed spendable non-frozen sum (${SPENDABLE_WHEN_FROZEN}); ` +
+        'getBalance() includes the frozen UTXO while getUtxo() does not — that gap is the defect',
+    );
+
+    // Must not throw ("Not enough balance…" is the current broken outcome)
+    const { tx, outputs, fee } = sellConfirm(w, amount, 3);
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(
+      outputs.some(o => o.address === DEPOSIT_ADDR),
+      'expected deposit address in outputs',
+    );
+    const depositOut = outputs.find(o => o.address === DEPOSIT_ADDR);
+    // A correct fix may reduce the sent amount send-max-style or clamp it — both acceptable
+    assert.ok(
+      depositOut.value + fee <= SPENDABLE_WHEN_FROZEN,
+      `output value (${depositOut.value}) + fee (${fee}) must not exceed spendable ${SPENDABLE_WHEN_FROZEN}`,
+    );
+  });
+
+  // FAILS until the sell-Max defect is fixed; this is the regression gate
+  it('sell confirm must survive a fee-rate increase between launch and confirm', () => {
+    const w = makeWallet();
+    const amount = apiFloor5(launchBalancesParam(w, 3));
+
+    // Launch estimated at feeRate 3; confirm runs at feeRate 4 — must not throw
+    const { tx, outputs, fee } = sellConfirm(w, amount, 4);
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(
+      outputs.some(o => o.address === DEPOSIT_ADDR),
+      'expected deposit address in outputs',
+    );
+    const depositOut = outputs.find(o => o.address === DEPOSIT_ADDR);
+    assert.ok(
+      depositOut.value + fee <= TOTAL_BALANCE,
+      `output value (${depositOut.value}) + fee (${fee}) must not exceed spendable ${TOTAL_BALANCE}`,
+    );
+  });
+
+  // FAILS until the sell-Max defect is fixed; this is the regression gate
+  it('sell confirm must handle amounts with more than 8 decimal places', () => {
+    const w = makeWallet();
+
+    // 9 decimals — exactly what a 5-significant-digit backend floor emits for sub-10,000-sat balances
+    assert.strictEqual(apiFloor5('0.0000123456789'), '0.000012345', 'backend 5-sig-digit floor must emit 0.000012345 for this input');
+    const amountStr = '0.000012345';
+
+    // Precondition: btcToSatoshi yields a fractional satoshi (1234.5)
+    const sats = currency.btcToSatoshi(amountStr);
+    assert.ok(
+      !Number.isInteger(sats),
+      `precondition: btcToSatoshi('${amountStr}') is ${sats} — fractional satoshis; fixed-value confirm must tolerate this`,
+    );
+
+    // Must not throw despite 1,750,000 sats available
+    const { tx, outputs } = sellConfirm(w, amountStr, 3);
+
+    assert.ok(tx, 'expected a transaction');
+    const depositOut = outputs.find(o => o.address === DEPOSIT_ADDR);
+    assert.ok(depositOut, 'expected deposit address in outputs');
+    // 1234 or 1235 both acceptable (floor or round of 1234.5)
+    assert.ok(Number.isInteger(depositOut.value), `output value must be an integer number of satoshis, got ${depositOut.value}`);
+    assert.ok(depositOut.value >= 1234 && depositOut.value <= 1235, `output value must be 1234 or 1235, got ${depositOut.value}`);
+  });
+});

--- a/tests/unit/dfx-swap-max.test.js
+++ b/tests/unit/dfx-swap-max.test.js
@@ -1,0 +1,231 @@
+/**
+ * DFX swap-flow Max-amount regression suite.
+ *
+ * Defect chain (why swap confirm can throw while in-wallet Max never does):
+ *   1. Launch (DfxServicesButtons) computes Max from getBalance() — includes frozen
+ *      and unconfirmed sats — minus a fee estimated over getUtxo() (excludes frozen).
+ *      Launch is shared between sell and swap.
+ *   2. That BTC amount is handed to the web app as the Max balance, then floored by the
+ *      backend to 5 significant digits, then returned via deeplink as a fixed amount.
+ *   3. Swap confirm (screen/dfx/swap) builds a FIXED-value target via btcToSatoshi(amount)
+ *      and coinselects over getUtxo() only — so frozen funds counted at launch are not
+ *      spendable at confirm → coinselect throws "Not enough balance…".
+ *   4. Related gaps: fee rate moving between launch and confirm, and fractional satoshis
+ *      from btcToSatoshi on >8-decimal strings, also trip the fixed-value path.
+ *
+ * Structural difference vs. sell: swap.tsx fetches FRESH fees at confirm time via
+ * NetworkTransactionFees.recommendedFees() (screen/dfx/swap.tsx:81-83), so a fee-rate
+ * change between launch and confirm is not an edge case here — it is the expected steady
+ * state whenever the mempool moves. Sell instead reads the AsyncStorage fee cache written
+ * at launch. Both still fail the same fixed-value / coinselect defects.
+ *
+ * Controls document behaviour that already works and must stay green.
+ * Regression gates encode the REQUIRED post-fix behaviour; they FAIL today on purpose
+ * so CI stays red until the sell/swap-Max defect is fixed.
+ *
+ * No network, no AsyncStorage — pure wallet/coinselect math with injected UTXOs/balances.
+ * confirmFeeRate is a separate parameter precisely because swap re-fetches fees.
+ */
+
+import assert from 'assert';
+import BigNumber from 'bignumber.js';
+import { HDSegwitBech32Wallet } from '../../class';
+
+const currency = require('../../blue_modules/currency');
+
+const SEED = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+// External addresses of SEED (BIP84)
+const ADDR0 = 'bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu'; // 1,000,000 sats
+const ADDR1 = 'bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g'; // 500,000 sats
+const ADDR2 = 'bc1qp59yckz4ae5c4efgw2s5wfyvrz0ala7rgvuz8z'; // 250,000 sats (frozen in freeze cases)
+
+const VAL0 = 1000000;
+const VAL1 = 500000;
+const VAL2 = 250000;
+const SPENDABLE_WHEN_FROZEN = VAL0 + VAL1; // 1,500,000
+const TOTAL_BALANCE = VAL0 + VAL1 + VAL2; // 1,750,000
+
+// Distinct fake 64-hex txids (one per utxo)
+const TXID0 = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const TXID1 = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+const TXID2 = 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+
+// Backend swap deposit address (P2SH) — same fixture shape as sell
+const DEPOSIT_ADDR = '3HoYu1UhmuZe33puQtkt9Q21y7kyi4adiC';
+// Fee-estimate dust address (verbatim from DfxServicesButtons)
+const DUST_ADDR = '36JxaUrpDzkEerkTf1FzwHNE1Hb7cCjgJV';
+
+/**
+ * Build an HDSegwitBech32Wallet with deterministic injected UTXOs + balances.
+ * mirrors abstract-hd-electrum-wallet getBalance/getUtxo structure — update this mirror
+ * together with the production flow when fixing; the assertions define the required behaviour
+ */
+function makeWallet({ freeze } = {}) {
+  const w = new HDSegwitBech32Wallet();
+  w.setSecret(SEED);
+
+  w._utxo = [
+    { value: VAL0, address: ADDR0, txId: TXID0, vout: 0, txid: TXID0, amount: VAL0, wif: '-' },
+    { value: VAL1, address: ADDR1, txId: TXID1, vout: 0, txid: TXID1, amount: VAL1, wif: '-' },
+    { value: VAL2, address: ADDR2, txId: TXID2, vout: 0, txid: TXID2, amount: VAL2, wif: '-' },
+  ];
+
+  // Exactly the structure a real electrum fetch fills — so getBalance() behaves like production
+  w._balances_by_external_index[0] = { c: VAL0, u: 0 };
+  w._balances_by_external_index[1] = { c: VAL1, u: 0 };
+  w._balances_by_external_index[2] = { c: VAL2, u: 0 };
+
+  if (freeze) {
+    w.setUTXOMetadata(TXID2, 0, { frozen: true });
+  }
+
+  return w;
+}
+
+/**
+ * mirrors screen/dfx/swap.tsx change-address resolution — update this mirror together with
+ * the production flow when fixing; the assertions define the required behaviour
+ */
+function changeAddress(w) {
+  return w._getInternalAddressByIndex(w.getNextFreeChangeAddressIndex());
+}
+
+/**
+ * mirrors components/DfxServicesButtons.tsx:89-117 — update this mirror together with the
+ * production flow when fixing; the assertions define the required behaviour
+ *
+ * Launch Max is shared between sell and swap: fee from dust send-max over getUtxo(), then
+ * getBalance() - fee (balance includes frozen/unconfirmed; utxo path does not).
+ */
+function launchBalancesParam(w, feeRate) {
+  const { fee } = w.createTransaction(w.getUtxo(), [{ address: DUST_ADDR }], feeRate, changeAddress(w), false);
+  return new BigNumber(currency.satoshiToBTC(w.getBalance() - fee)).toString();
+}
+
+/**
+ * mirrors the backend's asset floor (5 significant digits, BigNumber.ROUND_FLOOR) — update
+ * this mirror together with the production flow when fixing; the assertions define the
+ * required behaviour
+ */
+function apiFloor5(amountStr) {
+  return new BigNumber(amountStr).precision(5, BigNumber.ROUND_FLOOR).toString();
+}
+
+/**
+ * mirrors screen/dfx/swap.tsx:81-95 — update this mirror together with the production flow
+ * when fixing; the assertions define the required behaviour
+ *
+ * Production confirm (swap.tsx:81-91):
+ *   const networkTransactionFees = await NetworkTransactionFees.recommendedFees();
+ *   const requestedSatPerByte = Number(networkTransactionFees.fastestFee);
+ *   const targets = [{ address: swapInfo?.deposit.address, value: currency.btcToSatoshi(amount) }];
+ *   wallet.createTransaction(lutxo, targets, requestedSatPerByte, changeAddress, …)
+ *
+ * confirmFeeRate is a separate parameter because swap always re-fetches fees at confirm
+ * time (unlike sell, which reads the AsyncStorage cache written at launch).
+ */
+function swapConfirm(w, amountString, confirmFeeRate) {
+  const targets = [{ address: DEPOSIT_ADDR, value: currency.btcToSatoshi(amountString) }];
+  return w.createTransaction(w.getUtxo(), targets, confirmFeeRate, changeAddress(w), HDSegwitBech32Wallet.defaultRBFSequence);
+}
+
+describe('DFX swap flow: Max amount handling', () => {
+  it('control: swap confirm builds a tx in the clean case (fee unchanged, nothing frozen)', () => {
+    const w = makeWallet();
+    const amount = apiFloor5(launchBalancesParam(w, 3));
+    // Launch rate 3, confirm rate 3 (fee unchanged)
+    const { tx, outputs, fee } = swapConfirm(w, amount, 3);
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(
+      outputs.some(o => o.address === DEPOSIT_ADDR),
+      'expected deposit address in outputs',
+    );
+    assert.ok(fee > 0, 'expected a positive fee');
+  });
+
+  // FAILS until the sell/swap-Max defect is fixed; this is the regression gate
+  it('swap confirm must not fail when part of the balance is frozen', () => {
+    const w = makeWallet({ freeze: true });
+    const amount = apiFloor5(launchBalancesParam(w, 3));
+
+    // With the current launch mirror the amount (~1,749,400 sats) exceeds the spendable
+    // non-frozen sum (1,500,000): getBalance() includes the frozen UTXO while getUtxo()
+    // does not — that gap is the defect. A launch-side fix shrinks the amount, a
+    // confirm-side fix absorbs it; either way the confirm below must build a tx.
+    const { tx, outputs, fee } = swapConfirm(w, amount, 3);
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(
+      outputs.some(o => o.address === DEPOSIT_ADDR),
+      'expected deposit address in outputs',
+    );
+    const depositOut = outputs.find(o => o.address === DEPOSIT_ADDR);
+    // A correct fix may reduce the sent amount send-max-style or clamp it — both acceptable.
+    // Upper bound: must not spend frozen funds. Lower bound: must still be a genuine
+    // Max-swap (a token 1-sat deposit output would not fix anything).
+    assert.ok(
+      depositOut.value + fee <= SPENDABLE_WHEN_FROZEN,
+      `output value (${depositOut.value}) + fee (${fee}) must not exceed spendable ${SPENDABLE_WHEN_FROZEN}`,
+    );
+    assert.ok(
+      depositOut.value + fee >= SPENDABLE_WHEN_FROZEN - 5000,
+      `output value (${depositOut.value}) + fee (${fee}) must stay within 5000 sats of spendable ${SPENDABLE_WHEN_FROZEN} — ` +
+        'a Max swap must move essentially the whole spendable balance',
+    );
+  });
+
+  // FAILS until the sell/swap-Max defect is fixed; this is the regression gate
+  it('swap confirm must survive the fee rate moving between launch and confirm', () => {
+    const w = makeWallet();
+    const amount = apiFloor5(launchBalancesParam(w, 3));
+
+    // Launch at feeRate 3; confirm at feeRate 4. For swap this is the NORMAL case, not
+    // drift: confirm re-fetches via NetworkTransactionFees.recommendedFees()
+    // (screen/dfx/swap.tsx:81), so any mempool move yields a different rate at confirm.
+    const { tx, outputs, fee } = swapConfirm(w, amount, 4);
+
+    assert.ok(tx, 'expected a transaction');
+    assert.ok(
+      outputs.some(o => o.address === DEPOSIT_ADDR),
+      'expected deposit address in outputs',
+    );
+    const depositOut = outputs.find(o => o.address === DEPOSIT_ADDR);
+    assert.ok(
+      depositOut.value + fee <= TOTAL_BALANCE,
+      `output value (${depositOut.value}) + fee (${fee}) must not exceed spendable ${TOTAL_BALANCE}`,
+    );
+    // Lower bound: the fix must still move essentially the whole balance (no token output)
+    assert.ok(
+      depositOut.value + fee >= TOTAL_BALANCE - 5000,
+      `output value (${depositOut.value}) + fee (${fee}) must stay within 5000 sats of spendable ${TOTAL_BALANCE}`,
+    );
+  });
+
+  // FAILS until the sell/swap-Max defect is fixed; this is the regression gate
+  it('swap confirm must handle amounts with more than 8 decimal places', () => {
+    const w = makeWallet();
+
+    // 9 decimals — exactly what a 5-significant-digit backend floor emits for sub-10,000-sat balances
+    assert.strictEqual(apiFloor5('0.0000123456789'), '0.000012345', 'backend 5-sig-digit floor must emit 0.000012345 for this input');
+    const amountStr = '0.000012345';
+
+    // Precondition: btcToSatoshi yields a fractional satoshi (1234.5)
+    const sats = currency.btcToSatoshi(amountStr);
+    assert.ok(
+      !Number.isInteger(sats),
+      `precondition: btcToSatoshi('${amountStr}') is ${sats} — fractional satoshis; fixed-value confirm must tolerate this`,
+    );
+
+    // Must not throw despite 1,750,000 sats available
+    const { tx, outputs } = swapConfirm(w, amountStr, 3);
+
+    assert.ok(tx, 'expected a transaction');
+    const depositOut = outputs.find(o => o.address === DEPOSIT_ADDR);
+    assert.ok(depositOut, 'expected deposit address in outputs');
+    // 1234 or 1235 both acceptable (floor or round of 1234.5)
+    assert.ok(Number.isInteger(depositOut.value), `output value must be an integer number of satoshis, got ${depositOut.value}`);
+    assert.ok(depositOut.value >= 1234 && depositOut.value <= 1235, `output value must be 1234 or 1235, got ${depositOut.value}`);
+  });
+});

--- a/tests/unit/dfx-swap-max.test.js
+++ b/tests/unit/dfx-swap-max.test.js
@@ -170,8 +170,8 @@ describe('DFX swap flow: Max amount handling', () => {
       `output value (${depositOut.value}) + fee (${fee}) must not exceed spendable ${SPENDABLE_WHEN_FROZEN}`,
     );
     assert.ok(
-      depositOut.value + fee >= SPENDABLE_WHEN_FROZEN - 5000,
-      `output value (${depositOut.value}) + fee (${fee}) must stay within 5000 sats of spendable ${SPENDABLE_WHEN_FROZEN} — ` +
+      depositOut.value + fee >= SPENDABLE_WHEN_FROZEN - 1000,
+      `output value (${depositOut.value}) + fee (${fee}) must stay within 1000 sats of spendable ${SPENDABLE_WHEN_FROZEN} — ` +
         'a Max swap must move essentially the whole spendable balance',
     );
   });
@@ -198,9 +198,13 @@ describe('DFX swap flow: Max amount handling', () => {
     );
     // Lower bound: the fix must still move essentially the whole balance (no token output)
     assert.ok(
-      depositOut.value + fee >= TOTAL_BALANCE - 5000,
-      `output value (${depositOut.value}) + fee (${fee}) must stay within 5000 sats of spendable ${TOTAL_BALANCE}`,
+      depositOut.value + fee >= TOTAL_BALANCE - 1000,
+      `output value (${depositOut.value}) + fee (${fee}) must stay within 1000 sats of spendable ${TOTAL_BALANCE}`,
     );
+    // The freshly fetched confirm-time rate must actually be honored: a "fix" that
+    // falls back to the stale launch rate 3 would also build — catch it via the
+    // effective fee rate.
+    assert.ok(fee >= tx.virtualSize() * 4, `fee (${fee}) must cover the confirm-time rate of 4 sat/vB over ${tx.virtualSize()} vB`);
   });
 
   // FAILS until the sell/swap-Max defect is fixed; this is the regression gate
@@ -224,8 +228,8 @@ describe('DFX swap flow: Max amount handling', () => {
     assert.ok(tx, 'expected a transaction');
     const depositOut = outputs.find(o => o.address === DEPOSIT_ADDR);
     assert.ok(depositOut, 'expected deposit address in outputs');
-    // 1234 or 1235 both acceptable (floor or round of 1234.5)
+    // Exactly the floor: rounding 1234.5 UP would send more than the user confirmed
     assert.ok(Number.isInteger(depositOut.value), `output value must be an integer number of satoshis, got ${depositOut.value}`);
-    assert.ok(depositOut.value >= 1234 && depositOut.value <= 1235, `output value must be 1234 or 1235, got ${depositOut.value}`);
+    assert.strictEqual(depositOut.value, 1234, `output value must be the floored 1234 sats, got ${depositOut.value}`);
   });
 });


### PR DESCRIPTION
## What

Adds a regression test suite for the sell/swap-flow "Max" amount defect: `tests/unit/dfx-sell-max.test.js` and `tests/unit/dfx-swap-max.test.js` (both run in the existing `npm run unit` CI gate, no config changes, no network).

**These tests encode the required behaviour, so the seven gate tests fail on purpose — CI on this branch stays red until the underlying fix lands.** The suites then turn green with a correct fix and guard it from regressing.

## The defect

In-wallet Max works; selling/swapping via the web app fails on confirm every time for affected wallets. Root cause chain:

1. **Launch** (`components/DfxServicesButtons.tsx`, shared by sell and swap): the Max balance handed to the web app is `getBalance() - estimatedFee`. `getBalance()` **includes frozen and unconfirmed coins**, while the fee estimate (and later the coin selection) runs over `getUtxo()`, which **excludes frozen coins**.
2. The web app's MAX button uses that value as-is; the backend floors it to 5 significant digits and hands it back via deeplink.
3. **Confirm** (`screen/dfx/sell.tsx` / `screen/dfx/swap.tsx`): the deeplink amount becomes a **fixed-value** target (`btcToSatoshi(amount)`) into `coinselect` — unlike the in-wallet Max, which uses a send-max target (no `value`) that deducts the fee from whatever is spendable.
4. Whenever launch balance and spendable UTXOs diverge — frozen coins, an unconfirmed incoming payment that gets replaced, a fee-rate change — or the floored amount has more than 8 decimals (fractional satoshis that `coinselect` rejects), the confirm dies with "Not enough balance. Try sending smaller amount or decrease the fee." (`class/wallets/legacy-wallet.ts`).

Structural note on swap: `swap.tsx` re-fetches fees at confirm time, so a rate change between launch and confirm is its **normal operating state**, not an edge case. Sell reads the fee cache written at launch — but that cache read has no empty-cache guard, and the screen is reachable via an external deeplink that never ran the launch path (today: TypeError on `fastestFee`).

All failure modes were reproduced end-to-end on a private regtest chain (bitcoind + Electrum server + backend + web app + these wallet classes) before being distilled into these offline suites — including the unconfirmed case live: an incoming unconfirmed payment counted at launch and then replaced via RBF while the user is in the widget makes the confirm fail with the same error.

## The tests

| Suite | Test | Today |
|---|---|---|
| sell | control: in-wallet Max (send-max) builds even with a frozen UTXO | ✅ |
| sell | control: confirm builds in the clean case | ✅ |
| sell | control: clean case with a single-utxo wallet | ✅ |
| sell | control: builds with uneconomic dust utxos in the wallet | ✅ |
| sell | control: builds with partially unconfirmed balance | ✅ |
| sell | gate: must not fail when part of the balance is frozen | ❌ until fixed |
| sell | gate: must survive a fee-rate increase between launch and confirm | ❌ until fixed |
| sell | gate: must handle amounts with more than 8 decimal places | ❌ until fixed |
| sell | gate: must not depend on a pre-populated network fee cache | ❌ until fixed |
| swap | control: confirm builds in the clean case | ✅ |
| swap | gate: must not fail when part of the balance is frozen | ❌ until fixed |
| swap | gate: must survive the fee rate moving between launch and confirm | ❌ until fixed |
| swap | gate: must handle amounts with more than 8 decimal places | ❌ until fixed |

Local verification: six gates fail exactly with the production throw (`Not enough balance…`), the fee-cache gate with the production `TypeError: Cannot read properties of null (reading 'fastestFee')`; all other unit suites stay green, `tsc` and `eslint` clean.

Note on the unit gate: `npm run unit` runs jest with `-b` (bail), so while the gates are red, suites scheduled after these are skipped in that run. Known, temporary side effect until the fix lands.

The launch/confirm/backend-floor logic lives in UI components and the backend, so the suites mirror those few lines in small helpers, each annotated with the exact `file:line` it mirrors — whoever fixes the flow updates the mirror along with it; the assertions define the required behaviour and deliberately allow either fix shape (clamp to spendable or switch to a send-max target near the full balance). The gates also reject token fixes: the deposit output plus fee must stay within 5000 sats of the spendable sum.

## Suggested fix direction (out of scope here)

- Launch: derive the Max balance from the spendable UTXO sum instead of `getBalance()` (#213 already does this part).
- Confirm (sell and swap): treat near-max amounts send-max-style (target without `value`) or clamp to spendable minus fee, floor the satoshi value to an integer, and give the fee-cache read a sane fallback.
