### PR TITLE
ADD: direct links to individual handbook screens

### DIFF
--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -450,22 +450,44 @@ function slugify(key) {
 }
 
 /**
- * Return `base`, or `base-1`, `base-2`, … if `base` is already taken. Mirrors
- * the counter in createHeadingRenderer: every emitted id is registered, so a
- * later collision never re-uses a suffix that is already in use. `seen` is a
- * Map shared across one render pass; the first occurrence keeps the bare id, so
- * ids of existing content do not change when a colliding name is added later.
+ * Register an anchor id and remember where it came from. `seen` maps id →
+ * source labels; assertNoAnchorCollisions() turns any id claimed twice into a
+ * build failure.
+ *
+ * Suffixing the loser instead (a-1, a-2, …) was the first attempt and is wrong
+ * here: "first" would mean first in sort order, not oldest, and ' ' and '_'
+ * sort before '-' under sortStrings. Adding `07_sprache.png` next to an
+ * existing `07-sprache.png` would hand the newcomer the incumbent's bare id and
+ * push the incumbent to `-1` — so a permalink copied from the page yesterday
+ * would open a different screenshot today, silently. A red build asking the
+ * author to rename the new file is the honest outcome; the handbook has ~50
+ * screens and can afford unique slugs. Same treatment as two sources claiming
+ * one output path.
  */
-function uniqueAnchorId(seen, base) {
-  let candidate = base;
-  while (seen.has(candidate)) {
-    const n = seen.get(base);
-    seen.set(base, n + 1);
-    candidate = base + '-' + n;
+function claimAnchorId(seen, id, source) {
+  if (!seen.has(id)) seen.set(id, []);
+  seen.get(id).push(source);
+  return id;
+}
+
+/** Fail the build if any anchor id was claimed by more than one source. */
+function assertNoAnchorCollisions(seen) {
+  const collisions = [];
+  for (const [id, sources] of seen.entries()) {
+    const unique = Array.from(new Set(sources)).sort(sortStrings);
+    if (unique.length > 1) collisions.push({ id, sources: unique });
   }
-  seen.set(candidate, 1);
-  if (!seen.has(base)) seen.set(base, 1);
-  return candidate;
+  if (collisions.length === 0) return;
+  collisions.sort((a, b) => sortStrings(a.id, b.id));
+  const lines = collisions.map(
+    (c) => `  #${c.id}\n` + c.sources.map((s) => `    - ${s}`).join('\n'),
+  );
+  fail(
+    'handbook anchor collision: several screenshots or groups claim the same ' +
+      'permalink target, so a copied link would open the wrong screen. ' +
+      'Resolve the naming conflict before rebuilding:\n' +
+      lines.join('\n'),
+  );
 }
 
 /**
@@ -1696,7 +1718,7 @@ function main() {
     // land on the same id (e.g. the group dirs `05-karte/dfx` and `05-karte-dfx`,
     // or `99-fee ok.png` next to `99-fee-ok.png`). getElementById always returns
     // the first match, so the copied link would silently point at the wrong
-    // screen. Suffix collisions the same way createHeadingRenderer does.
+    // screen. Collect every id with its source and fail the build on a clash.
     const anchorIds = new Map();
     let allShotsBody = '';
     for (const gKey of groupKeys) {
@@ -1707,7 +1729,11 @@ function main() {
         meta && meta.description
           ? escapeHtml(meta.description)
           : `Screenshot-Gruppe <code>${escapeHtml(gKey)}</code> (Auto-Discovery).`;
-      const groupId = uniqueAnchorId(anchorIds, 'group-' + slugify(gKey));
+      const groupId = claimAnchorId(
+        anchorIds,
+        'group-' + slugify(gKey),
+        'screenshot group ' + gKey,
+      );
       let cards =
         `<div class="group-head">` +
         `<h3 id="${escapeHtml(groupId)}">` +
@@ -1718,9 +1744,10 @@ function main() {
       cards += `<p class="spec-intro">${desc}</p>`;
       cards += '<div class="tests">';
       for (const e of list) {
-        const cardId = uniqueAnchorId(
+        const cardId = claimAnchorId(
           anchorIds,
           'shot-' + slugify(e.group + '-' + e.title),
+          e.sourcePath,
         );
         const shotHref = escapeHtml(encodeHtmlPath(e.outputPath));
         cards +=
@@ -1736,6 +1763,7 @@ function main() {
       cards += '</div>';
       allShotsBody += cards;
     }
+    assertNoAnchorCollisions(anchorIds);
     pushSection(
       'screenshots',
       null,

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -450,6 +450,22 @@ function slugify(key) {
 }
 
 /**
+ * Copy-link button for an anchor. The anchor alone is not enough: without a
+ * visible permalink a reader can only obtain the URL of a single screen by
+ * reading the page source. Behaviour (clipboard with execCommand fallback,
+ * confirmation, hash update) lives in handbook.js so the CSP stays at
+ * script-src 'self'. Button label is German — so is the handbook.
+ */
+function copyLinkButton(anchorId) {
+  return (
+    `<button class="copy-link" type="button" ` +
+    `data-target="${escapeHtml(anchorId)}" ` +
+    `title="Direkt-Link kopieren" aria-label="Direkt-Link kopieren">` +
+    `\u{1F517} Link</button>`
+  );
+}
+
+/**
  * Recursive PNG scan. Skips directories whose basename starts with '.'.
  * Non-PNG files are ignored (no error). Returns sorted list of
  * { abs, relPosix } where relPosix is relative to rootDir.
@@ -1503,6 +1519,42 @@ function main() {
         font-size: 12.5px;
         color: var(--ink-3);
       }
+      a.name.permalink {
+        text-decoration: none;
+        color: inherit;
+      }
+      a.name.permalink:hover {
+        text-decoration: underline;
+        color: var(--brand);
+      }
+      .group-head {
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+      }
+      .group-head h3 { margin: 0; }
+      .copy-link {
+        appearance: none;
+        background: transparent;
+        border: 1px solid transparent;
+        padding: 2px 6px;
+        font: inherit;
+        font-size: 11.5px;
+        line-height: 1;
+        color: var(--ink-3);
+        cursor: pointer;
+        border-radius: 4px;
+      }
+      .copy-link:hover {
+        color: var(--brand);
+        background: var(--surface);
+        border-color: var(--line);
+      }
+      .copy-link[data-copied='true'] {
+        color: var(--brand);
+        background: var(--surface);
+        border-color: var(--brand);
+      }
   `;
 
   // TOC/hash helper as external file so CSP can use script-src 'self'
@@ -1533,6 +1585,48 @@ function main() {
     "    if (t.id === 'toc-collapse-all') {\n" +
     "      document.querySelectorAll('details.spec').forEach(function (d) { d.open = false; });\n" +
     '    }\n' +
+    '  });\n' +
+    '  // Copy a direct link. Without the button the anchor exists but is only\n' +
+    '  // reachable via the page source — same interaction as the RealUnit handbook.\n' +
+    '  function fallbackCopy(text) {\n' +
+    "    var ta = document.createElement('textarea');\n" +
+    '    ta.value = text;\n' +
+    "    ta.setAttribute('readonly', '');\n" +
+    "    ta.style.position = 'fixed';\n" +
+    "    ta.style.opacity = '0';\n" +
+    '    document.body.appendChild(ta);\n' +
+    '    ta.select();\n' +
+    "    try { document.execCommand('copy'); } catch (e) {}\n" +
+    '    document.body.removeChild(ta);\n' +
+    '  }\n' +
+    "  document.querySelectorAll('.copy-link').forEach(function (btn) {\n" +
+    '    var origText = btn.textContent;\n' +
+    '    var resetTimer = null;\n' +
+    "    btn.addEventListener('click', function () {\n" +
+    '      var target = btn.getAttribute(\'data-target\');\n' +
+    '      if (!target) return;\n' +
+    "      var url = location.origin + location.pathname + '#' + target;\n" +
+    '      var done = function () {\n' +
+    "        btn.textContent = '\\u2713 Kopiert';\n" +
+    "        btn.setAttribute('data-copied', 'true');\n" +
+    '        if (resetTimer) clearTimeout(resetTimer);\n' +
+    '        resetTimer = setTimeout(function () {\n' +
+    '          btn.textContent = origText;\n' +
+    "          btn.removeAttribute('data-copied');\n" +
+    '          resetTimer = null;\n' +
+    '        }, 1200);\n' +
+    "        if (location.hash !== '#' + target) location.hash = target;\n" +
+    '      };\n' +
+    '      if (navigator.clipboard && navigator.clipboard.writeText) {\n' +
+    '        navigator.clipboard.writeText(url).then(done, function () {\n' +
+    '          fallbackCopy(url);\n' +
+    '          done();\n' +
+    '        });\n' +
+    '      } else {\n' +
+    '        fallbackCopy(url);\n' +
+    '        done();\n' +
+    '      }\n' +
+    '    });\n' +
     '  });\n' +
     '})();\n';
 
@@ -1573,7 +1667,14 @@ function main() {
         meta && meta.description
           ? escapeHtml(meta.description)
           : `Screenshot-Gruppe <code>${escapeHtml(gKey)}</code> (Auto-Discovery).`;
-      let cards = `<h3 id="group-${escapeHtml(slugify(gKey))}">${escapeHtml(title)}</h3>`;
+      const groupId = 'group-' + slugify(gKey);
+      let cards =
+        `<div class="group-head">` +
+        `<h3 id="${escapeHtml(groupId)}">` +
+        `<a class="name permalink" href="#${escapeHtml(groupId)}">${escapeHtml(title)}</a>` +
+        `</h3>` +
+        copyLinkButton(groupId) +
+        `</div>`;
       cards += `<p class="spec-intro">${desc}</p>`;
       cards += '<div class="tests">';
       for (const e of list) {
@@ -1581,7 +1682,10 @@ function main() {
         const shotHref = escapeHtml(encodeHtmlPath(e.outputPath));
         cards +=
           `<div class="test" id="${escapeHtml(cardId)}">` +
-          `<div class="head"><span class="name">${escapeHtml(e.title)}</span></div>` +
+          `<div class="head">` +
+          `<a class="name permalink" href="#${escapeHtml(cardId)}">${escapeHtml(e.title)}</a>` +
+          copyLinkButton(cardId) +
+          `</div>` +
           `<div class="img"><a href="${shotHref}">` +
           `<img src="${shotHref}" alt="${escapeHtml(e.title)}" loading="lazy"></a></div>` +
           `</div>`;

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -31,8 +31,7 @@ const MIN_ASSETS = 20;
 const MIN_PNG_BYTES = 1000;
 const MIN_ASSET_PNG_BYTES = 100;
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-const MARKED_INSTALL =
-  'npm install --prefix ./_handbook-deps --no-save --no-audit --no-fund marked@15.0.7';
+const MARKED_INSTALL = 'npm install --prefix ./_handbook-deps --no-save --no-audit --no-fund marked@15.0.7';
 
 // Repo-relative discovery roots (same strings discovery walks). prepareOutputDir
 // refuses to empty these or any ancestor path that would wipe them.
@@ -140,17 +139,7 @@ function createHeadingRenderer() {
     seen.set(candidate, 1);
     if (!seen.has(slug)) seen.set(slug, 1);
     slug = candidate;
-    return (
-      '<h' +
-      depth +
-      ' id="' +
-      slug +
-      '">' +
-      this.parser.parseInline(tokens) +
-      '</h' +
-      depth +
-      '>\n'
-    );
+    return '<h' + depth + ' id="' + slug + '">' + this.parser.parseInline(tokens) + '</h' + depth + '>\n';
   };
   return renderer;
 }
@@ -162,12 +151,7 @@ function markedParse(md) {
 }
 
 function escapeHtml(str) {
-  return String(str)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
 // Inverse of escapeHtml, for re-reading paths out of already-escaped HTML.
@@ -199,7 +183,7 @@ function encodeHtmlPath(p) {
 function decodeHtmlPath(p) {
   return String(p)
     .split('/')
-    .map((seg) => {
+    .map(seg => {
       try {
         return decodeURIComponent(seg);
       } catch {
@@ -262,19 +246,14 @@ function prepareOutputDir(outDir, repoRoot) {
   const homeDir = resolveHomeDir();
 
   if (resolvedOut === path.resolve('/')) {
-    fail(
-      'handbook: refusing to use filesystem root (/) as output directory.',
-    );
+    fail('handbook: refusing to use filesystem root (/) as output directory.');
   }
   if (homeDir === null) {
     console.error(
-      'handbook warning: home directory could not be determined; ' +
-        'skipping home-directory output guard (other guards still apply).',
+      'handbook warning: home directory could not be determined; ' + 'skipping home-directory output guard (other guards still apply).',
     );
   } else if (resolvedOut === homeDir) {
-    fail(
-      `handbook: refusing to use home directory as output directory: ${resolvedOut}`,
-    );
+    fail(`handbook: refusing to use home directory as output directory: ${resolvedOut}`);
   }
   // Repo root itself, or any ancestor of the repo (emptying would wipe the tree).
   if (isSameOrAncestor(resolvedOut, resolvedRoot)) {
@@ -298,9 +277,7 @@ function prepareOutputDir(outDir, repoRoot) {
   // Never touch anything under .git (object store, hooks, config).
   const segments = resolvedOut.split(path.sep);
   if (segments.includes('.git')) {
-    fail(
-      `handbook: refusing to empty output path that contains a .git segment: ${resolvedOut}`,
-    );
+    fail(`handbook: refusing to empty output path that contains a .git segment: ${resolvedOut}`);
   }
 
   if (fs.existsSync(resolvedOut)) {
@@ -334,11 +311,8 @@ function assertNoOutputCollisions(artifacts) {
   }
   collisions.sort((a, b) => sortStrings(a.outPath, b.outPath));
   if (collisions.length > 0) {
-    const lines = collisions.map((c) => {
-      return (
-        `  ${c.outPath}\n` +
-        c.sources.map((s) => `    - ${s}`).join('\n')
-      );
+    const lines = collisions.map(c => {
+      return `  ${c.outPath}\n` + c.sources.map(s => `    - ${s}`).join('\n');
     });
     fail(
       'handbook output collision: multiple sources claim the same output path ' +
@@ -356,10 +330,7 @@ function assertValidPng(filePath, minBytes = MIN_PNG_BYTES) {
     fail(`handbook PNG guard: cannot stat ${filePath}: ${err.message}`);
   }
   if (st.size <= minBytes) {
-    fail(
-      `handbook PNG guard: ${filePath} is ${st.size} bytes (must be > ${minBytes}). ` +
-        'Possible incomplete checkout or LFS pointer.',
-    );
+    fail(`handbook PNG guard: ${filePath} is ${st.size} bytes (must be > ${minBytes}). ` + 'Possible incomplete checkout or LFS pointer.');
   }
   const fd = fs.openSync(filePath, 'r');
   const buf = Buffer.alloc(8);
@@ -369,10 +340,7 @@ function assertValidPng(filePath, minBytes = MIN_PNG_BYTES) {
     fs.closeSync(fd);
   }
   if (!buf.equals(PNG_MAGIC)) {
-    fail(
-      `handbook PNG guard: ${filePath} does not start with PNG magic bytes. ` +
-        'Possible incomplete checkout or LFS pointer.',
-    );
+    fail(`handbook PNG guard: ${filePath} does not start with PNG magic bytes. ` + 'Possible incomplete checkout or LFS pointer.');
   }
 }
 
@@ -433,7 +401,7 @@ function defaultDocTitle(relSrc) {
   const base = path.posix.basename(relSrc).replace(/\.md$/i, '');
   const words = base.split(/[-_]+/).filter(Boolean);
   if (words.length === 0) return base;
-  return words.map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+  return words.map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
 }
 
 function titleFromFilename(filename) {
@@ -447,6 +415,25 @@ function slugify(key) {
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-+|-+$/g, '') || 'item'
   );
+}
+
+/**
+ * Return `base`, or `base-1`, `base-2`, … if `base` is already taken. Mirrors
+ * the counter in createHeadingRenderer: every emitted id is registered, so a
+ * later collision never re-uses a suffix that is already in use. `seen` is a
+ * Map shared across one render pass; the first occurrence keeps the bare id, so
+ * ids of existing content do not change when a colliding name is added later.
+ */
+function uniqueAnchorId(seen, base) {
+  let candidate = base;
+  while (seen.has(candidate)) {
+    const n = seen.get(base);
+    seen.set(base, n + 1);
+    candidate = base + '-' + n;
+  }
+  seen.set(candidate, 1);
+  if (!seen.has(base)) seen.set(base, 1);
+  return candidate;
 }
 
 /**
@@ -515,11 +502,7 @@ function collectRelativeRefs(html) {
   let m;
   while ((m = re.exec(html)) !== null) {
     const raw = m[1] !== undefined ? m[1] : m[2];
-    if (
-      ABSOLUTE_URI_SCHEME_RE.test(raw) ||
-      raw.startsWith('//') ||
-      raw.startsWith('#')
-    ) {
+    if (ABSOLUTE_URI_SCHEME_RE.test(raw) || raw.startsWith('//') || raw.startsWith('#')) {
       continue;
     }
     // Browser order: decode HTML entities first (a literal '#' inside an entity
@@ -542,9 +525,7 @@ function collectRelativeRefs(html) {
  *   infrastructure/Readme.md   → docs/infrastructure/Readme.html
  */
 function docOutputPath(relSrc) {
-  const outInner = (
-    relSrc.startsWith('docs/') ? relSrc.slice(5) : relSrc
-  ).replace(/\.md$/i, '.html');
+  const outInner = (relSrc.startsWith('docs/') ? relSrc.slice(5) : relSrc).replace(/\.md$/i, '.html');
   return path.posix.join('docs', outInner);
 }
 
@@ -577,21 +558,18 @@ function stripDangerousHtml(html) {
   // Drop inline event handlers (onerror=, onclick=, …).
   out = out.replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
   // Neutralize dangerous URL schemes in href/src (keep data:image/*).
-  out = out.replace(
-    /\b(href|src)\s*=\s*(["'])([^"']*)\2/gi,
-    (full, attr, q, url) => {
-      const trimmed = String(url).trim();
-      const lower = trimmed.toLowerCase();
-      if (
-        lower.startsWith('javascript:') ||
-        lower.startsWith('vbscript:') ||
-        (lower.startsWith('data:') && !/^data:image\//i.test(trimmed))
-      ) {
-        return attr + '=' + q + q;
-      }
-      return full;
-    },
-  );
+  out = out.replace(/\b(href|src)\s*=\s*(["'])([^"']*)\2/gi, (full, attr, q, url) => {
+    const trimmed = String(url).trim();
+    const lower = trimmed.toLowerCase();
+    if (
+      lower.startsWith('javascript:') ||
+      lower.startsWith('vbscript:') ||
+      (lower.startsWith('data:') && !/^data:image\//i.test(trimmed))
+    ) {
+      return attr + '=' + q + q;
+    }
+    return full;
+  });
   return out;
 }
 
@@ -635,15 +613,11 @@ function sanitizeDocHtml(html, docOutRel, discoveredMdToOut) {
     const key = docOutRel + '\0' + ref;
     if (logged.has(key)) return;
     logged.add(key);
-    console.error(
-      `handbook: stripped unresolved local link in ${docOutRel}: ${ref}`,
-    );
+    console.error(`handbook: stripped unresolved local link in ${docOutRel}: ${ref}`);
   }
 
   function tryRewriteMdLink(rawHref) {
-    const decoded = decodeHtmlPath(
-      decodeHtmlEntities(rawHref).split('#')[0].split('?')[0],
-    );
+    const decoded = decodeHtmlPath(decodeHtmlEntities(rawHref).split('#')[0].split('?')[0]);
     if (!decoded || ABSOLUTE_URI_SCHEME_RE.test(decoded) || decoded.startsWith('//')) {
       return null;
     }
@@ -656,79 +630,50 @@ function sanitizeDocHtml(html, docOutRel, discoveredMdToOut) {
     let rel = path.posix.relative(pageDir, targetOut);
     if (!rel) rel = path.posix.basename(targetOut);
     // Preserve fragment if present
-    const frag = decodeHtmlEntities(rawHref).includes('#')
-      ? '#' + decodeHtmlEntities(rawHref).split('#').slice(1).join('#')
-      : '';
+    const frag = decodeHtmlEntities(rawHref).includes('#') ? '#' + decodeHtmlEntities(rawHref).split('#').slice(1).join('#') : '';
     return encodeHtmlPath(rel) + frag;
   }
 
   function targetExists(rawHref) {
-    const decoded = decodeHtmlPath(
-      decodeHtmlEntities(rawHref).split('#')[0].split('?')[0],
-    );
+    const decoded = decodeHtmlPath(decodeHtmlEntities(rawHref).split('#')[0].split('?')[0]);
     if (!decoded) return true; // empty after strip — ignore
-    if (
-      ABSOLUTE_URI_SCHEME_RE.test(decoded) ||
-      decoded.startsWith('//') ||
-      decoded.startsWith('#')
-    ) {
+    if (ABSOLUTE_URI_SCHEME_RE.test(decoded) || decoded.startsWith('//') || decoded.startsWith('#')) {
       return true;
     }
     // Candidate under the output tree relative to the page dir
     const underPage = resolvePosix(pageDir, decoded);
     // Also allow absolute-from-handbook-root style (no leading /)
-    return (
-      fs.existsSync(path.join(sanitizeDocHtml._outDir, underPage)) ||
-      fs.existsSync(path.join(sanitizeDocHtml._outDir, decoded))
-    );
+    return fs.existsSync(path.join(sanitizeDocHtml._outDir, underPage)) || fs.existsSync(path.join(sanitizeDocHtml._outDir, decoded));
   }
 
   // Rewrite or strip <a href="...">…</a>
-  html = html.replace(
-    /<a\s+([^>]*?)href=(?:"([^"]*)"|'([^']*)')([^>]*)>([\s\S]*?)<\/a>/gi,
-    (full, pre, dHref, sHref, post, inner) => {
-      const href = dHref !== undefined ? dHref : sHref;
-      if (
-        ABSOLUTE_URI_SCHEME_RE.test(href) ||
-        href.startsWith('//') ||
-        href.startsWith('#')
-      ) {
-        return full;
-      }
-      const rewritten = tryRewriteMdLink(href);
-      if (rewritten !== null) {
-        const q = dHref !== undefined ? '"' : "'";
-        return `<a ${pre}href=${q}${rewritten}${q}${post}>${inner}</a>`;
-      }
-      if (targetExists(href)) return full;
-      logOnce(decodeHtmlEntities(href).split('#')[0].split('?')[0]);
-      return inner;
-    },
-  );
+  html = html.replace(/<a\s+([^>]*?)href=(?:"([^"]*)"|'([^']*)')([^>]*)>([\s\S]*?)<\/a>/gi, (full, pre, dHref, sHref, post, inner) => {
+    const href = dHref !== undefined ? dHref : sHref;
+    if (ABSOLUTE_URI_SCHEME_RE.test(href) || href.startsWith('//') || href.startsWith('#')) {
+      return full;
+    }
+    const rewritten = tryRewriteMdLink(href);
+    if (rewritten !== null) {
+      const q = dHref !== undefined ? '"' : "'";
+      return `<a ${pre}href=${q}${rewritten}${q}${post}>${inner}</a>`;
+    }
+    if (targetExists(href)) return full;
+    logOnce(decodeHtmlEntities(href).split('#')[0].split('?')[0]);
+    return inner;
+  });
 
   // Strip unresolved <img src="..."> — keep alt text if present.
-  html = html.replace(
-    /<img\s+([^>]*?)src=(?:"([^"]*)"|'([^']*)')([^>]*?)\/?>/gi,
-    (full, pre, dSrc, sSrc, post) => {
-      const src = dSrc !== undefined ? dSrc : sSrc;
-      if (
-        ABSOLUTE_URI_SCHEME_RE.test(src) ||
-        src.startsWith('//') ||
-        src.startsWith('#')
-      ) {
-        return full;
-      }
-      if (targetExists(src)) return full;
-      logOnce(decodeHtmlEntities(src).split('#')[0].split('?')[0]);
-      const altMatch = full.match(/\balt=(?:"([^"]*)"|'([^']*)')/i);
-      const alt = altMatch
-        ? altMatch[1] !== undefined
-          ? altMatch[1]
-          : altMatch[2]
-        : '';
-      return alt ? escapeHtml(decodeHtmlEntities(alt)) : '';
-    },
-  );
+  html = html.replace(/<img\s+([^>]*?)src=(?:"([^"]*)"|'([^']*)')([^>]*?)\/?>/gi, (full, pre, dSrc, sSrc, post) => {
+    const src = dSrc !== undefined ? dSrc : sSrc;
+    if (ABSOLUTE_URI_SCHEME_RE.test(src) || src.startsWith('//') || src.startsWith('#')) {
+      return full;
+    }
+    if (targetExists(src)) return full;
+    logOnce(decodeHtmlEntities(src).split('#')[0].split('?')[0]);
+    const altMatch = full.match(/\balt=(?:"([^"]*)"|'([^']*)')/i);
+    const alt = altMatch ? (altMatch[1] !== undefined ? altMatch[1] : altMatch[2]) : '';
+    return alt ? escapeHtml(decodeHtmlEntities(alt)) : '';
+  });
 
   return html;
 }
@@ -756,14 +701,9 @@ function collectStoreFields(localeAbs, localeRelPosix) {
       if (d.isDirectory()) {
         if (name.startsWith('.')) continue;
         if (name === 'images') continue;
-        walk(
-          path.join(absDir, name),
-          relDir ? path.posix.join(relDir, name) : name,
-        );
+        walk(path.join(absDir, name), relDir ? path.posix.join(relDir, name) : name);
       } else if (d.isFile() && name.toLowerCase().endsWith('.txt')) {
-        const fieldRel = relDir
-          ? path.posix.join(relDir, name)
-          : name;
+        const fieldRel = relDir ? path.posix.join(relDir, name) : name;
         const fieldName = fieldRel.replace(/\.txt$/i, '');
         const content = fs.readFileSync(path.join(absDir, name), 'utf8').trim();
         fields.push({
@@ -785,9 +725,7 @@ function main() {
   }
 
   const scriptDir = __dirname;
-  const repoRoot = process.env.HANDBOOK_REPO_ROOT
-    ? path.resolve(process.env.HANDBOOK_REPO_ROOT)
-    : path.resolve(scriptDir, '../..');
+  const repoRoot = process.env.HANDBOOK_REPO_ROOT ? path.resolve(process.env.HANDBOOK_REPO_ROOT) : path.resolve(scriptDir, '../..');
   const outDir = path.resolve(outArg);
   sanitizeDocHtml._outDir = outDir;
   const gitSha = process.env.GIT_SHA || process.env.HANDBOOK_GIT_SHA || 'unknown';
@@ -801,10 +739,7 @@ function main() {
   if (fs.existsSync(metadataPath)) {
     metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
   }
-  const screenshotsMeta =
-    (metadata && metadata.screenshots && typeof metadata.screenshots === 'object'
-      ? metadata.screenshots
-      : {}) || {};
+  const screenshotsMeta = (metadata && metadata.screenshots && typeof metadata.screenshots === 'object' ? metadata.screenshots : {}) || {};
   const docsMeta = (metadata && metadata.docs) || {};
 
   const artifacts = [];
@@ -862,11 +797,10 @@ function main() {
   // -------------------------------------------------------------------------
   const discoveredDocs = listMarkdownFiles(repoRoot);
   const discoveredMdToOut = new Map();
-  const docSpecs = discoveredDocs.map((relSrc) => {
+  const docSpecs = discoveredDocs.map(relSrc => {
     const out = docOutputPath(relSrc);
     discoveredMdToOut.set(relSrc, out);
-    const title =
-      (docsMeta[relSrc] && docsMeta[relSrc].title) || defaultDocTitle(relSrc);
+    const title = (docsMeta[relSrc] && docsMeta[relSrc].title) || defaultDocTitle(relSrc);
     return { src: relSrc, out, title };
   });
   if (docSpecs.length < MIN_DOCS) {
@@ -895,16 +829,10 @@ function main() {
   const androidMetaRoot = path.join(repoRoot, SOURCE_ANDROID_META_REL);
   const iosMetaRoot = path.join(repoRoot, SOURCE_IOS_META_REL);
   if (!fs.existsSync(androidMetaRoot)) {
-    fail(
-      `handbook: missing Android store-metadata root ${androidMetaRoot} ` +
-        '(broken checkout — both platform roots are required).',
-    );
+    fail(`handbook: missing Android store-metadata root ${androidMetaRoot} ` + '(broken checkout — both platform roots are required).');
   }
   if (!fs.existsSync(iosMetaRoot)) {
-    fail(
-      `handbook: missing iOS store-metadata root ${iosMetaRoot} ` +
-        '(broken checkout — both platform roots are required).',
-    );
+    fail(`handbook: missing iOS store-metadata root ${iosMetaRoot} ` + '(broken checkout — both platform roots are required).');
   }
 
   const storeEntries = []; // { platform, locale, field, content, sourcePath }
@@ -913,8 +841,8 @@ function main() {
   {
     const locales = fs
       .readdirSync(androidMetaRoot, { withFileTypes: true })
-      .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
-      .map((d) => d.name)
+      .filter(d => d.isDirectory() && !d.name.startsWith('.'))
+      .map(d => d.name)
       .sort(sortStrings);
     for (const locale of locales) {
       const localeAbs = path.join(androidMetaRoot, locale);
@@ -943,9 +871,7 @@ function main() {
     for (const d of entries) {
       if (d.isFile() && d.name.toLowerCase().endsWith('.txt')) {
         const fieldName = d.name.replace(/\.txt$/i, '');
-        const content = fs
-          .readFileSync(path.join(iosMetaRoot, d.name), 'utf8')
-          .trim();
+        const content = fs.readFileSync(path.join(iosMetaRoot, d.name), 'utf8').trim();
         globalFields.push({
           field: fieldName,
           content,
@@ -965,8 +891,8 @@ function main() {
     }
 
     const locales = entries
-      .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
-      .map((d) => d.name)
+      .filter(d => d.isDirectory() && !d.name.startsWith('.'))
+      .map(d => d.name)
       .sort(sortStrings);
     for (const locale of locales) {
       const localeAbs = path.join(iosMetaRoot, locale);
@@ -1018,13 +944,8 @@ function main() {
   if (fs.existsSync(imgDir)) {
     const iconNames = fs
       .readdirSync(imgDir, { withFileTypes: true })
-      .filter(
-        (d) =>
-          d.isFile() &&
-          d.name.toLowerCase().endsWith('.png') &&
-          /^icon/i.test(d.name),
-      )
-      .map((d) => d.name)
+      .filter(d => d.isFile() && d.name.toLowerCase().endsWith('.png') && /^icon/i.test(d.name))
+      .map(d => d.name)
       .sort(sortStrings);
     for (const name of iconNames) {
       const abs = path.join(imgDir, name);
@@ -1120,18 +1041,14 @@ function main() {
   // Orphan metadata: screenshots.* without a matching group → warning only
   for (const key of Object.keys(screenshotsMeta).sort(sortStrings)) {
     if (!groups.has(key)) {
-      console.error(
-        `handbook warning: metadata.json screenshots entry "${key}" has no matching screenshots (orphan).`,
-      );
+      console.error(`handbook warning: metadata.json screenshots entry "${key}" has no matching screenshots (orphan).`);
     }
   }
   // Symmetric orphan warning for docs title overrides without a discovered file.
   const discoveredDocSet = new Set(discoveredDocs);
   for (const key of Object.keys(docsMeta).sort(sortStrings)) {
     if (!discoveredDocSet.has(key)) {
-      console.error(
-        `handbook warning: metadata.json docs entry "${key}" has no matching document (orphan).`,
-      );
+      console.error(`handbook warning: metadata.json docs entry "${key}" has no matching document (orphan).`);
     }
   }
 
@@ -1527,12 +1444,6 @@ function main() {
         text-decoration: underline;
         color: var(--brand);
       }
-      .group-head {
-        display: flex;
-        align-items: baseline;
-        gap: 8px;
-      }
-      .group-head h3 { margin: 0; }
       .copy-link {
         appearance: none;
         background: transparent;
@@ -1603,7 +1514,7 @@ function main() {
     '    var origText = btn.textContent;\n' +
     '    var resetTimer = null;\n' +
     "    btn.addEventListener('click', function () {\n" +
-    '      var target = btn.getAttribute(\'data-target\');\n' +
+    "      var target = btn.getAttribute('data-target');\n" +
     '      if (!target) return;\n' +
     "      var url = location.origin + location.pathname + '#' + target;\n" +
     '      var done = function () {\n' +
@@ -1658,27 +1569,32 @@ function main() {
   // before we reach HTML generation when the set is empty, so a "no screenshots"
   // empty-state branch would be dead code — render groups only.
   {
+    // Anchor ids become user-facing with the permalink buttons: a reader can
+    // copy one and send it on. slugify() is lossy, so two different sources can
+    // land on the same id (e.g. the group dirs `05-karte/dfx` and `05-karte-dfx`,
+    // or `99-fee ok.png` next to `99-fee-ok.png`). getElementById always returns
+    // the first match, so the copied link would silently point at the wrong
+    // screen. Suffix collisions the same way createHeadingRenderer does.
+    const anchorIds = new Map();
     let allShotsBody = '';
     for (const gKey of groupKeys) {
       const list = groups.get(gKey);
       const meta = screenshotsMeta[gKey];
       const title = meta && meta.title ? meta.title : gKey;
       const desc =
-        meta && meta.description
-          ? escapeHtml(meta.description)
-          : `Screenshot-Gruppe <code>${escapeHtml(gKey)}</code> (Auto-Discovery).`;
-      const groupId = 'group-' + slugify(gKey);
+        meta && meta.description ? escapeHtml(meta.description) : `Screenshot-Gruppe <code>${escapeHtml(gKey)}</code> (Auto-Discovery).`;
+      // Button inside the <h3>, not in a wrapper element: the heading keeps its
+      // own margins, so adding the permalink changes no vertical spacing.
+      const groupId = uniqueAnchorId(anchorIds, 'group-' + slugify(gKey));
       let cards =
-        `<div class="group-head">` +
         `<h3 id="${escapeHtml(groupId)}">` +
         `<a class="name permalink" href="#${escapeHtml(groupId)}">${escapeHtml(title)}</a>` +
-        `</h3>` +
         copyLinkButton(groupId) +
-        `</div>`;
+        `</h3>`;
       cards += `<p class="spec-intro">${desc}</p>`;
       cards += '<div class="tests">';
       for (const e of list) {
-        const cardId = 'shot-' + slugify(e.group + '-' + e.title);
+        const cardId = uniqueAnchorId(anchorIds, 'shot-' + slugify(e.group + '-' + e.title));
         const shotHref = escapeHtml(encodeHtmlPath(e.outputPath));
         cards +=
           `<div class="test" id="${escapeHtml(cardId)}">` +
@@ -1729,14 +1645,13 @@ function main() {
         platform === 'android' ? 'Android (Play Store)' : 'iOS (App Store)',
       )}</h3>`;
       for (const locale of localeKeys) {
-        const fields = byLocale.get(locale).slice().sort((a, b) =>
-          sortStrings(a.field, b.field),
-        );
+        const fields = byLocale
+          .get(locale)
+          .slice()
+          .sort((a, b) => sortStrings(a.field, b.field));
         storeBody += `<div class="store-locale"><h4>${escapeHtml(locale)}</h4><dl>`;
         for (const f of fields) {
-          storeBody +=
-            `<dt>${escapeHtml(f.field)}</dt>` +
-            `<dd>${escapeHtml(f.content)}</dd>`;
+          storeBody += `<dt>${escapeHtml(f.field)}</dt>` + `<dd>${escapeHtml(f.content)}</dd>`;
         }
         storeBody += '</dl></div>';
       }
@@ -1778,9 +1693,7 @@ function main() {
   // Documentation list
   {
     let docsBody = '<ul class="doc-list">';
-    const sortedDocs = renderedDocs
-      .slice()
-      .sort((a, b) => sortStrings(a.title, b.title));
+    const sortedDocs = renderedDocs.slice().sort((a, b) => sortStrings(a.title, b.title));
     for (const d of sortedDocs) {
       docsBody +=
         `<li><a href="${escapeHtml(encodeHtmlPath(d.out))}">` +
@@ -1891,10 +1804,7 @@ function main() {
   for (const a of artifacts) {
     const full = path.join(outDir, a.outputPath);
     if (!fs.existsSync(full)) {
-      fail(
-        `handbook integrity check failed (manifest): missing ${a.outputPath}` +
-          ` (sourcePath=${a.sourcePath}, title=${a.title})`,
-      );
+      fail(`handbook integrity check failed (manifest): missing ${a.outputPath}` + ` (sourcePath=${a.sourcePath}, title=${a.title})`);
     }
   }
 
@@ -1909,11 +1819,7 @@ function main() {
       // fragment/query split); only percent-decoding remains here.
       const ref = decodeHtmlPath(rawRef);
       const underOut = path.join(path.dirname(path.join(outDir, d.out)), ref);
-      if (
-        !ref.startsWith('/') &&
-        !fs.existsSync(underOut) &&
-        !fs.existsSync(path.join(outDir, ref))
-      ) {
+      if (!ref.startsWith('/') && !fs.existsSync(underOut) && !fs.existsSync(path.join(outDir, ref))) {
         fail(`handbook integrity check failed (${d.out}): missing ${ref}`);
       }
     }

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -1558,10 +1558,22 @@ function main() {
         cursor: pointer;
         border-radius: 4px;
       }
-      /* Card heads are flex with a gap; the group heading is not, so the button
-         needs its own separation there. */
-      h3 .copy-link {
-        margin-left: 8px;
+      /* The copy button sits NEXT TO the group heading, never inside it: a
+         button placed within the heading element becomes part of its text and
+         of its accessible name ("Einstellungen Direkt-Link kopieren"). The
+         wrapper therefore carries the margins the heading gives up — h3 has no
+         font-size rule, so its UA margin is 1em of 1.17 * 14.5px; 1.17em on the
+         wrapper (font-size 14.5px inherited) reproduces exactly that. Same
+         arrangement as the RealUnit handbook, where .copy-link lives in the
+         head next to the name. */
+      .group-head {
+        display: flex;
+        align-items: baseline;
+        gap: 8px;
+        margin: 1.17em 0;
+      }
+      .group-head h3 {
+        margin: 0;
       }
       .copy-link:hover {
         color: var(--brand);
@@ -1695,14 +1707,14 @@ function main() {
         meta && meta.description
           ? escapeHtml(meta.description)
           : `Screenshot-Gruppe <code>${escapeHtml(gKey)}</code> (Auto-Discovery).`;
-      // Button inside the <h3>, not in a wrapper element: the heading keeps its
-      // own margins, so adding the permalink changes no vertical spacing.
       const groupId = uniqueAnchorId(anchorIds, 'group-' + slugify(gKey));
       let cards =
+        `<div class="group-head">` +
         `<h3 id="${escapeHtml(groupId)}">` +
         `<a class="name permalink" href="#${escapeHtml(groupId)}">${escapeHtml(title)}</a>` +
+        `</h3>` +
         copyLinkButton(groupId) +
-        `</h3>`;
+        `</div>`;
       cards += `<p class="spec-intro">${desc}</p>`;
       cards += '<div class="tests">';
       for (const e of list) {

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -31,7 +31,8 @@ const MIN_ASSETS = 20;
 const MIN_PNG_BYTES = 1000;
 const MIN_ASSET_PNG_BYTES = 100;
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
-const MARKED_INSTALL = 'npm install --prefix ./_handbook-deps --no-save --no-audit --no-fund marked@15.0.7';
+const MARKED_INSTALL =
+  'npm install --prefix ./_handbook-deps --no-save --no-audit --no-fund marked@15.0.7';
 
 // Repo-relative discovery roots (same strings discovery walks). prepareOutputDir
 // refuses to empty these or any ancestor path that would wipe them.
@@ -139,7 +140,17 @@ function createHeadingRenderer() {
     seen.set(candidate, 1);
     if (!seen.has(slug)) seen.set(slug, 1);
     slug = candidate;
-    return '<h' + depth + ' id="' + slug + '">' + this.parser.parseInline(tokens) + '</h' + depth + '>\n';
+    return (
+      '<h' +
+      depth +
+      ' id="' +
+      slug +
+      '">' +
+      this.parser.parseInline(tokens) +
+      '</h' +
+      depth +
+      '>\n'
+    );
   };
   return renderer;
 }
@@ -151,7 +162,12 @@ function markedParse(md) {
 }
 
 function escapeHtml(str) {
-  return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  return String(str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 // Inverse of escapeHtml, for re-reading paths out of already-escaped HTML.
@@ -183,7 +199,7 @@ function encodeHtmlPath(p) {
 function decodeHtmlPath(p) {
   return String(p)
     .split('/')
-    .map(seg => {
+    .map((seg) => {
       try {
         return decodeURIComponent(seg);
       } catch {
@@ -246,14 +262,19 @@ function prepareOutputDir(outDir, repoRoot) {
   const homeDir = resolveHomeDir();
 
   if (resolvedOut === path.resolve('/')) {
-    fail('handbook: refusing to use filesystem root (/) as output directory.');
+    fail(
+      'handbook: refusing to use filesystem root (/) as output directory.',
+    );
   }
   if (homeDir === null) {
     console.error(
-      'handbook warning: home directory could not be determined; ' + 'skipping home-directory output guard (other guards still apply).',
+      'handbook warning: home directory could not be determined; ' +
+        'skipping home-directory output guard (other guards still apply).',
     );
   } else if (resolvedOut === homeDir) {
-    fail(`handbook: refusing to use home directory as output directory: ${resolvedOut}`);
+    fail(
+      `handbook: refusing to use home directory as output directory: ${resolvedOut}`,
+    );
   }
   // Repo root itself, or any ancestor of the repo (emptying would wipe the tree).
   if (isSameOrAncestor(resolvedOut, resolvedRoot)) {
@@ -277,7 +298,9 @@ function prepareOutputDir(outDir, repoRoot) {
   // Never touch anything under .git (object store, hooks, config).
   const segments = resolvedOut.split(path.sep);
   if (segments.includes('.git')) {
-    fail(`handbook: refusing to empty output path that contains a .git segment: ${resolvedOut}`);
+    fail(
+      `handbook: refusing to empty output path that contains a .git segment: ${resolvedOut}`,
+    );
   }
 
   if (fs.existsSync(resolvedOut)) {
@@ -311,8 +334,11 @@ function assertNoOutputCollisions(artifacts) {
   }
   collisions.sort((a, b) => sortStrings(a.outPath, b.outPath));
   if (collisions.length > 0) {
-    const lines = collisions.map(c => {
-      return `  ${c.outPath}\n` + c.sources.map(s => `    - ${s}`).join('\n');
+    const lines = collisions.map((c) => {
+      return (
+        `  ${c.outPath}\n` +
+        c.sources.map((s) => `    - ${s}`).join('\n')
+      );
     });
     fail(
       'handbook output collision: multiple sources claim the same output path ' +
@@ -330,7 +356,10 @@ function assertValidPng(filePath, minBytes = MIN_PNG_BYTES) {
     fail(`handbook PNG guard: cannot stat ${filePath}: ${err.message}`);
   }
   if (st.size <= minBytes) {
-    fail(`handbook PNG guard: ${filePath} is ${st.size} bytes (must be > ${minBytes}). ` + 'Possible incomplete checkout or LFS pointer.');
+    fail(
+      `handbook PNG guard: ${filePath} is ${st.size} bytes (must be > ${minBytes}). ` +
+        'Possible incomplete checkout or LFS pointer.',
+    );
   }
   const fd = fs.openSync(filePath, 'r');
   const buf = Buffer.alloc(8);
@@ -340,7 +369,10 @@ function assertValidPng(filePath, minBytes = MIN_PNG_BYTES) {
     fs.closeSync(fd);
   }
   if (!buf.equals(PNG_MAGIC)) {
-    fail(`handbook PNG guard: ${filePath} does not start with PNG magic bytes. ` + 'Possible incomplete checkout or LFS pointer.');
+    fail(
+      `handbook PNG guard: ${filePath} does not start with PNG magic bytes. ` +
+        'Possible incomplete checkout or LFS pointer.',
+    );
   }
 }
 
@@ -401,7 +433,7 @@ function defaultDocTitle(relSrc) {
   const base = path.posix.basename(relSrc).replace(/\.md$/i, '');
   const words = base.split(/[-_]+/).filter(Boolean);
   if (words.length === 0) return base;
-  return words.map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+  return words.map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
 }
 
 function titleFromFilename(filename) {
@@ -502,7 +534,11 @@ function collectRelativeRefs(html) {
   let m;
   while ((m = re.exec(html)) !== null) {
     const raw = m[1] !== undefined ? m[1] : m[2];
-    if (ABSOLUTE_URI_SCHEME_RE.test(raw) || raw.startsWith('//') || raw.startsWith('#')) {
+    if (
+      ABSOLUTE_URI_SCHEME_RE.test(raw) ||
+      raw.startsWith('//') ||
+      raw.startsWith('#')
+    ) {
       continue;
     }
     // Browser order: decode HTML entities first (a literal '#' inside an entity
@@ -525,7 +561,9 @@ function collectRelativeRefs(html) {
  *   infrastructure/Readme.md   → docs/infrastructure/Readme.html
  */
 function docOutputPath(relSrc) {
-  const outInner = (relSrc.startsWith('docs/') ? relSrc.slice(5) : relSrc).replace(/\.md$/i, '.html');
+  const outInner = (
+    relSrc.startsWith('docs/') ? relSrc.slice(5) : relSrc
+  ).replace(/\.md$/i, '.html');
   return path.posix.join('docs', outInner);
 }
 
@@ -558,18 +596,21 @@ function stripDangerousHtml(html) {
   // Drop inline event handlers (onerror=, onclick=, …).
   out = out.replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
   // Neutralize dangerous URL schemes in href/src (keep data:image/*).
-  out = out.replace(/\b(href|src)\s*=\s*(["'])([^"']*)\2/gi, (full, attr, q, url) => {
-    const trimmed = String(url).trim();
-    const lower = trimmed.toLowerCase();
-    if (
-      lower.startsWith('javascript:') ||
-      lower.startsWith('vbscript:') ||
-      (lower.startsWith('data:') && !/^data:image\//i.test(trimmed))
-    ) {
-      return attr + '=' + q + q;
-    }
-    return full;
-  });
+  out = out.replace(
+    /\b(href|src)\s*=\s*(["'])([^"']*)\2/gi,
+    (full, attr, q, url) => {
+      const trimmed = String(url).trim();
+      const lower = trimmed.toLowerCase();
+      if (
+        lower.startsWith('javascript:') ||
+        lower.startsWith('vbscript:') ||
+        (lower.startsWith('data:') && !/^data:image\//i.test(trimmed))
+      ) {
+        return attr + '=' + q + q;
+      }
+      return full;
+    },
+  );
   return out;
 }
 
@@ -613,11 +654,15 @@ function sanitizeDocHtml(html, docOutRel, discoveredMdToOut) {
     const key = docOutRel + '\0' + ref;
     if (logged.has(key)) return;
     logged.add(key);
-    console.error(`handbook: stripped unresolved local link in ${docOutRel}: ${ref}`);
+    console.error(
+      `handbook: stripped unresolved local link in ${docOutRel}: ${ref}`,
+    );
   }
 
   function tryRewriteMdLink(rawHref) {
-    const decoded = decodeHtmlPath(decodeHtmlEntities(rawHref).split('#')[0].split('?')[0]);
+    const decoded = decodeHtmlPath(
+      decodeHtmlEntities(rawHref).split('#')[0].split('?')[0],
+    );
     if (!decoded || ABSOLUTE_URI_SCHEME_RE.test(decoded) || decoded.startsWith('//')) {
       return null;
     }
@@ -630,50 +675,79 @@ function sanitizeDocHtml(html, docOutRel, discoveredMdToOut) {
     let rel = path.posix.relative(pageDir, targetOut);
     if (!rel) rel = path.posix.basename(targetOut);
     // Preserve fragment if present
-    const frag = decodeHtmlEntities(rawHref).includes('#') ? '#' + decodeHtmlEntities(rawHref).split('#').slice(1).join('#') : '';
+    const frag = decodeHtmlEntities(rawHref).includes('#')
+      ? '#' + decodeHtmlEntities(rawHref).split('#').slice(1).join('#')
+      : '';
     return encodeHtmlPath(rel) + frag;
   }
 
   function targetExists(rawHref) {
-    const decoded = decodeHtmlPath(decodeHtmlEntities(rawHref).split('#')[0].split('?')[0]);
+    const decoded = decodeHtmlPath(
+      decodeHtmlEntities(rawHref).split('#')[0].split('?')[0],
+    );
     if (!decoded) return true; // empty after strip — ignore
-    if (ABSOLUTE_URI_SCHEME_RE.test(decoded) || decoded.startsWith('//') || decoded.startsWith('#')) {
+    if (
+      ABSOLUTE_URI_SCHEME_RE.test(decoded) ||
+      decoded.startsWith('//') ||
+      decoded.startsWith('#')
+    ) {
       return true;
     }
     // Candidate under the output tree relative to the page dir
     const underPage = resolvePosix(pageDir, decoded);
     // Also allow absolute-from-handbook-root style (no leading /)
-    return fs.existsSync(path.join(sanitizeDocHtml._outDir, underPage)) || fs.existsSync(path.join(sanitizeDocHtml._outDir, decoded));
+    return (
+      fs.existsSync(path.join(sanitizeDocHtml._outDir, underPage)) ||
+      fs.existsSync(path.join(sanitizeDocHtml._outDir, decoded))
+    );
   }
 
   // Rewrite or strip <a href="...">…</a>
-  html = html.replace(/<a\s+([^>]*?)href=(?:"([^"]*)"|'([^']*)')([^>]*)>([\s\S]*?)<\/a>/gi, (full, pre, dHref, sHref, post, inner) => {
-    const href = dHref !== undefined ? dHref : sHref;
-    if (ABSOLUTE_URI_SCHEME_RE.test(href) || href.startsWith('//') || href.startsWith('#')) {
-      return full;
-    }
-    const rewritten = tryRewriteMdLink(href);
-    if (rewritten !== null) {
-      const q = dHref !== undefined ? '"' : "'";
-      return `<a ${pre}href=${q}${rewritten}${q}${post}>${inner}</a>`;
-    }
-    if (targetExists(href)) return full;
-    logOnce(decodeHtmlEntities(href).split('#')[0].split('?')[0]);
-    return inner;
-  });
+  html = html.replace(
+    /<a\s+([^>]*?)href=(?:"([^"]*)"|'([^']*)')([^>]*)>([\s\S]*?)<\/a>/gi,
+    (full, pre, dHref, sHref, post, inner) => {
+      const href = dHref !== undefined ? dHref : sHref;
+      if (
+        ABSOLUTE_URI_SCHEME_RE.test(href) ||
+        href.startsWith('//') ||
+        href.startsWith('#')
+      ) {
+        return full;
+      }
+      const rewritten = tryRewriteMdLink(href);
+      if (rewritten !== null) {
+        const q = dHref !== undefined ? '"' : "'";
+        return `<a ${pre}href=${q}${rewritten}${q}${post}>${inner}</a>`;
+      }
+      if (targetExists(href)) return full;
+      logOnce(decodeHtmlEntities(href).split('#')[0].split('?')[0]);
+      return inner;
+    },
+  );
 
   // Strip unresolved <img src="..."> — keep alt text if present.
-  html = html.replace(/<img\s+([^>]*?)src=(?:"([^"]*)"|'([^']*)')([^>]*?)\/?>/gi, (full, pre, dSrc, sSrc, post) => {
-    const src = dSrc !== undefined ? dSrc : sSrc;
-    if (ABSOLUTE_URI_SCHEME_RE.test(src) || src.startsWith('//') || src.startsWith('#')) {
-      return full;
-    }
-    if (targetExists(src)) return full;
-    logOnce(decodeHtmlEntities(src).split('#')[0].split('?')[0]);
-    const altMatch = full.match(/\balt=(?:"([^"]*)"|'([^']*)')/i);
-    const alt = altMatch ? (altMatch[1] !== undefined ? altMatch[1] : altMatch[2]) : '';
-    return alt ? escapeHtml(decodeHtmlEntities(alt)) : '';
-  });
+  html = html.replace(
+    /<img\s+([^>]*?)src=(?:"([^"]*)"|'([^']*)')([^>]*?)\/?>/gi,
+    (full, pre, dSrc, sSrc, post) => {
+      const src = dSrc !== undefined ? dSrc : sSrc;
+      if (
+        ABSOLUTE_URI_SCHEME_RE.test(src) ||
+        src.startsWith('//') ||
+        src.startsWith('#')
+      ) {
+        return full;
+      }
+      if (targetExists(src)) return full;
+      logOnce(decodeHtmlEntities(src).split('#')[0].split('?')[0]);
+      const altMatch = full.match(/\balt=(?:"([^"]*)"|'([^']*)')/i);
+      const alt = altMatch
+        ? altMatch[1] !== undefined
+          ? altMatch[1]
+          : altMatch[2]
+        : '';
+      return alt ? escapeHtml(decodeHtmlEntities(alt)) : '';
+    },
+  );
 
   return html;
 }
@@ -701,9 +775,14 @@ function collectStoreFields(localeAbs, localeRelPosix) {
       if (d.isDirectory()) {
         if (name.startsWith('.')) continue;
         if (name === 'images') continue;
-        walk(path.join(absDir, name), relDir ? path.posix.join(relDir, name) : name);
+        walk(
+          path.join(absDir, name),
+          relDir ? path.posix.join(relDir, name) : name,
+        );
       } else if (d.isFile() && name.toLowerCase().endsWith('.txt')) {
-        const fieldRel = relDir ? path.posix.join(relDir, name) : name;
+        const fieldRel = relDir
+          ? path.posix.join(relDir, name)
+          : name;
         const fieldName = fieldRel.replace(/\.txt$/i, '');
         const content = fs.readFileSync(path.join(absDir, name), 'utf8').trim();
         fields.push({
@@ -725,7 +804,9 @@ function main() {
   }
 
   const scriptDir = __dirname;
-  const repoRoot = process.env.HANDBOOK_REPO_ROOT ? path.resolve(process.env.HANDBOOK_REPO_ROOT) : path.resolve(scriptDir, '../..');
+  const repoRoot = process.env.HANDBOOK_REPO_ROOT
+    ? path.resolve(process.env.HANDBOOK_REPO_ROOT)
+    : path.resolve(scriptDir, '../..');
   const outDir = path.resolve(outArg);
   sanitizeDocHtml._outDir = outDir;
   const gitSha = process.env.GIT_SHA || process.env.HANDBOOK_GIT_SHA || 'unknown';
@@ -739,7 +820,10 @@ function main() {
   if (fs.existsSync(metadataPath)) {
     metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
   }
-  const screenshotsMeta = (metadata && metadata.screenshots && typeof metadata.screenshots === 'object' ? metadata.screenshots : {}) || {};
+  const screenshotsMeta =
+    (metadata && metadata.screenshots && typeof metadata.screenshots === 'object'
+      ? metadata.screenshots
+      : {}) || {};
   const docsMeta = (metadata && metadata.docs) || {};
 
   const artifacts = [];
@@ -797,10 +881,11 @@ function main() {
   // -------------------------------------------------------------------------
   const discoveredDocs = listMarkdownFiles(repoRoot);
   const discoveredMdToOut = new Map();
-  const docSpecs = discoveredDocs.map(relSrc => {
+  const docSpecs = discoveredDocs.map((relSrc) => {
     const out = docOutputPath(relSrc);
     discoveredMdToOut.set(relSrc, out);
-    const title = (docsMeta[relSrc] && docsMeta[relSrc].title) || defaultDocTitle(relSrc);
+    const title =
+      (docsMeta[relSrc] && docsMeta[relSrc].title) || defaultDocTitle(relSrc);
     return { src: relSrc, out, title };
   });
   if (docSpecs.length < MIN_DOCS) {
@@ -829,10 +914,16 @@ function main() {
   const androidMetaRoot = path.join(repoRoot, SOURCE_ANDROID_META_REL);
   const iosMetaRoot = path.join(repoRoot, SOURCE_IOS_META_REL);
   if (!fs.existsSync(androidMetaRoot)) {
-    fail(`handbook: missing Android store-metadata root ${androidMetaRoot} ` + '(broken checkout — both platform roots are required).');
+    fail(
+      `handbook: missing Android store-metadata root ${androidMetaRoot} ` +
+        '(broken checkout — both platform roots are required).',
+    );
   }
   if (!fs.existsSync(iosMetaRoot)) {
-    fail(`handbook: missing iOS store-metadata root ${iosMetaRoot} ` + '(broken checkout — both platform roots are required).');
+    fail(
+      `handbook: missing iOS store-metadata root ${iosMetaRoot} ` +
+        '(broken checkout — both platform roots are required).',
+    );
   }
 
   const storeEntries = []; // { platform, locale, field, content, sourcePath }
@@ -841,8 +932,8 @@ function main() {
   {
     const locales = fs
       .readdirSync(androidMetaRoot, { withFileTypes: true })
-      .filter(d => d.isDirectory() && !d.name.startsWith('.'))
-      .map(d => d.name)
+      .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+      .map((d) => d.name)
       .sort(sortStrings);
     for (const locale of locales) {
       const localeAbs = path.join(androidMetaRoot, locale);
@@ -871,7 +962,9 @@ function main() {
     for (const d of entries) {
       if (d.isFile() && d.name.toLowerCase().endsWith('.txt')) {
         const fieldName = d.name.replace(/\.txt$/i, '');
-        const content = fs.readFileSync(path.join(iosMetaRoot, d.name), 'utf8').trim();
+        const content = fs
+          .readFileSync(path.join(iosMetaRoot, d.name), 'utf8')
+          .trim();
         globalFields.push({
           field: fieldName,
           content,
@@ -891,8 +984,8 @@ function main() {
     }
 
     const locales = entries
-      .filter(d => d.isDirectory() && !d.name.startsWith('.'))
-      .map(d => d.name)
+      .filter((d) => d.isDirectory() && !d.name.startsWith('.'))
+      .map((d) => d.name)
       .sort(sortStrings);
     for (const locale of locales) {
       const localeAbs = path.join(iosMetaRoot, locale);
@@ -944,8 +1037,13 @@ function main() {
   if (fs.existsSync(imgDir)) {
     const iconNames = fs
       .readdirSync(imgDir, { withFileTypes: true })
-      .filter(d => d.isFile() && d.name.toLowerCase().endsWith('.png') && /^icon/i.test(d.name))
-      .map(d => d.name)
+      .filter(
+        (d) =>
+          d.isFile() &&
+          d.name.toLowerCase().endsWith('.png') &&
+          /^icon/i.test(d.name),
+      )
+      .map((d) => d.name)
       .sort(sortStrings);
     for (const name of iconNames) {
       const abs = path.join(imgDir, name);
@@ -1041,14 +1139,18 @@ function main() {
   // Orphan metadata: screenshots.* without a matching group → warning only
   for (const key of Object.keys(screenshotsMeta).sort(sortStrings)) {
     if (!groups.has(key)) {
-      console.error(`handbook warning: metadata.json screenshots entry "${key}" has no matching screenshots (orphan).`);
+      console.error(
+        `handbook warning: metadata.json screenshots entry "${key}" has no matching screenshots (orphan).`,
+      );
     }
   }
   // Symmetric orphan warning for docs title overrides without a discovered file.
   const discoveredDocSet = new Set(discoveredDocs);
   for (const key of Object.keys(docsMeta).sort(sortStrings)) {
     if (!discoveredDocSet.has(key)) {
-      console.error(`handbook warning: metadata.json docs entry "${key}" has no matching document (orphan).`);
+      console.error(
+        `handbook warning: metadata.json docs entry "${key}" has no matching document (orphan).`,
+      );
     }
   }
 
@@ -1456,6 +1558,11 @@ function main() {
         cursor: pointer;
         border-radius: 4px;
       }
+      /* Card heads are flex with a gap; the group heading is not, so the button
+         needs its own separation there. */
+      h3 .copy-link {
+        margin-left: 8px;
+      }
       .copy-link:hover {
         color: var(--brand);
         background: var(--surface);
@@ -1507,8 +1614,10 @@ function main() {
     "    ta.style.opacity = '0';\n" +
     '    document.body.appendChild(ta);\n' +
     '    ta.select();\n' +
-    "    try { document.execCommand('copy'); } catch (e) {}\n" +
+    '    var ok = false;\n' +
+    "    try { ok = document.execCommand('copy'); } catch (e) { ok = false; }\n" +
     '    document.body.removeChild(ta);\n' +
+    '    return ok;\n' +
     '  }\n' +
     "  document.querySelectorAll('.copy-link').forEach(function (btn) {\n" +
     '    var origText = btn.textContent;\n' +
@@ -1517,25 +1626,26 @@ function main() {
     "      var target = btn.getAttribute('data-target');\n" +
     '      if (!target) return;\n' +
     "      var url = location.origin + location.pathname + '#' + target;\n" +
-    '      var done = function () {\n' +
-    "        btn.textContent = '\\u2713 Kopiert';\n" +
-    "        btn.setAttribute('data-copied', 'true');\n" +
+    '      var done = function (ok) {\n' +
+    "        btn.textContent = ok ? '\\u2713 Kopiert' : '\\u2717 Nicht kopiert';\n" +
+    "        if (ok) btn.setAttribute('data-copied', 'true');\n" +
     '        if (resetTimer) clearTimeout(resetTimer);\n' +
     '        resetTimer = setTimeout(function () {\n' +
     '          btn.textContent = origText;\n' +
     "          btn.removeAttribute('data-copied');\n" +
     '          resetTimer = null;\n' +
     '        }, 1200);\n' +
+    '        // Set the hash either way: the reader can then copy the URL from\n' +
+    '        // the address bar even when the clipboard is unavailable.\n' +
     "        if (location.hash !== '#' + target) location.hash = target;\n" +
     '      };\n' +
     '      if (navigator.clipboard && navigator.clipboard.writeText) {\n' +
-    '        navigator.clipboard.writeText(url).then(done, function () {\n' +
-    '          fallbackCopy(url);\n' +
-    '          done();\n' +
-    '        });\n' +
+    '        navigator.clipboard.writeText(url).then(\n' +
+    '          function () { done(true); },\n' +
+    '          function () { done(fallbackCopy(url)); }\n' +
+    '        );\n' +
     '      } else {\n' +
-    '        fallbackCopy(url);\n' +
-    '        done();\n' +
+    '        done(fallbackCopy(url));\n' +
     '      }\n' +
     '    });\n' +
     '  });\n' +
@@ -1582,7 +1692,9 @@ function main() {
       const meta = screenshotsMeta[gKey];
       const title = meta && meta.title ? meta.title : gKey;
       const desc =
-        meta && meta.description ? escapeHtml(meta.description) : `Screenshot-Gruppe <code>${escapeHtml(gKey)}</code> (Auto-Discovery).`;
+        meta && meta.description
+          ? escapeHtml(meta.description)
+          : `Screenshot-Gruppe <code>${escapeHtml(gKey)}</code> (Auto-Discovery).`;
       // Button inside the <h3>, not in a wrapper element: the heading keeps its
       // own margins, so adding the permalink changes no vertical spacing.
       const groupId = uniqueAnchorId(anchorIds, 'group-' + slugify(gKey));
@@ -1594,7 +1706,10 @@ function main() {
       cards += `<p class="spec-intro">${desc}</p>`;
       cards += '<div class="tests">';
       for (const e of list) {
-        const cardId = uniqueAnchorId(anchorIds, 'shot-' + slugify(e.group + '-' + e.title));
+        const cardId = uniqueAnchorId(
+          anchorIds,
+          'shot-' + slugify(e.group + '-' + e.title),
+        );
         const shotHref = escapeHtml(encodeHtmlPath(e.outputPath));
         cards +=
           `<div class="test" id="${escapeHtml(cardId)}">` +
@@ -1645,13 +1760,14 @@ function main() {
         platform === 'android' ? 'Android (Play Store)' : 'iOS (App Store)',
       )}</h3>`;
       for (const locale of localeKeys) {
-        const fields = byLocale
-          .get(locale)
-          .slice()
-          .sort((a, b) => sortStrings(a.field, b.field));
+        const fields = byLocale.get(locale).slice().sort((a, b) =>
+          sortStrings(a.field, b.field),
+        );
         storeBody += `<div class="store-locale"><h4>${escapeHtml(locale)}</h4><dl>`;
         for (const f of fields) {
-          storeBody += `<dt>${escapeHtml(f.field)}</dt>` + `<dd>${escapeHtml(f.content)}</dd>`;
+          storeBody +=
+            `<dt>${escapeHtml(f.field)}</dt>` +
+            `<dd>${escapeHtml(f.content)}</dd>`;
         }
         storeBody += '</dl></div>';
       }
@@ -1693,7 +1809,9 @@ function main() {
   // Documentation list
   {
     let docsBody = '<ul class="doc-list">';
-    const sortedDocs = renderedDocs.slice().sort((a, b) => sortStrings(a.title, b.title));
+    const sortedDocs = renderedDocs
+      .slice()
+      .sort((a, b) => sortStrings(a.title, b.title));
     for (const d of sortedDocs) {
       docsBody +=
         `<li><a href="${escapeHtml(encodeHtmlPath(d.out))}">` +
@@ -1804,7 +1922,10 @@ function main() {
   for (const a of artifacts) {
     const full = path.join(outDir, a.outputPath);
     if (!fs.existsSync(full)) {
-      fail(`handbook integrity check failed (manifest): missing ${a.outputPath}` + ` (sourcePath=${a.sourcePath}, title=${a.title})`);
+      fail(
+        `handbook integrity check failed (manifest): missing ${a.outputPath}` +
+          ` (sourcePath=${a.sourcePath}, title=${a.title})`,
+      );
     }
   }
 
@@ -1819,7 +1940,11 @@ function main() {
       // fragment/query split); only percent-decoding remains here.
       const ref = decodeHtmlPath(rawRef);
       const underOut = path.join(path.dirname(path.join(outDir, d.out)), ref);
-      if (!ref.startsWith('/') && !fs.existsSync(underOut) && !fs.existsSync(path.join(outDir, ref))) {
+      if (
+        !ref.startsWith('/') &&
+        !fs.existsSync(underOut) &&
+        !fs.existsSync(path.join(outDir, ref))
+      ) {
         fail(`handbook integrity check failed (${d.out}): missing ${ref}`);
       }
     }

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -642,13 +642,12 @@ describe('unit - handbook build guards', () => {
     assert.deepStrictEqual([...new Set(dupes)], []);
   });
 
-  it('suffixes colliding permalink anchor ids instead of emitting duplicates', function () {
+  it('fails the build when two sources claim the same permalink anchor', function () {
     const { fixture, out } = freshDirs();
     populateValidFixture(fixture, { shotSize: MIN_PNG_BYTES + 1 });
     const shots = path.join(fixture, 'docs/handbook/screenshots');
     // slugify() collapses every non-alphanumeric run to '-', so each pair below
-    // lands on one id. getElementById returns the first match, so without
-    // suffixing a copied permalink would point at the wrong screen.
+    // lands on one id — one pair of screenshots, one pair of groups.
     writePng(path.join(shots, 'group', 'fee ok.png'), MIN_PNG_BYTES + 1);
     writePng(path.join(shots, 'group', 'fee-ok.png'), MIN_PNG_BYTES + 1);
     writePng(path.join(shots, 'karte/dfx', 'x.png'), MIN_PNG_BYTES + 1);
@@ -658,27 +657,16 @@ describe('unit - handbook build guards', () => {
       NODE_PATH: markedNodePath,
       GIT_SHA: 't',
     });
-    assert.strictEqual(r.status, 0, r.stderr);
-    const index = fs.readFileSync(path.join(out, 'index.html'), 'utf8');
-    const ids = [...index.matchAll(/id="((?:shot|group)-[^"]+)"/g)].map(m => m[1]);
-    const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
-    assert.deepStrictEqual([...new Set(dupes)], []);
-    // First occurrence keeps the bare id so existing links stay valid.
-    assert.ok(ids.includes('shot-group-fee-ok'), 'bare id missing');
-    assert.ok(ids.includes('shot-group-fee-ok-1'), 'suffixed id missing');
-    assert.ok(ids.includes('group-karte-dfx'), 'bare group id missing');
-    assert.ok(ids.includes('group-karte-dfx-1'), 'suffixed group id missing');
-
-    // The suffixed entry must link to ITSELF. If the href were derived from the
-    // raw slug a second time instead of from the deduped id, the second card's
-    // permalink would point back at the first — the very bug the suffixing
-    // exists to prevent, and it would not show up as a duplicate id.
-    for (const [, id, head] of index.matchAll(/<div class="test" id="([^"]+)">([\s\S]*?)<div class="img">/g)) {
-      assertSelfLinked(id, head, 'screenshot');
-    }
-    for (const [, block] of index.matchAll(/<div class="group-head">([\s\S]*?)<\/div>/g)) {
-      assertSelfLinked(block.match(/<h3 id="([^"]+)"/)[1], block, 'group');
-    }
+    // Suffixing the loser would be worse than failing: "first" is first in sort
+    // order, not oldest, and ' ' sorts before '-'. The newcomer would take the
+    // incumbent's bare id, so a permalink copied yesterday would open a
+    // different screenshot today — silently, with a green build.
+    assert.notStrictEqual(r.status, 0, r.stderr);
+    assert.match(r.stderr, /anchor collision/i);
+    assert.match(r.stderr, /#shot-group-fee-ok\b/);
+    assert.match(r.stderr, /fee ok\.png/);
+    assert.match(r.stderr, /fee-ok\.png/);
+    assert.match(r.stderr, /#group-karte-dfx\b/);
   });
 
   it('ships the copy-link handler in handbook.js, not inline', function () {

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -654,7 +654,10 @@ describe('unit - handbook build guards', () => {
     assert.strictEqual(r.status, 0, r.stderr);
     const js = fs.readFileSync(path.join(out, 'handbook.js'), 'utf8');
     assert.match(js, /copy-link/);
-    assert.match(js, /clipboard/);
+    // Pin the calls, not the word: `clipboard` also occurs in a prose comment,
+    // so matching it would keep passing after the whole API use was removed.
+    assert.match(js, /navigator\.clipboard\.writeText\(/);
+    assert.match(js, /execCommand\('copy'\)/);
     // CSP is script-src 'self': an inline <script> carrying logic would break
     // the page silently. The HTML may only carry the external reference.
     const index = fs.readFileSync(path.join(out, 'index.html'), 'utf8');
@@ -663,5 +666,24 @@ describe('unit - handbook build guards', () => {
       inlineScripts.map(m => m[0]),
       [],
     );
+  });
+
+  it('keeps the copy button out of the heading element', function () {
+    const { fixture, out } = freshDirs();
+    populateValidFixture(fixture, { shotSize: MIN_PNG_BYTES + 1 });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const index = fs.readFileSync(path.join(out, 'index.html'), 'utf8');
+    // A button inside <h3> becomes part of the heading's text and its
+    // accessible name — a screen reader then announces "Einstellungen
+    // Direkt-Link kopieren". The button belongs next to the heading.
+    const headings = [...index.matchAll(/<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/g)];
+    assert.ok(headings.length > 0, 'fixture must produce headings');
+    const polluted = headings.filter(m => m[2].includes('copy-link')).map(m => m[0]);
+    assert.deepStrictEqual(polluted, []);
   });
 });

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -573,4 +573,67 @@ describe('unit - handbook build guards', () => {
     assert.match(index, /q%3Fx\.png/);
     assert.ok(fs.existsSync(path.join(out, 'assets/dfx/hash#tag.png')));
   });
+
+  it('gives every screenshot and every group a reachable permalink', function () {
+    const { fixture, out } = freshDirs();
+    populateValidFixture(fixture, { shotSize: MIN_PNG_BYTES + 1 });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const index = fs.readFileSync(path.join(out, 'index.html'), 'utf8');
+
+    // The anchor alone is not enough — without an href a reader can only get a
+    // screen's URL from the page source. Every shot/group id must therefore also
+    // be the target of a link and of a copy button.
+    const anchorIds = [...index.matchAll(/id="((?:shot|group)-[^"]+)"/g)].map(m => m[1]);
+    assert.ok(anchorIds.length > 0, 'fixture must produce shot/group anchors');
+    const linked = new Set([...index.matchAll(/href="#([^"]+)"/g)].map(m => m[1]));
+    const copyTargets = new Set([...index.matchAll(/data-target="([^"]+)"/g)].map(m => m[1]));
+    const unlinked = anchorIds.filter(id => !linked.has(id));
+    const uncopyable = anchorIds.filter(id => !copyTargets.has(id));
+    assert.deepStrictEqual(unlinked, [], 'anchors without a permalink');
+    assert.deepStrictEqual(uncopyable, [], 'anchors without a copy button');
+  });
+
+  it('keeps permalink anchor ids unique', function () {
+    const { fixture, out } = freshDirs();
+    populateValidFixture(fixture, { shotSize: MIN_PNG_BYTES + 1 });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const index = fs.readFileSync(path.join(out, 'index.html'), 'utf8');
+    const ids = [...index.matchAll(/id="([^"]+)"/g)].map(m => m[1]);
+    const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
+    // A duplicate anchor yields a link that jumps to the wrong screen — with
+    // permalinks made visible that lands on the reader.
+    assert.deepStrictEqual([...new Set(dupes)], []);
+  });
+
+  it('ships the copy-link handler in handbook.js, not inline', function () {
+    const { fixture, out } = freshDirs();
+    populateValidFixture(fixture, { shotSize: MIN_PNG_BYTES + 1 });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const js = fs.readFileSync(path.join(out, 'handbook.js'), 'utf8');
+    assert.match(js, /copy-link/);
+    assert.match(js, /clipboard/);
+    // CSP is script-src 'self': an inline <script> carrying logic would break
+    // the page silently. The HTML may only carry the external reference.
+    const index = fs.readFileSync(path.join(out, 'index.html'), 'utf8');
+    const inlineScripts = [...index.matchAll(/<script(?![^>]*\ssrc=)[^>]*>/g)];
+    assert.deepStrictEqual(
+      inlineScripts.map(m => m[0]),
+      [],
+    );
+  });
 });

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -615,6 +615,34 @@ describe('unit - handbook build guards', () => {
     assert.deepStrictEqual([...new Set(dupes)], []);
   });
 
+  it('suffixes colliding permalink anchor ids instead of emitting duplicates', function () {
+    const { fixture, out } = freshDirs();
+    populateValidFixture(fixture, { shotSize: MIN_PNG_BYTES + 1 });
+    const shots = path.join(fixture, 'docs/handbook/screenshots');
+    // slugify() collapses every non-alphanumeric run to '-', so each pair below
+    // lands on one id. getElementById returns the first match, so without
+    // suffixing a copied permalink would point at the wrong screen.
+    writePng(path.join(shots, 'group', 'fee ok.png'), MIN_PNG_BYTES + 1);
+    writePng(path.join(shots, 'group', 'fee-ok.png'), MIN_PNG_BYTES + 1);
+    writePng(path.join(shots, 'karte/dfx', 'x.png'), MIN_PNG_BYTES + 1);
+    writePng(path.join(shots, 'karte-dfx', 'x.png'), MIN_PNG_BYTES + 1);
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const index = fs.readFileSync(path.join(out, 'index.html'), 'utf8');
+    const ids = [...index.matchAll(/id="((?:shot|group)-[^"]+)"/g)].map(m => m[1]);
+    const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
+    assert.deepStrictEqual([...new Set(dupes)], []);
+    // First occurrence keeps the bare id so existing links stay valid.
+    assert.ok(ids.includes('shot-group-fee-ok'), 'bare id missing');
+    assert.ok(ids.includes('shot-group-fee-ok-1'), 'suffixed id missing');
+    assert.ok(ids.includes('group-karte-dfx'), 'bare group id missing');
+    assert.ok(ids.includes('group-karte-dfx-1'), 'suffixed group id missing');
+  });
+
   it('ships the copy-link handler in handbook.js, not inline', function () {
     const { fixture, out } = freshDirs();
     populateValidFixture(fixture, { shotSize: MIN_PNG_BYTES + 1 });

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -232,6 +232,19 @@ function ensureMarkedNodePath(repoRoot) {
   return path.join(prefix, 'node_modules');
 }
 
+/**
+ * A permalink and a copy button are only useful if they carry the id of the
+ * entry they sit in. `html` is the markup of that one entry.
+ */
+function assertSelfLinked(id, html, kind) {
+  const href = html.match(/<a class="name permalink" href="#([^"]+)"/);
+  const target = html.match(/data-target="([^"]+)"/);
+  assert.ok(href, `${kind} ${id}: no permalink`);
+  assert.ok(target, `${kind} ${id}: no copy button`);
+  assert.strictEqual(href[1], id, `${kind} ${id}: permalink points at ${href[1]}`);
+  assert.strictEqual(target[1], id, `${kind} ${id}: copy button targets ${target[1]}`);
+}
+
 describe('unit - handbook build guards', () => {
   // Fixture setup can install marked once into repo _handbook-deps/.
   jest.setTimeout(120000);
@@ -585,17 +598,31 @@ describe('unit - handbook build guards', () => {
     assert.strictEqual(r.status, 0, r.stderr);
     const index = fs.readFileSync(path.join(out, 'index.html'), 'utf8');
 
-    // The anchor alone is not enough — without an href a reader can only get a
-    // screen's URL from the page source. Every shot/group id must therefore also
-    // be the target of a link and of a copy button.
+    // Assert the pairing, not just membership: an entry's permalink and copy
+    // button must carry that entry's OWN id. Checking only that every id occurs
+    // somewhere as an href would still pass if the hrefs were rotated by one —
+    // every link would then point at the neighbouring screen.
     const anchorIds = [...index.matchAll(/id="((?:shot|group)-[^"]+)"/g)].map(m => m[1]);
     assert.ok(anchorIds.length > 0, 'fixture must produce shot/group anchors');
-    const linked = new Set([...index.matchAll(/href="#([^"]+)"/g)].map(m => m[1]));
-    const copyTargets = new Set([...index.matchAll(/data-target="([^"]+)"/g)].map(m => m[1]));
-    const unlinked = anchorIds.filter(id => !linked.has(id));
-    const uncopyable = anchorIds.filter(id => !copyTargets.has(id));
-    assert.deepStrictEqual(unlinked, [], 'anchors without a permalink');
-    assert.deepStrictEqual(uncopyable, [], 'anchors without a copy button');
+
+    const paired = [];
+    for (const [, id, head] of index.matchAll(/<div class="test" id="([^"]+)">([\s\S]*?)<div class="img">/g)) {
+      assertSelfLinked(id, head, 'screenshot');
+      paired.push(id);
+    }
+    for (const [, block] of index.matchAll(/<div class="group-head">([\s\S]*?)<\/div>/g)) {
+      const gid = block.match(/<h3 id="([^"]+)"/);
+      assert.ok(gid, `group head without an id: ${block.slice(0, 80)}`);
+      assertSelfLinked(gid[1], block, 'group');
+      paired.push(gid[1]);
+    }
+    // Every anchor must have been reached by one of the two loops above, so a
+    // new kind of entry cannot slip past the pairing check unnoticed.
+    assert.deepStrictEqual(
+      anchorIds.filter(id => !paired.includes(id)),
+      [],
+      'anchors not covered by the pairing check',
+    );
   });
 
   it('keeps permalink anchor ids unique', function () {
@@ -641,6 +668,17 @@ describe('unit - handbook build guards', () => {
     assert.ok(ids.includes('shot-group-fee-ok-1'), 'suffixed id missing');
     assert.ok(ids.includes('group-karte-dfx'), 'bare group id missing');
     assert.ok(ids.includes('group-karte-dfx-1'), 'suffixed group id missing');
+
+    // The suffixed entry must link to ITSELF. If the href were derived from the
+    // raw slug a second time instead of from the deduped id, the second card's
+    // permalink would point back at the first — the very bug the suffixing
+    // exists to prevent, and it would not show up as a duplicate id.
+    for (const [, id, head] of index.matchAll(/<div class="test" id="([^"]+)">([\s\S]*?)<div class="img">/g)) {
+      assertSelfLinked(id, head, 'screenshot');
+    }
+    for (const [, block] of index.matchAll(/<div class="group-head">([\s\S]*?)<\/div>/g)) {
+      assertSelfLinked(block.match(/<h3 id="([^"]+)"/)[1], block, 'group');
+    }
   });
 
   it('ships the copy-link handler in handbook.js, not inline', function () {


### PR DESCRIPTION
Direct links to individual screens were missing from the handbook. `RealUnitCH/app` does this correctly and is the model here.

## The gap

The generated page already had everything except the way in. Every screenshot and every group carried a stable anchor id, and `handbook.js` already opened the matching `<details>` and scrolled to it when a hash was present. But nothing on the page ever pointed at those anchors:

| | RealUnit handbook | Taro handbook (before) |
|---|---|---|
| anchor ids | 415 | 56 |
| internal `href="#…"` | 414 | **4** (top-level navigation only) |
| permalink on the entry | `<a class="name permalink">` | — |
| copy button | `🔗 Link` | — |

To point a colleague at one specific screen you had to open the page source and assemble the URL by hand.

## Change

Per screenshot and per group the head now carries a permalink anchor instead of a plain `<span>`, plus a copy button that writes the absolute URL to the clipboard (with an `execCommand` fallback), reports whether the copy actually happened and updates the hash either way, so the URL can still be taken from the address bar. Same interaction as the RealUnit handbook. The button sits **next to** the heading, never inside it — a button within a heading element joins its text and its accessible name; the wrapper carries the margins the heading gives up, so vertical spacing is unchanged.

The handler lives in `handbook.js`, not inline, so the CSP stays at `script-src 'self'`.

**Colliding anchor ids now fail the build.** Ids come from a lossy `slugify()`, so two sources can land on one id — the group dirs `05-karte/dfx` and `05-karte-dfx` collide, as do `fee ok.png` and `fee-ok.png` in one group. That weakness predates this branch and was harmless while the anchors were unreachable; handing the reader a copy button turns it into a link that silently points at the wrong screen, because `getElementById` always returns the first match.

The first attempt suffixed the loser (`…-1`). A review probe showed that this is worse than it looks: "first" is first in *sort order*, not oldest, and a space and `_` sort before `-`. Adding `07_sprache.png` next to an existing `07-sprache.png` handed the newcomer the incumbent’s bare id and pushed the incumbent to `-1`, so a permalink copied yesterday would open a different screenshot today — silently, exit 0, no warning. A collision is therefore a **build error** now, listing both sources, the same treatment `build.js` already gives two sources claiming one output path. Ids of today’s content and `manifest.json` are unchanged, and existing links keep working.

## Verified

Off-host, against the real repository content:

- internal `href="#…"`: **4 → 54** (42 screenshots + 8 groups + 4 navigation); 50 permalink anchors and 50 copy buttons
- 56 anchor ids, no duplicates; the real repository content still builds (all 42 screenshot names are strict kebab-case), while a fixture with four deliberately colliding names exits non-zero and names both source paths
- every entry's permalink and copy button carry that entry's own id — asserted per entry, not as set membership, and every anchor in the document is covered by that check
- `manifest.json` byte-identical to a `develop` build
- output byte-identical across `LANG=C/TZ=UTC` and `LANG=de_CH.UTF-8/TZ=Europe/Zurich`
- layout and headings measured against a `develop` build with headless Chrome: all eight group boundaries identical (16.95 px, 24.00 px for the first), card head height 39.59 px in both, heading text identical (`"Einstellungen"`, no button label), heading-to-button gap 8.00 px
- `node --check` on the generated `handbook.js`; no inline `<script>` in the HTML
- **24/24 unit tests** (19 existing + 5 new)
- `npm run lint`: 0 errors, unchanged at the develop baseline of 296 warnings

Each new test was mutation-probed — all five turn it red:

| mutation | result |
|---|---|
| permalink `href` removed | 1 failed |
| copy button removed | 1 failed |
| `navigator.clipboard` call removed (comment left in place) | 1 failed |
| script inlined instead of external | 2 failed |
| button moved back inside the heading | 1 failed |
| each card links to the *next* entry's id instead of its own | 2 failed |
| collision guard call removed | 1 failed |

## Diff scope

`scripts/handbook/build.js` is develop's file plus this branch's additions — 3 deletions, no reformatting of surrounding code. An earlier commit on this branch had reformatted roughly 200 lines of pre-existing code as a side effect of running prettier over the whole file; that was reverted, and the rebuilt output was compared byte-for-byte to confirm the revert changed nothing. (The commit message of `71ac8727` still quotes the insertion count as it stood at that commit; later commits added to it.)

## Not in this PR

Documents, assets and store-listing entries keep their current markup — the request was about screens. Extending the same pattern there is a small follow-up if wanted.



### Known limitation of one guard

The handler test pins `navigator.clipboard.writeText(` and `execCommand('copy')` as text in the generated `handbook.js`. Deleting either call turns it red, but wrapping a call in `if (false)` leaves the text in place and passes — a text-level guard cannot see dead code, and this suite does not execute a browser.



