### PR TITLE
FIX: refuse output paths inside the repository, harden the doc sanitizer

### DIFF
--- a/docs/handbook/README.md
+++ b/docs/handbook/README.md
@@ -73,10 +73,16 @@ Guards (Build bricht ab bei Verletzung):
   (verlustbehaftetes `slugify`) → Build-Fehler mit beiden Quellen (#217)
 - **Kapitel-Doppelzuordnung:** ein Screenshot in zwei Kapiteln → Build-Fehler
   mit beiden Kapitel-Ids
-- **Leeres Ausgabeverzeichnis:** jeder Lauf leert das Zielverzeichnis zuerst
-  (Wächter gegen Repo-Root, Discovery-Quellen wie `docs/handbook/screenshots`
-  und `img/dfx`, `.git`, `/` und Home), damit keine veralteten Dateien und
-  keine Quellbäume gelöscht werden
+- **Leeres Ausgabeverzeichnis:** jeder Lauf leert das Zielverzeichnis zuerst.
+  Das Ziel muss **ausserhalb** des Repository-Baums liegen — jede Datei im Repo
+  ist potenzielle Quelle (`listMarkdownFiles` scannt ab Repo-Root). Zusätzlich
+  greifen sprechende Wächter für Repo-Root/Vorfahren, bekannte Discovery-
+  Wurzeln, `.git`, `/` und Home — case-insensitiv verglichen (macOS/Windows),
+  damit ein Pfad in anderer Groß-/Kleinschreibung keinen dieser Wächter
+  umgeht. Falsche Argumente (z. B. ein Unterverzeichnis unter
+  `docs/handbook/screenshots/` oder `scripts/handbook`) werden abgelehnt,
+  bevor etwas gelöscht wird. CI und Docker schreiben nach `/out` bzw. unter
+  `/tmp/…`.
 
 Überschreitung der Mindestzahl ist **kein** Fehler — neue Dateien landen
 automatisch.
@@ -117,6 +123,28 @@ Links (kein JS).
 
 Oben: Kapitel aus `content`. Unten, standardmäßig zugeklappt: Store-Listing,
 App-Assets und Dokumentation (`ui.developerSection`).
+
+### HTML-Sanitizer (Markdown-Body)
+
+`marked` sanitisiert nicht. Vor dem Ausliefern entfernt der Build aktive
+Vektoren im gerenderten Body (CSP in nginx ist die zweite Schicht):
+
+- Blöcke: `script`, `iframe`, `object`, `embed`, `meta`, `form`, `base`, `link`
+- Event-Handler `on*` — auch mit `/` als Attribut-Trenner und unzitierten Werten
+  (z. B. `<img/onerror=…>`)
+- Gefährliche Schemes in `href`/`src` (`javascript:`, `vbscript:`, nicht-Bild-
+  `data:`) — zitiert und unzitiert
+- `script`/`iframe`/`object`/`form`-Blöcke: ein gemeinsamer Stack prüft die
+  Reihenfolge über alle vier Tag-Typen hinweg, nicht nur die Gesamtzahl je Typ
+  — **Build bricht ab**, sobald ein Schließer ohne passenden Öffner auftaucht,
+  ein Tag am Dokumentende offen bleibt, oder sich zwei verschiedene Tag-Typen
+  überlappen statt sauber zu verschachteln (kein stilles Löschen bis zum
+  nächsten Schließer irgendwo im Dokument)
+- Selbstschließende Tags (`<script/>`) erkennt der Guard und der Entferner
+  über **dieselbe** Prüfung, damit beide Seiten nie auseinanderlaufen
+
+Die nginx-CSP setzt zusätzlich `form-action 'none'` (und `base-uri 'none'`,
+`object-src 'none'`).
 
 ### Nicht auflösende Markdown-Links und Remote-Bilder
 
@@ -163,13 +191,13 @@ des Repos:
 
 ```bash
 npm install --prefix ./_handbook-deps --no-save --no-audit --no-fund marked@15.0.7
-NODE_PATH=./_handbook-deps/node_modules node scripts/handbook/build.js docs/handbook/build
+NODE_PATH=./_handbook-deps/node_modules node scripts/handbook/build.js /tmp/handbook-out
 ```
 
-Anschliessend `docs/handbook/build/index.html` im Browser öffnen.
+Anschliessend `/tmp/handbook-out/index.html` im Browser öffnen. Das
+Ausgabeverzeichnis muss **ausserhalb** des Repos liegen (Löschschutz).
 
-Das Scratch-Verzeichnis `_handbook-deps/` und `docs/handbook/build/` sind
-gitignored.
+Das Scratch-Verzeichnis `_handbook-deps/` ist gitignored.
 
 Optional: `GIT_SHA=…` (oder `HANDBOOK_GIT_SHA`) setzt den Stand im Seitenkopf.
 Optional: `HANDBOOK_REPO_ROOT=/pfad/zum/repo` überschreibt die Root-Erkennung

--- a/handbook.nginx.conf
+++ b/handbook.nginx.conf
@@ -21,7 +21,7 @@ server {
     # style-src 'unsafe-inline': build.js inlines CSS in <style> (no separate CSS file).
     # script-src 'self' only: TOC helper is handbook.js, not inline.
     # img-src data: unused today but harmless for future inline icons.
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'self'" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'self'" always;
     # Kept private/no-store for now; with no auth wall public caching would be
     # possible — product decision, not changed here.
     add_header Cache-Control "private, no-store" always;
@@ -45,7 +45,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'self'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'self'" always;
         add_header Cache-Control "no-store" always;
         default_type text/plain;
         return 200 "OK\n";
@@ -58,7 +58,7 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header X-Frame-Options "SAMEORIGIN" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'none'; frame-ancestors 'self'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; object-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'self'" always;
         add_header Cache-Control "private, no-store" always;
         try_files $uri =404;
     }

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -302,7 +302,19 @@ function resolveHomeDir() {
 
 /** True if `a` is the same path as `b` or a strict ancestor of `b`. */
 function isSameOrAncestor(a, b) {
-  return a === b || b.startsWith(a + path.sep);
+  if (a === b || b.startsWith(a + path.sep)) {
+    return true;
+  }
+  // macOS APFS and Windows NTFS default to case-insensitive, case-preserving
+  // paths. A spelling that differs only in letter case is the same directory.
+  // Linux is case-sensitive by default; folding there would treat distinct
+  // paths as identical and block legitimate output dirs.
+  if (process.platform !== 'linux') {
+    const aFolded = a.toLowerCase();
+    const bFolded = b.toLowerCase();
+    return aFolded === bFolded || bFolded.startsWith(aFolded + path.sep);
+  }
+  return false;
 }
 
 /**

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -2377,7 +2377,10 @@ function assertBalancedDangerBlocks(html) {
       }
     } else {
       const attrs = m[2] || '';
-      if (/\/\s*$/.test(attrs)) continue; // self-closing
+      // `/` is a self-close marker only as its own token (start of the
+      // attr string, or preceded by whitespace) — not when it is the
+      // last character of an attribute value such as a URL.
+      if (/(^|\s)\/\s*$/.test(attrs)) continue; // self-closing
       stack.push(String(m[1] || '').toLowerCase());
     }
   }
@@ -2405,11 +2408,14 @@ function stripDangerousHtml(html) {
   let out = String(html);
   assertBalancedDangerBlocks(out);
   // Remove script/iframe/object/embed blocks (content discarded).
-  out = out.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '');
+  // Closers tolerate whitespace before `>` — same grammar as the
+  // balance guard (`<\/tag\s*>`). A stricter `<\/tag>` leaves the
+  // whole block in the published page when the closer is `</tag >`.
+  out = out.replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, '');
   out = out.replace(/<script\b[^>]*\/>/gi, '');
-  out = out.replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe>/gi, '');
+  out = out.replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe\s*>/gi, '');
   out = out.replace(/<iframe\b[^>]*\/>/gi, '');
-  out = out.replace(/<object\b[^>]*>[\s\S]*?<\/object>/gi, '');
+  out = out.replace(/<object\b[^>]*>[\s\S]*?<\/object\s*>/gi, '');
   out = out.replace(/<object\b[^>]*\/>/gi, '');
   out = out.replace(/<embed\b[^>]*\/?>/gi, '');
   // Navigation / document chrome not needed in handbook body, and not covered
@@ -2417,7 +2423,7 @@ function stripDangerousHtml(html) {
   out = out.replace(/<meta\b[^>]*\/?>/gi, '');
   out = out.replace(/<base\b[^>]*\/?>/gi, '');
   out = out.replace(/<link\b[^>]*\/?>/gi, '');
-  out = out.replace(/<form\b[^>]*>[\s\S]*?<\/form>/gi, '');
+  out = out.replace(/<form\b[^>]*>[\s\S]*?<\/form\s*>/gi, '');
   out = out.replace(/<\/?form\b[^>]*\/?>/gi, '');
   // Drop inline event handlers (onerror=, onclick=, …). `/` is a valid
   // attribute separator in HTML, not only whitespace.

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -2345,26 +2345,38 @@ function resolvePosix(fromDir, relHref) {
 }
 
 /**
- * Fail closed when open/close counts for active blocks disagree. A non-greedy
- * `<tag>…</tag>` replace would otherwise delete everything up to the next
- * closer in the document (silent content loss, green build).
+ * Fail closed when open/close tags for active blocks are not nested in
+ * document order. A count-only check would accept a closer before its opener
+ * (or an extra closer between two well-formed pairs) as "balanced"; a
+ * non-greedy `<tag>…</tag>` replace would then leave a later opener intact
+ * (or delete everything up to the next closer — silent content loss, green
+ * build). Self-closing tags (`<tag …/>`) are not opens.
  */
 function assertBalancedDangerBlocks(html) {
-  for (const tag of ['script', 'iframe', 'object']) {
-    let opens = 0;
-    const openRe = new RegExp('<' + tag + '\\b([^>]*)>', 'gi');
+  for (const tag of ['script', 'iframe', 'object', 'form']) {
+    const tokenRe = new RegExp('<' + tag + '\\b([^>]*)>|</' + tag + '\\s*>', 'gi');
+    let depth = 0;
     let m;
-    while ((m = openRe.exec(html)) !== null) {
-      const attrs = m[1] || '';
-      if (/\/\s*$/.test(attrs)) continue; // self-closing
-      opens += 1;
+    while ((m = tokenRe.exec(html)) !== null) {
+      if (/^<\//.test(m[0])) {
+        depth -= 1;
+        if (depth < 0) {
+          fail(
+            `handbook sanitizer: unbalanced <${tag}> blocks ` +
+              '(close without a matching open). Refusing to strip across content ' +
+              'boundaries — fix the markdown source.',
+          );
+        }
+      } else {
+        const attrs = m[1] || '';
+        if (/\/\s*$/.test(attrs)) continue; // self-closing
+        depth += 1;
+      }
     }
-    const closeMatches = html.match(new RegExp('</' + tag + '\\s*>', 'gi'));
-    const closes = closeMatches ? closeMatches.length : 0;
-    if (opens !== closes) {
+    if (depth !== 0) {
       fail(
         `handbook sanitizer: unbalanced <${tag}> blocks ` +
-          `(${opens} open, ${closes} close). Refusing to strip across content ` +
+          `(${depth} open without a matching close). Refusing to strip across content ` +
           'boundaries — fix the markdown source.',
       );
     }

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -309,11 +309,13 @@ function isSameOrAncestor(a, b) {
  * Empty the output directory before writing so a rebuild never leaves stale
  * files from a previous run (deleted markdown still present as HTML, old
  * discovery trees, leftover foreign files). The CLI accepts an arbitrary
- * path, so rmdir must never touch the repo root, discovery source trees
- * (screenshots, store metadata, assets, docs), .git, the filesystem root or
- * the home directory — a wrong argument would be catastrophic.
+ * path, so rmdir must never touch the repo (any path inside the tree is a
+ * potential source — listMarkdownFiles walks from repoRoot), discovery source
+ * roots (clearer messages), .git, the filesystem root or the home directory.
+ * A wrong argument would otherwise be catastrophic.
  *
  * Missing outDir is fine (nothing to clear); writers recreate it.
+ * Legitimate targets live outside the repo (CI/Docker: /out, /tmp/…).
  */
 function prepareOutputDir(outDir, repoRoot) {
   const resolvedOut = path.resolve(outDir);
@@ -344,6 +346,8 @@ function prepareOutputDir(outDir, repoRoot) {
   }
   // Never empty a discovery source tree (or an ancestor that would wipe it).
   // E.g. outDir=docs/handbook/screenshots would delete the PNG set.
+  // Kept for a precise message; the generic in-repo guard below is the
+  // complete protection (covers subdirs and sources not listed here).
   for (const rel of DISCOVERY_SOURCE_RELS) {
     const protectedPath = path.resolve(resolvedRoot, rel);
     if (isSameOrAncestor(resolvedOut, protectedPath)) {
@@ -359,6 +363,16 @@ function prepareOutputDir(outDir, repoRoot) {
   if (segments.includes('.git')) {
     fail(
       `handbook: refusing to empty output path that contains a .git segment: ${resolvedOut}`,
+    );
+  }
+  // Any path inside the repository is a potential source (screenshots subdirs,
+  // scripts/handbook, content templates, metadata, …). Refuse generically so
+  // a second hand-maintained allowlist cannot drift from discovery.
+  if (isSameOrAncestor(resolvedRoot, resolvedOut)) {
+    fail(
+      'handbook: refusing to empty output path inside the repository: ' +
+        `${resolvedOut} (repo root: ${resolvedRoot}). ` +
+        'Write to a directory outside the repo (e.g. /tmp/handbook-out).',
     );
   }
 
@@ -2256,15 +2270,16 @@ const ABSOLUTE_URI_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 
 function collectRelativeRefs(html) {
   const refs = [];
-  // Only match real attribute names, after start-of-string, whitespace or '<'.
+  // Only match real attribute names, after start-of-string, whitespace, '/' or '<'.
   // A word boundary alone also matches after '-' and ':', so data-src,
   // xlink:href and ng-src would be checked as if a browser resolved them.
-  // Alternation per quote style so a double-quoted value may contain apostrophes
-  // (e.g. href="docs/Bank's%20Guide.md" from marked link parsing).
-  const re = /(?:^|[\s<])(?:src|href)=(?:"([^"]*)"|'([^']*)')/g;
+  // Alternation per quote style (and unquoted) so a double-quoted value may
+  // contain apostrophes (e.g. href="docs/Bank's%20Guide.md") and so unquoted
+  // values are not skipped by integrity checks.
+  const re = /(?:^|[\s/<])(?:src|href)=(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g;
   let m;
   while ((m = re.exec(html)) !== null) {
-    const raw = m[1] !== undefined ? m[1] : m[2];
+    const raw = m[1] !== undefined ? m[1] : m[2] !== undefined ? m[2] : m[3];
     if (
       ABSOLUTE_URI_SCHEME_RE.test(raw) ||
       raw.startsWith('//') ||
@@ -2309,13 +2324,45 @@ function resolvePosix(fromDir, relHref) {
 }
 
 /**
+ * Fail closed when open/close counts for active blocks disagree. A non-greedy
+ * `<tag>…</tag>` replace would otherwise delete everything up to the next
+ * closer in the document (silent content loss, green build).
+ */
+function assertBalancedDangerBlocks(html) {
+  for (const tag of ['script', 'iframe', 'object']) {
+    let opens = 0;
+    const openRe = new RegExp('<' + tag + '\\b([^>]*)>', 'gi');
+    let m;
+    while ((m = openRe.exec(html)) !== null) {
+      const attrs = m[1] || '';
+      if (/\/\s*$/.test(attrs)) continue; // self-closing
+      opens += 1;
+    }
+    const closeMatches = html.match(new RegExp('</' + tag + '\\s*>', 'gi'));
+    const closes = closeMatches ? closeMatches.length : 0;
+    if (opens !== closes) {
+      fail(
+        `handbook sanitizer: unbalanced <${tag}> blocks ` +
+          `(${opens} open, ${closes} close). Refusing to strip across content ` +
+          'boundaries — fix the markdown source.',
+      );
+    }
+  }
+}
+
+/**
  * Strip active HTML/script vectors from marked output before link rewriting.
  * marked does not sanitize by default; without this, any repo *.md is shipped
  * to handbook.taro.dfx.swiss with scripts and javascript: URLs intact.
  * CSP is a second layer; this cleans the HTML itself.
+ *
+ * Attribute separators: HTML allows `/` as well as whitespace between
+ * attributes (`<img/onerror=…>`). Values may be unquoted. Both must be
+ * covered — whitespace-only / quote-only patterns miss live vectors.
  */
 function stripDangerousHtml(html) {
   let out = String(html);
+  assertBalancedDangerBlocks(out);
   // Remove script/iframe/object/embed blocks (content discarded).
   out = out.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '');
   out = out.replace(/<script\b[^>]*\/>/gi, '');
@@ -2324,12 +2371,27 @@ function stripDangerousHtml(html) {
   out = out.replace(/<object\b[^>]*>[\s\S]*?<\/object>/gi, '');
   out = out.replace(/<object\b[^>]*\/>/gi, '');
   out = out.replace(/<embed\b[^>]*\/?>/gi, '');
-  // Drop inline event handlers (onerror=, onclick=, …).
-  out = out.replace(/\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+  // Navigation / document chrome not needed in handbook body, and not covered
+  // by CSP alone (meta refresh has no directive; form-action is separate).
+  out = out.replace(/<meta\b[^>]*\/?>/gi, '');
+  out = out.replace(/<base\b[^>]*\/?>/gi, '');
+  out = out.replace(/<link\b[^>]*\/?>/gi, '');
+  out = out.replace(/<form\b[^>]*>[\s\S]*?<\/form>/gi, '');
+  out = out.replace(/<\/?form\b[^>]*\/?>/gi, '');
+  // Drop inline event handlers (onerror=, onclick=, …). `/` is a valid
+  // attribute separator in HTML, not only whitespace.
+  out = out.replace(/[\s/]+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
   // Neutralize dangerous URL schemes in href/src (keep data:image/*).
+  // Quoted and unquoted attribute values.
   out = out.replace(
-    /\b(href|src)\s*=\s*(["'])([^"']*)\2/gi,
-    (full, attr, q, url) => {
+    /\b(href|src)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/gi,
+    (full, attr, dQuoted, sQuoted, unquoted) => {
+      const url =
+        dQuoted !== undefined
+          ? dQuoted
+          : sQuoted !== undefined
+            ? sQuoted
+            : unquoted;
       const trimmed = String(url).trim();
       const lower = trimmed.toLowerCase();
       if (
@@ -2337,7 +2399,9 @@ function stripDangerousHtml(html) {
         lower.startsWith('vbscript:') ||
         (lower.startsWith('data:') && !/^data:image\//i.test(trimmed))
       ) {
-        return attr + '=' + q + q;
+        if (dQuoted !== undefined) return attr + '=""';
+        if (sQuoted !== undefined) return attr + "=''";
+        return attr + '=""';
       }
       return full;
     },
@@ -2351,8 +2415,10 @@ function stripDangerousHtml(html) {
  * scripts, platform trees, etc. that are intentionally out of scope.
  *
  * Behaviour (documented in docs/handbook/README.md):
- * 0. Strip script/iframe/object/embed, on* handlers, and javascript:/vbscript:/
- *    non-image data: URLs (defence in depth with CSP).
+ * 0. Strip script/iframe/object/embed/meta/form/base/link, on* handlers
+ *    (whitespace or `/` separators, quoted or unquoted values), and
+ *    javascript:/vbscript:/non-image data: URLs; fail on unbalanced
+ *    script/iframe/object (defence in depth with CSP + form-action).
  * 1. Relative *.md links that resolve to a discovered handbook doc are
  *    rewritten to the corresponding HTML output path.
  * 2. Any other relative src/href that does not resolve under the output
@@ -2433,11 +2499,13 @@ function sanitizeDocHtml(html, docOutRel, discoveredMdToOut) {
     );
   }
 
-  // Rewrite or strip <a href="...">…</a>
+  // Rewrite or strip <a href=…>…</a> (whitespace or `/` after tag name;
+  // quoted or unquoted href).
   html = html.replace(
-    /<a\s+([^>]*?)href=(?:"([^"]*)"|'([^']*)')([^>]*)>([\s\S]*?)<\/a>/gi,
-    (full, pre, dHref, sHref, post, inner) => {
-      const href = dHref !== undefined ? dHref : sHref;
+    /<a[\s/]+([^>]*?)href=(?:"([^"]*)"|'([^']*)'|([^\s>]+))([^>]*)>([\s\S]*?)<\/a>/gi,
+    (full, pre, dHref, sHref, uHref, post, inner) => {
+      const href =
+        dHref !== undefined ? dHref : sHref !== undefined ? sHref : uHref;
       if (
         ABSOLUTE_URI_SCHEME_RE.test(href) ||
         href.startsWith('//') ||
@@ -2447,7 +2515,7 @@ function sanitizeDocHtml(html, docOutRel, discoveredMdToOut) {
       }
       const rewritten = tryRewriteMdLink(href);
       if (rewritten !== null) {
-        const q = dHref !== undefined ? '"' : "'";
+        const q = dHref !== undefined ? '"' : sHref !== undefined ? "'" : '"';
         return `<a ${pre}href=${q}${rewritten}${q}${post}>${inner}</a>`;
       }
       if (targetExists(href)) return full;
@@ -2459,16 +2527,20 @@ function sanitizeDocHtml(html, docOutRel, discoveredMdToOut) {
   // Replace remote absolute <img> (http/https/protocol-relative) with alt text —
   // CSP img-src is 'self' data: only. Keep data:image/* and fragment-only.
   // Strip unresolved relative <img> the same way (label kept, src removed).
+  // `/` is a valid attribute separator (not only whitespace); src/alt may be
+  // unquoted.
   html = html.replace(
-    /<img\s+([^>]*?)src=(?:"([^"]*)"|'([^']*)')([^>]*?)\/?>/gi,
-    (full, pre, dSrc, sSrc, post) => {
-      const src = dSrc !== undefined ? dSrc : sSrc;
+    /<img[\s/]+([^>]*?)src=(?:"([^"]*)"|'([^']*)'|([^\s>]+))([^>]*?)\/?>/gi,
+    (full, pre, dSrc, sSrc, uSrc, post) => {
+      const src = dSrc !== undefined ? dSrc : sSrc !== undefined ? sSrc : uSrc;
       const decodedSrc = decodeHtmlEntities(src).split('#')[0].split('?')[0];
-      const altMatch = full.match(/\balt=(?:"([^"]*)"|'([^']*)')/i);
+      const altMatch = full.match(/\balt=(?:"([^"]*)"|'([^']*)'|([^\s>]+))/i);
       const alt = altMatch
         ? altMatch[1] !== undefined
           ? altMatch[1]
-          : altMatch[2]
+          : altMatch[2] !== undefined
+            ? altMatch[2]
+            : altMatch[3]
         : '';
       const altOut = alt ? escapeHtml(decodeHtmlEntities(alt)) : '';
       // data:image is CSP-legal and may be intentional; leave alone.

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -317,6 +317,15 @@ function isSameOrAncestor(a, b) {
   return false;
 }
 
+/** True if `a` and `b` name the same path (case-folded on non-Linux). */
+function pathsEqual(a, b) {
+  if (a === b) return true;
+  if (process.platform !== 'linux') {
+    return a.toLowerCase() === b.toLowerCase();
+  }
+  return false;
+}
+
 /**
  * Empty the output directory before writing so a rebuild never leaves stale
  * files from a previous run (deleted markdown still present as HTML, old
@@ -344,7 +353,7 @@ function prepareOutputDir(outDir, repoRoot) {
       'handbook warning: home directory could not be determined; ' +
         'skipping home-directory output guard (other guards still apply).',
     );
-  } else if (resolvedOut === homeDir) {
+  } else if (pathsEqual(resolvedOut, homeDir)) {
     fail(
       `handbook: refusing to use home directory as output directory: ${resolvedOut}`,
     );
@@ -372,7 +381,7 @@ function prepareOutputDir(outDir, repoRoot) {
   }
   // Never touch anything under .git (object store, hooks, config).
   const segments = resolvedOut.split(path.sep);
-  if (segments.includes('.git')) {
+  if (segments.some(s => pathsEqual(s, '.git'))) {
     fail(
       `handbook: refusing to empty output path that contains a .git segment: ${resolvedOut}`,
     );

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -2345,6 +2345,16 @@ function resolvePosix(fromDir, relHref) {
 }
 
 /**
+ * A `/` counts as a self-close marker only as its own token — preceded by
+ * whitespace or the start of the attribute string — never when it is the
+ * last character of an attribute value such as a URL. Shared by the guard
+ * and the stripper so both sides agree on exactly the same tags.
+ */
+function isSelfClosingAttrs(attrs) {
+  return /(^|\s)\/\s*$/.test(attrs || '');
+}
+
+/**
  * Fail closed when open/close tags for active blocks are not nested in
  * document order, including across tag types. A per-tag depth counter
  * accepts an interleaved pair such as
@@ -2377,10 +2387,7 @@ function assertBalancedDangerBlocks(html) {
       }
     } else {
       const attrs = m[2] || '';
-      // `/` is a self-close marker only as its own token (start of the
-      // attr string, or preceded by whitespace) — not when it is the
-      // last character of an attribute value such as a URL.
-      if (/(^|\s)\/\s*$/.test(attrs)) continue; // self-closing
+      if (isSelfClosingAttrs(attrs)) continue;
       stack.push(String(m[1] || '').toLowerCase());
     }
   }
@@ -2411,12 +2418,15 @@ function stripDangerousHtml(html) {
   // Closers tolerate whitespace before `>` — same grammar as the
   // balance guard (`<\/tag\s*>`). A stricter `<\/tag>` leaves the
   // whole block in the published page when the closer is `</tag >`.
+  // Remaining opens are dropped only when isSelfClosingAttrs says so —
+  // the same check the guard used — not via a second `/>` regex that
+  // missed whitespace between `/` and `>`.
   out = out.replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, '');
-  out = out.replace(/<script\b[^>]*\/>/gi, '');
+  out = out.replace(/<script\b([^>]*)>/gi, (full, attrs) => (isSelfClosingAttrs(attrs) ? '' : full));
   out = out.replace(/<iframe\b[^>]*>[\s\S]*?<\/iframe\s*>/gi, '');
-  out = out.replace(/<iframe\b[^>]*\/>/gi, '');
+  out = out.replace(/<iframe\b([^>]*)>/gi, (full, attrs) => (isSelfClosingAttrs(attrs) ? '' : full));
   out = out.replace(/<object\b[^>]*>[\s\S]*?<\/object\s*>/gi, '');
-  out = out.replace(/<object\b[^>]*\/>/gi, '');
+  out = out.replace(/<object\b([^>]*)>/gi, (full, attrs) => (isSelfClosingAttrs(attrs) ? '' : full));
   out = out.replace(/<embed\b[^>]*\/?>/gi, '');
   // Navigation / document chrome not needed in handbook body, and not covered
   // by CSP alone (meta refresh has no directive; form-action is separate).

--- a/scripts/handbook/build.js
+++ b/scripts/handbook/build.js
@@ -2346,40 +2346,48 @@ function resolvePosix(fromDir, relHref) {
 
 /**
  * Fail closed when open/close tags for active blocks are not nested in
- * document order. A count-only check would accept a closer before its opener
- * (or an extra closer between two well-formed pairs) as "balanced"; a
- * non-greedy `<tag>…</tag>` replace would then leave a later opener intact
- * (or delete everything up to the next closer — silent content loss, green
- * build). Self-closing tags (`<tag …/>`) are not opens.
+ * document order, including across tag types. A per-tag depth counter
+ * accepts an interleaved pair such as
+ * `<iframe>…<script></iframe></script>` as "balanced"; sequential
+ * non-greedy `<tag>…</tag>` replaces then eat the outer closer and leave
+ * its opener intact. A single stack over all four tags rejects that
+ * mismatch. Self-closing tags (`<tag …/>`) are not opens.
  */
 function assertBalancedDangerBlocks(html) {
-  for (const tag of ['script', 'iframe', 'object', 'form']) {
-    const tokenRe = new RegExp('<' + tag + '\\b([^>]*)>|</' + tag + '\\s*>', 'gi');
-    let depth = 0;
-    let m;
-    while ((m = tokenRe.exec(html)) !== null) {
-      if (/^<\//.test(m[0])) {
-        depth -= 1;
-        if (depth < 0) {
-          fail(
-            `handbook sanitizer: unbalanced <${tag}> blocks ` +
-              '(close without a matching open). Refusing to strip across content ' +
-              'boundaries — fix the markdown source.',
-          );
-        }
-      } else {
-        const attrs = m[1] || '';
-        if (/\/\s*$/.test(attrs)) continue; // self-closing
-        depth += 1;
+  const tokenRe = /<(script|iframe|object|form)\b([^>]*)>|<\/(script|iframe|object|form)\s*>/gi;
+  const stack = [];
+  let m;
+  while ((m = tokenRe.exec(html)) !== null) {
+    if (/^<\//.test(m[0])) {
+      const closeName = String(m[3] || '').toLowerCase();
+      if (stack.length === 0) {
+        fail(
+          `handbook sanitizer: unbalanced <${closeName}> blocks ` +
+            '(close without a matching open). Refusing to strip across content ' +
+            'boundaries — fix the markdown source.',
+        );
       }
+      const openName = stack.pop();
+      if (openName !== closeName) {
+        fail(
+          `handbook sanitizer: unbalanced <${openName}> / <${closeName}> blocks ` +
+            `(expected closing </${openName}>, found </${closeName}>). ` +
+            'Refusing to strip across content boundaries — fix the markdown source.',
+        );
+      }
+    } else {
+      const attrs = m[2] || '';
+      if (/\/\s*$/.test(attrs)) continue; // self-closing
+      stack.push(String(m[1] || '').toLowerCase());
     }
-    if (depth !== 0) {
-      fail(
-        `handbook sanitizer: unbalanced <${tag}> blocks ` +
-          `(${depth} open without a matching close). Refusing to strip across content ` +
-          'boundaries — fix the markdown source.',
-      );
-    }
+  }
+  if (stack.length !== 0) {
+    const names = [...new Set(stack)].map(tag => `<${tag}>`).join(', ');
+    fail(
+      `handbook sanitizer: unbalanced ${names} blocks ` +
+        `(${stack.length} open without a matching close). Refusing to strip across content ` +
+        'boundaries — fix the markdown source.',
+    );
   }
 }
 

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -913,6 +913,70 @@ describe('unit - handbook build guards', () => {
     assert.match(r.stderr, /unbalanced <form>/i);
   });
 
+  // Per-tag depth is balanced (one iframe pair, one script pair) but the
+  // closer of the outer tag arrives while the inner tag is still open.
+  // Sequential non-greedy strip then eats `</iframe>` with the script
+  // block and leaves the iframe opener in the published page.
+  it('fails the build on count-balanced but cross-tag-interleaved iframe/script blocks', function () {
+    const { fixture, out } = freshDirs();
+    const danger = '# Title\n\n' + '<iframe src="http://evil.example">CLICKME<script></iframe></script>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.notStrictEqual(r.status, 0, 'cross-tag interleaved iframe/script must fail the build');
+    assert.match(r.stderr, /iframe/i);
+    assert.match(r.stderr, /script/i);
+    assert.match(r.stderr, /expected closing/i);
+  });
+
+  // Same interleaving class, different pair: object closer while form is open.
+  it('fails the build on count-balanced but cross-tag-interleaved object/form blocks', function () {
+    const { fixture, out } = freshDirs();
+    const danger = '# Title\n\n' + '<object data="http://evil.example/o"><form action="http://evil.example/f"></object></form>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.notStrictEqual(r.status, 0, 'cross-tag interleaved object/form must fail the build');
+    assert.match(r.stderr, /object/i);
+    assert.match(r.stderr, /form/i);
+    assert.match(r.stderr, /expected closing/i);
+  });
+
+  // Counterdirection: different tag types, correctly nested, must not trip
+  // the stack guard. Sequential strip then removes both pairs.
+  it('accepts correctly nested iframe/script blocks of different tag types', function () {
+    const { fixture, out } = freshDirs();
+    const nested =
+      '# Title\n\n' + '<p>KEEP-NESTED</p>\n\n' + '<div><iframe src="https://example.com/ok"><script>x</script></iframe></div>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': nested },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const html = fs.readFileSync(path.join(out, 'docs/DOC-0.html'), 'utf8');
+    const body = html.replace(/^[\s\S]*?<body[^>]*>/i, '').replace(/<\/body>[\s\S]*$/i, '');
+    assert.ok(body.includes('KEEP-NESTED'));
+    assert.ok(!/<iframe\b/i.test(body), 'nested iframe stripped');
+    assert.ok(!/<script\b/i.test(body), 'nested script stripped');
+  });
+
   it('leaves a harmless document free of sanitizer damage', function () {
     const { fixture, out } = freshDirs();
     // Counterdirection: no attack vectors — body content must round-trip.

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -425,6 +425,55 @@ describe('unit - handbook build guards', () => {
     assert.ok(fs.existsSync(canary), 'screenshot source must not be deleted');
   });
 
+  // B1: guard must refuse a path *under* a source, not only the source root.
+  it('refuses output dir nested under a discovery source without deleting it', function () {
+    const { fixture } = freshDirs();
+    populateValidFixture(fixture);
+    const nested = path.join(fixture, 'docs/handbook/screenshots/group');
+    const before = fs.readdirSync(nested).filter(n => n.endsWith('.png'));
+    assert.ok(before.length >= MIN_SCREENSHOTS, `fixture nested shots ${before.length}`);
+
+    const r = runBuild(nested, { HANDBOOK_REPO_ROOT: fixture });
+    assert.notStrictEqual(r.status, 0, r.stderr);
+    // Nested path is inside the repo (generic guard) — must not wipe PNGs.
+    assert.match(r.stderr, /inside the repository|discovery source/i);
+    const after = fs.readdirSync(nested).filter(n => n.endsWith('.png'));
+    assert.strictEqual(after.length, before.length, 'nested screenshot dir must not be emptied');
+  });
+
+  // B2: sources not listed in DISCOVERY_SOURCE_RELS (e.g. scripts/handbook).
+  it('refuses output dir equal to scripts/handbook without deleting it', function () {
+    const { fixture } = freshDirs();
+    populateValidFixture(fixture);
+    const scriptsHb = path.join(fixture, 'scripts/handbook');
+    fs.mkdirSync(scriptsHb, { recursive: true });
+    writeText(path.join(scriptsHb, 'CANARY.txt'), 'keep-build-sources\n');
+    writeText(path.join(scriptsHb, 'pod/tokens.css'), ':root{}\n');
+    const before = fs.readdirSync(scriptsHb, { recursive: true });
+
+    const r = runBuild(scriptsHb, { HANDBOOK_REPO_ROOT: fixture });
+    assert.notStrictEqual(r.status, 0, r.stderr);
+    assert.match(r.stderr, /inside the repository/i);
+    assert.match(r.stderr, /outside the repo/i);
+    assert.ok(fs.existsSync(path.join(scriptsHb, 'CANARY.txt')), 'scripts/handbook not emptied');
+    assert.strictEqual(fs.readFileSync(path.join(scriptsHb, 'CANARY.txt'), 'utf8'), 'keep-build-sources\n');
+    const after = fs.readdirSync(scriptsHb, { recursive: true });
+    assert.deepStrictEqual(after, before);
+  });
+
+  it('refuses any other path inside the repository without deleting it', function () {
+    const { fixture } = freshDirs();
+    populateValidFixture(fixture);
+    const inside = path.join(fixture, 'some/nested/out');
+    fs.mkdirSync(inside, { recursive: true });
+    writeText(path.join(inside, 'CANARY'), 'stay\n');
+
+    const r = runBuild(inside, { HANDBOOK_REPO_ROOT: fixture });
+    assert.notStrictEqual(r.status, 0, r.stderr);
+    assert.match(r.stderr, /inside the repository/i);
+    assert.ok(fs.existsSync(path.join(inside, 'CANARY')));
+  });
+
   it('rejects screenshot PNG just below MIN_PNG_BYTES', function () {
     const { fixture, out } = freshDirs();
     // Pin the threshold: size = MIN_PNG_BYTES - 1 (not a far-below value that
@@ -681,6 +730,115 @@ describe('unit - handbook build guards', () => {
     assert.match(scriptTags[0], /\bsrc\s*=/i, 'the only script must have src=');
     assert.match(scriptTags[0], /handbook\.js/i, 'script src must be handbook.js');
     assert.ok(!/<script\b(?![^>]*\bsrc\s*=)[^>]*>/i.test(html), 'no inline <script>');
+  });
+
+  // B3: slash as attribute separator + unquoted dangerous schemes.
+  it('strips slash-separated on* handlers and unquoted javascript schemes', function () {
+    const { fixture, out } = freshDirs();
+    const evilScheme = ['java', 'script', ':'].join('');
+    // These two vectors survived the old \\s+ / quoted-only sanitizer.
+    // Wrapped in block HTML so marked passes them through (bare
+    // `<img/onerror=…>` is escaped by marked, not shipped as a tag).
+    // Absolute src so integrity does not fail after onerror is stripped.
+    const danger =
+      '# Title\n\n' +
+      '<div><img/onerror=alert(1) src=https://example.com/x.png></div>\n\n' +
+      '<div><a href=' +
+      evilScheme +
+      'alert(2)>unquoted</a></div>\n\n' +
+      // Harmless markup must survive (counterdirection for over-eager filters).
+      '<p class="keep-me">SAFE-PARAGRAPH</p>\n' +
+      '<img src="https://example.com/ok.png" alt="ok">\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const html = fs.readFileSync(path.join(out, 'docs/DOC-0.html'), 'utf8');
+    assert.ok(!/onerror/i.test(html), 'slash-separated onerror must be stripped');
+    assert.ok(!new RegExp('java' + 'script:', 'i').test(html), 'unquoted javascript: neutralized');
+    assert.ok(html.includes('SAFE-PARAGRAPH'), 'harmless paragraph kept');
+    assert.ok(html.includes('class="keep-me"'), 'harmless class attr kept');
+    assert.match(html, /src="https:\/\/example\.com\/ok\.png"/);
+  });
+
+  // B4: meta refresh / form / base / link — not covered by script strip or CSP alone.
+  it('strips meta refresh, form, base and link tags from rendered docs', function () {
+    const { fixture, out } = freshDirs();
+    const danger =
+      '# Title\n\n' +
+      '<meta http-equiv="refresh" content="0;url=https://evil.example/">\n\n' +
+      '<form action="https://evil.example/collect"><input name="x"></form>\n\n' +
+      '<base href="https://evil.example/">\n\n' +
+      '<link rel="stylesheet" href="https://evil.example/x.css">\n\n' +
+      '<p>KEEP-AFTER-STRIP</p>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const html = fs.readFileSync(path.join(out, 'docs/DOC-0.html'), 'utf8');
+    // Body must not retain the attack tags (page chrome may still have <meta charset>).
+    const body = html.replace(/^[\s\S]*?<body[^>]*>/i, '').replace(/<\/body>[\s\S]*$/i, '');
+    assert.ok(!/<meta\b/i.test(body), 'meta stripped from body');
+    assert.ok(!/<form\b/i.test(body), 'form stripped');
+    assert.ok(!/<base\b/i.test(body), 'base stripped');
+    assert.ok(!/<link\b/i.test(body), 'link stripped');
+    assert.ok(!/evil\.example/i.test(body), 'evil targets not left in body');
+    assert.ok(body.includes('KEEP-AFTER-STRIP'));
+  });
+
+  // B5: unbalanced <script> must fail loudly, not eat following content.
+  it('fails the build on unbalanced script blocks instead of silent content loss', function () {
+    const { fixture, out } = freshDirs();
+    const danger =
+      '# Title\n\n' + '<div><script>alert(7)</div>\n\n' + 'TAIL-CONTENT-SHOULD-SURVIVE\n\n' + '<div><script>x</script></div>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.notStrictEqual(r.status, 0, 'unbalanced script must fail the build');
+    assert.match(r.stderr, /unbalanced <script>/i);
+    // Output page must not be written half-sanitized (or, if written, not the only success path).
+    assert.ok(r.status !== 0, 'build must not exit 0 after silent content loss');
+  });
+
+  it('leaves a harmless document free of sanitizer damage', function () {
+    const { fixture, out } = freshDirs();
+    // Counterdirection: no attack vectors — body content must round-trip.
+    const clean = '# Clean Title\n\n' + 'Paragraph with **bold** and a [peer](./DOC-1.md) link.\n\n' + '- item one\n- item two\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': clean },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const html = fs.readFileSync(path.join(out, 'docs/DOC-0.html'), 'utf8');
+    assert.match(html, /id="clean-title"/);
+    assert.match(html, /<strong>bold<\/strong>/);
+    assert.match(html, /href="DOC-1\.html"/);
+    assert.match(html, /item one/);
+    assert.match(html, /item two/);
+    assert.ok(!/stripped unresolved/i.test(r.stderr));
   });
 
   it('escapes HTML special characters in store field content on index', function () {

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -384,6 +384,24 @@ describe('unit - handbook build guards', () => {
     assert.strictEqual(fs.readFileSync(canary, 'utf8'), 'keep-me\n');
   });
 
+  // Linux default filesystems are case-sensitive: fixture.toUpperCase() names a
+  // different directory there, so this case-folding hole cannot be observed.
+  (process.platform === 'linux' ? it.skip : it)(
+    'refuses output dir that differs from the repo root only in letter case without deleting it',
+    function () {
+      const { fixture } = freshDirs();
+      populateValidFixture(fixture);
+      const canary = path.join(fixture, 'CANARY.md');
+      writeText(canary, 'keep-me\n');
+      assert.notStrictEqual(fixture.toUpperCase(), fixture);
+
+      const r = runBuild(fixture.toUpperCase(), { HANDBOOK_REPO_ROOT: fixture });
+      assert.notStrictEqual(r.status, 0, r.stderr);
+      assert.ok(fs.existsSync(canary), 'repo root must not be emptied via case-folded path');
+      assert.strictEqual(fs.readFileSync(canary, 'utf8'), 'keep-me\n');
+    },
+  );
+
   it('refuses output path containing a .git segment', function () {
     const { fixture } = freshDirs();
     populateValidFixture(fixture);

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -1008,6 +1008,7 @@ describe('unit - handbook build guards', () => {
       '<div><script/></div>\n\n' +
       '<div><script /></div>\n\n' +
       '<div><script  /></div>\n\n' +
+      '<div><script/ ></div>\n\n' +
       '<img src="https://example.com/x.png" />\n';
     populateValidFixture(fixture, {
       shotSize: MIN_PNG_BYTES + 1,
@@ -1024,6 +1025,53 @@ describe('unit - handbook build guards', () => {
     assert.ok(body.includes('KEEP-SELFCLOSE'));
     assert.ok(!/<script\b/i.test(body), 'genuine self-closing script tags must be stripped');
     assert.match(body, /<img src="https:\/\/example\.com\/x\.png" \/>/);
+  });
+
+  // Guard already treats ` / ` before `>` as a self-close token
+  // (`/(^|\s)\/\s*$/`). The strip regex used to require `/` immediately
+  // before `>`, so `<script src=http://evil.example / >` passed the
+  // guard and shipped as a live tag. Both sides now share
+  // isSelfClosingAttrs; the sanitizer removes it and the build succeeds.
+  it('strips a self-closing script whose slash is surrounded by spaces before >', function () {
+    const { fixture, out } = freshDirs();
+    const danger = '# Title\n\n' + '<p>KEEP-SPACED-SLASH</p>\n\n' + '<script src=http://evil.example / >CLICKME</div>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const html = fs.readFileSync(path.join(out, 'docs/DOC-0.html'), 'utf8');
+    const body = html.replace(/^[\s\S]*?<body[^>]*>/i, '').replace(/<\/body>[\s\S]*$/i, '');
+    assert.ok(body.includes('KEEP-SPACED-SLASH'));
+    assert.ok(!/<script\b/i.test(body), 'script with space-slash-space before > must be stripped');
+    assert.ok(!/evil\.example/i.test(body), 'self-closing script src must not remain');
+  });
+
+  // Same construction on iframe: slash as its own token, whitespace on
+  // both sides, no matching closer. Must be stripped, not shipped.
+  it('strips a self-closing iframe whose slash is surrounded by spaces before >', function () {
+    const { fixture, out } = freshDirs();
+    const danger = '# Title\n\n' + '<p>KEEP-IFRAME-SPACED-SLASH</p>\n\n' + '<iframe src=http://evil.example / >CLICKME</div>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const html = fs.readFileSync(path.join(out, 'docs/DOC-0.html'), 'utf8');
+    const body = html.replace(/^[\s\S]*?<body[^>]*>/i, '').replace(/<\/body>[\s\S]*$/i, '');
+    assert.ok(body.includes('KEEP-IFRAME-SPACED-SLASH'));
+    assert.ok(!/<iframe\b/i.test(body), 'iframe with space-slash-space before > must be stripped');
+    assert.ok(!/evil\.example/i.test(body), 'self-closing iframe src must not remain');
   });
 
   // Counterdirection: different tag types, correctly nested, must not trip

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -412,6 +412,18 @@ describe('unit - handbook build guards', () => {
     assert.match(r.stderr, /\.git/);
   });
 
+  // Linux default filesystems are case-sensitive: .GIT is a different segment
+  // there, so this case-folding hole cannot be observed.
+  (process.platform === 'linux' ? it.skip : it)('refuses output path containing a .GIT segment', function () {
+    const { fixture } = freshDirs();
+    populateValidFixture(fixture);
+    const out = path.join(tmpRoot, 'nested', '.GIT', 'handbook-out');
+
+    const r = runBuild(out, { HANDBOOK_REPO_ROOT: fixture });
+    assert.notStrictEqual(r.status, 0, r.stderr);
+    assert.match(r.stderr, /\.git/);
+  });
+
   it('refuses output dir equal to the home directory', function () {
     const { fixture } = freshDirs();
     populateValidFixture(fixture);
@@ -428,6 +440,34 @@ describe('unit - handbook build guards', () => {
     assert.match(r.stderr, /home directory/i);
     assert.ok(fs.existsSync(path.join(fakeHome, 'CANARY')), 'fake home not emptied');
   });
+
+  // Linux default filesystems are case-sensitive: fakeHome.toUpperCase() names a
+  // different directory there, so this case-folding hole cannot be observed.
+  (process.platform === 'linux' ? it.skip : it)(
+    'refuses output dir that differs from the home directory only in letter case without deleting it',
+    function () {
+      const { fixture } = freshDirs();
+      populateValidFixture(fixture);
+      // Synthetic HOME under tmpRoot only — never use the real user home as
+      // outDir (a failed guard would rmSync it). resolveHomeDir() prefers env.
+      const fakeHome = fs.mkdtempSync(path.join(tmpRoot, 'fake-home-'));
+      const canary = path.join(fakeHome, 'CANARY');
+      writeText(canary, 'keep\n');
+      assert.notStrictEqual(fakeHome.toUpperCase(), fakeHome);
+      assert.ok(fs.existsSync(canary), 'canary must exist before the build');
+
+      const r = runBuild(fakeHome.toUpperCase(), {
+        HANDBOOK_REPO_ROOT: fixture,
+        HOME: fakeHome,
+      });
+      // Canary first: without the case-fold the home is rmSync'd before later
+      // build failures (e.g. missing marked), so the message check alone
+      // would hide the deletion.
+      assert.ok(fs.existsSync(canary), 'fake home not emptied via case-folded path');
+      assert.notStrictEqual(r.status, 0, r.stderr);
+      assert.match(r.stderr, /home directory/i);
+    },
+  );
 
   it('refuses output dir equal to a discovery source root', function () {
     const { fixture } = freshDirs();

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -954,6 +954,78 @@ describe('unit - handbook build guards', () => {
     assert.match(r.stderr, /expected closing/i);
   });
 
+  // Guard already accepts `</script >` (whitespace before `>`). The strip
+  // regexes used to require the exact closer `</script>`, so a balanced
+  // document kept the live <script> in the published page. After aligning
+  // strip with the guard, the block is balanced and removable.
+  it('strips a script block whose closer has whitespace before >', function () {
+    const { fixture, out } = freshDirs();
+    const danger = '# Title\n\n' + '<div><script>alert(1)</script ></div>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const html = fs.readFileSync(path.join(out, 'docs/DOC-0.html'), 'utf8');
+    const body = html.replace(/^[\s\S]*?<body[^>]*>/i, '').replace(/<\/body>[\s\S]*$/i, '');
+    assert.ok(!/<script\b/i.test(body), 'script with whitespace-before-> closer must be stripped');
+    assert.ok(!/alert\(1\)/i.test(body), 'script body must not remain');
+  });
+
+  // Guard used to treat an unquoted src ending in `/` as a self-close
+  // marker (`/\/\s*$/` on the raw attr string). The opener was never
+  // pushed, strip matched neither the block nor the `/>` form, and the
+  // live <script> shipped.
+  it('fails the build on an unclosed script whose src URL ends with a slash', function () {
+    const { fixture, out } = freshDirs();
+    const danger = '# Title\n\n' + '<script src=http://evil.example/ >CLICKME</div>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.notStrictEqual(r.status, 0, 'unclosed script with URL-ending-slash must fail the build');
+    assert.match(r.stderr, /unbalanced <script>/i);
+  });
+
+  // Genuine self-closing spellings must still be skipped by the stack
+  // guard (not treated as opens) and removed. A harmless <img … /> must
+  // survive the sanitizer.
+  it('strips genuine self-closing script tags and keeps a self-closing img', function () {
+    const { fixture, out } = freshDirs();
+    const danger =
+      '# Title\n\n' +
+      '<p>KEEP-SELFCLOSE</p>\n\n' +
+      '<div><script/></div>\n\n' +
+      '<div><script /></div>\n\n' +
+      '<div><script  /></div>\n\n' +
+      '<img src="https://example.com/x.png" />\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.strictEqual(r.status, 0, r.stderr);
+    const html = fs.readFileSync(path.join(out, 'docs/DOC-0.html'), 'utf8');
+    const body = html.replace(/^[\s\S]*?<body[^>]*>/i, '').replace(/<\/body>[\s\S]*$/i, '');
+    assert.ok(body.includes('KEEP-SELFCLOSE'));
+    assert.ok(!/<script\b/i.test(body), 'genuine self-closing script tags must be stripped');
+    assert.match(body, /<img src="https:\/\/example\.com\/x\.png" \/>/);
+  });
+
   // Counterdirection: different tag types, correctly nested, must not trip
   // the stack guard. Sequential strip then removes both pairs.
   it('accepts correctly nested iframe/script blocks of different tag types', function () {

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -822,7 +822,10 @@ describe('unit - handbook build guards', () => {
     assert.ok(!new RegExp('java' + 'script:', 'i').test(html), 'unquoted javascript: neutralized');
     assert.ok(html.includes('SAFE-PARAGRAPH'), 'harmless paragraph kept');
     assert.ok(html.includes('class="keep-me"'), 'harmless class attr kept');
-    assert.match(html, /src="https:\/\/example\.com\/ok\.png"/);
+    // Remote images are replaced with their alt text (CSP img-src is 'self'
+    // data: only) — the harmless counterdirection is that the alt text
+    // survives, not the remote src itself.
+    assert.ok(html.includes('ok'), 'harmless remote image alt text kept');
   });
 
   // B4: meta refresh / form / base / link — not covered by script strip or CSP alone.
@@ -998,8 +1001,9 @@ describe('unit - handbook build guards', () => {
   });
 
   // Genuine self-closing spellings must still be skipped by the stack
-  // guard (not treated as opens) and removed. A harmless <img … /> must
-  // survive the sanitizer.
+  // guard (not treated as opens) and removed. A harmless, CSP-legal
+  // data:image <img … /> must survive the sanitizer untouched — proof that
+  // the script guard's self-closing check doesn't leak into unrelated tags.
   it('strips genuine self-closing script tags and keeps a self-closing img', function () {
     const { fixture, out } = freshDirs();
     const danger =
@@ -1009,7 +1013,7 @@ describe('unit - handbook build guards', () => {
       '<div><script /></div>\n\n' +
       '<div><script  /></div>\n\n' +
       '<div><script/ ></div>\n\n' +
-      '<img src="https://example.com/x.png" />\n';
+      '<img src="data:image/png;base64,AAAA" />\n';
     populateValidFixture(fixture, {
       shotSize: MIN_PNG_BYTES + 1,
       docContents: { 'DOC-0.md': danger },
@@ -1024,7 +1028,7 @@ describe('unit - handbook build guards', () => {
     const body = html.replace(/^[\s\S]*?<body[^>]*>/i, '').replace(/<\/body>[\s\S]*$/i, '');
     assert.ok(body.includes('KEEP-SELFCLOSE'));
     assert.ok(!/<script\b/i.test(body), 'genuine self-closing script tags must be stripped');
-    assert.match(body, /<img src="https:\/\/example\.com\/x\.png" \/>/);
+    assert.match(body, /<img src="data:image\/png;base64,AAAA" \/>/);
   });
 
   // Guard already treats ` / ` before `>` as a self-close token

--- a/tests/unit/handbook-build.test.js
+++ b/tests/unit/handbook-build.test.js
@@ -876,6 +876,43 @@ describe('unit - handbook build guards', () => {
     assert.ok(r.status !== 0, 'build must not exit 0 after silent content loss');
   });
 
+  // Count-balanced but order-unbalanced: two opens and two closes, extra closer
+  // between two well-formed pairs. A count-only guard accepts this; the
+  // non-greedy strip then leaves the second <script> intact.
+  it('fails the build on count-balanced but order-unbalanced script blocks', function () {
+    const { fixture, out } = freshDirs();
+    const danger = '# Title\n\n' + '<div><script>x</script>y</script>z<script>alert(1)</div>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.notStrictEqual(r.status, 0, 'order-unbalanced script must fail the build');
+    assert.match(r.stderr, /unbalanced <script>/i);
+  });
+
+  // <form> is stripped with the same non-greedy pair regex as script, but was
+  // not in the balance-check tag list. An unclosed form must fail closed.
+  it('fails the build on unbalanced form blocks instead of silent content loss', function () {
+    const { fixture, out } = freshDirs();
+    const danger = '# Title\n\n' + '<div><form action="https://evil.example/collect">UNCLOSED-FORM</div>\n';
+    populateValidFixture(fixture, {
+      shotSize: MIN_PNG_BYTES + 1,
+      docContents: { 'DOC-0.md': danger },
+    });
+    const r = runBuild(out, {
+      HANDBOOK_REPO_ROOT: fixture,
+      NODE_PATH: markedNodePath,
+      GIT_SHA: 't',
+    });
+    assert.notStrictEqual(r.status, 0, 'unbalanced form must fail the build');
+    assert.match(r.stderr, /unbalanced <form>/i);
+  });
+
   it('leaves a harmless document free of sanitizer damage', function () {
     const { fixture, out } = freshDirs();
     // Counterdirection: no attack vectors — body content must round-trip.


### PR DESCRIPTION
Two defects in the handbook build, found by review passes over #218 and split out so they can land
on their own. Both are pre-existing on `develop`; neither needs #218 and #218 will rebase onto this.

**Not symptom-driven:** no incident and no report from production. Both defects were found by
reading the build during a review, and each was then reproduced with a fixture run before anything
was changed. Nothing is known to have been lost or exploited.
**Scale:** the output directory guard runs on every invocation of the build script — one wrong
argument is enough, and the damage is immediate and local. The sanitizer runs over **every** `*.md`
in the repository, because all of them are rendered and served at handbook.taro.dfx.swiss.
**Smaller fix considered:** for the deletion guard, one line — run the ancestor check in both
directions. That covers the sub-directory case but not the second one (sources missing from the
list entirely), and nothing of the sanitizer. Both belong to the same function and the same
protective intent, so they go together rather than opening this PR three times.

## The output directory guard only held at the root of a source

The output directory is emptied before writing. The guard rejected a path that **is** a discovery
source or sits **above** one — but a path **below** one passed every check and was deleted.

Reproduced on a fixture: 40 PNGs in `docs/handbook/screenshots/group`, then pointing the build at
that directory. It was emptied, and the build then failed with `found 0 screenshots`. In this
repository that applies to each of the eight screenshot directories.

The protection list was also a second hand-maintained list beside the one that says what is read,
and the two had already drifted: nothing protected `scripts/handbook/`, so pointing the build there
emptied 20 files.

Both are answered by **one** rule rather than a third list: an output directory anywhere inside the
repository is refused, because the build reads the whole tree (`listMarkdownFiles` walks from the
repository root) and everything in it is a potential source. The existing specific checks — the
repository root itself, ancestors, `.git`, `/`, the home directory — stay, because they tell the
caller more precisely what went wrong. Both the Dockerfile and the CI write outside the repository,
so no existing invocation is affected.

## The sanitizer recognised only whitespace separators and quoted values

`stripDangerousHtml` removes scripts and dangerous URL schemes from rendered markdown. Its patterns
required whitespace before an attribute and quotes around its value, so an image whose event
handler is separated by `/`, and a link whose `javascript:` target carries no quotes, both reached
the rendered page. They were stopped by the CSP alone — the comment above the function promises
defence in depth, and there was one layer.

Separators and unquoted values are handled now. `meta`, `form`, `base` and `link` are stripped as
well: `<meta http-equiv="refresh">` has no CSP directive at all and would turn the public page into
a redirector, and a form posting elsewhere would be a form on the DFX domain whose input goes to
someone else. The served CSP gained `form-action 'none'` in every `location` block, since
`add_header` does not inherit.

An unbalanced `<script>` used to swallow everything up to the next closing tag anywhere in the
document. Reproduced: a document lost a whole paragraph between two blocks, exit 0, nothing on
stderr. That now fails the build — a document that confuses the sanitizer needs a human, not a
half-rendered page.

**Exposure**: the rendered markdown comes from this repository, not from users, so exploiting any of
this required commit access. Nothing in the current content triggers it.

## Verification

| Check | Result |
|---|---|
| Build | 42 screenshots / 10 docs / 28 store fields / 28 assets — unchanged |
| Determinism | two builds, `diff -rq` identical |
| Unit suite | `Test Suites: 1 passed` · `Tests: 31 passed, 31 total` (24 before, 7 new) |
| CSP | `form-action 'none'` in all three `location` blocks |
| `eslint tests/unit/handbook-build.test.js` | empty output |

Deletion guard, each with the real exit code and a file count before and after:

| Target | Files | Exit |
|---|---|---|
| `docs/handbook/screenshots/01-onboarding` | 6 → 6 | 1 |
| `scripts/handbook` | 20 → 20 | 1 |
| `docs` | 46 → 46 | 1 |
| a nested path inside the repo | 0 → 0 | 1 |
| `/tmp/…` (outside) | builds normally, 83 files | 0 |

Sanitizer, on a fixture document: all four vectors neutralised in the rendered article, while a
plain paragraph and an ordinary external link survive untouched — the other direction was checked
too, so the filter is not simply eating markup. The unbalanced case now stops with
`unbalanced <script> blocks (2 open, 1 close)`.

Each of the seven new tests was verified by mutating the property it covers in the build script and
confirming it goes red, including two mutations of the "widened behaviour" kind — making the filter
strip `class` attributes, and making it strip every paragraph — so the tests pin the behaviour
rather than the mere presence of a filter.

The suite was run on a 28-core host because this machine could not free the memory the local gate
requires; the revision there was compared by SHA against the local branch tip.

## Not verified

- One rough edge remains, not fixed here: when the neutralised image vector meets the link
  integrity check, the build aborts with `missing x></p` rather than naming the real cause. It is
  fail-closed — nothing is written — and ordinary unquoted markup such as `<img src=assets/icon.png>`
  builds normally, which was checked separately.
- This is a regex sanitizer, hardened against the vectors that were demonstrated. It is not a
  parser-based allowlist and does not claim completeness; the CSP remains the second layer.
- Output paths that are symlinks resolving out of the repository were not examined.

## Notes on the automated hints

- **`const attrs = m[1] || ''`** (`build.js:628`) — a capture group that did not participate is
  `undefined`; the empty string is the correct value for "no attributes". No backend value and no
  parse result is masked.
- **"filter + length" in a test** (`handbook-build.test.js:333`) — the pattern matches, but the
  assertion is `strictEqual(after.length, before.length)` against a count measured before the run,
  and it is preceded by `before.length >= MIN_SCREENSHOTS` so the test cannot pass on an empty
  fixture. That is the opposite of a vacuous pass: it pins a number and checks its own premise.

---

## Six follow-up fix commits, found by review after the first pass

None of these were symptom-driven — no incident, no production report. Each was found by an
independent review pass reading the guard/sanitizer logic, reproduced on a fixture before being
fixed, and re-reviewed after the fix. Every one of the nine payloads below was verified with a
real build run (not reasoning alone): before the fix, the build exited `0` and the dangerous
markup reached the output HTML unmodified; after the fix, either the build fails closed or the
sanitizer removes the markup, and the previous eight payloads were re-run against each later
commit to confirm no regression.

| # | Commit | What broke | Payload | Before → after |
|---|---|---|---|---|
| 1 | `a7c622a1` | `isSameOrAncestor()` compared paths as plain strings — case-insensitive filesystems (macOS APFS, Windows NTFS defaults) let an output dir spelled with different case pass the repo-root and generic in-repo guards | `outDir` = repo root, different letter case | real repo content deleted → build fails closed |
| 2 | `009051dd` | Same class, two sibling guards that didn't route through `isSameOrAncestor`: the home-directory check (`===`) and the `.git`-segment check (`Array.includes`) | `outDir` = `$HOME`/`.GIT` path, different case | `$HOME` or a `.git`-segment path deleted → build fails closed |
| 3 | `b606a35c` | `assertBalancedDangerBlocks` counted total opens/closes per tag instead of validating order — a count-balanced but misordered pair passed as "balanced" | `<div><script>x</script>y</script>z<script>alert(1)</div>` | live, unclosed `<script>alert(1)` in the served HTML → build fails closed |
| 4 | `e617591d` | Order was checked per tag type independently — an interleaved pair across two different tags passed both single-tag checks | `<iframe src="...">text<script></iframe></script>` | live, unclosed `<iframe>` in the served HTML → build fails closed |
| 5 | `9c72a297` | Two whitespace-tolerance mismatches between the guard and the strip regexes: strip needed an exact closing tag where the guard already tolerated whitespace, and the guard's self-close check matched a `/` that was part of a URL ending in `/` | `<script>alert(1)</script >` · `<script src=http://evil.example/ >CLICKME` | live `<script>` survives (case 1) / no closer found so the build fails closed (case 2) — after: sanitized / fails closed |
| 6 | `340b5305` | Guard and strip each had their own self-close detection; a third whitespace placement (`/` preceded by whitespace, followed by whitespace before `>`) passed the guard's self-close check but not strip's | `<script src=http://evil.example / >CLICKME` | live external `<script src="...">` in the served HTML → sanitized |

`isSameOrAncestor` and `isSelfClosingAttrs` are now each a single shared implementation instead of
several independently-drifted copies, so the same class of mismatch can't reopen at a fourth call
site without a matching code change.

**Not verified (new, from this round):**
- Windows drive-root case-insensitivity: `resolvedOut === path.resolve('/')` in the filesystem-root
  guard is still a plain string comparison. Inert on POSIX (`/` has no case variant); on Windows,
  a differently-cased drive letter would bypass it, and the guard only ever covered one drive root
  regardless. No Windows CI runs in this repo and no development happens on Windows; named here
  rather than fixed, since closing it properly means a multi-drive-root design, not a one-line
  change.
- The new `object`-tag test for the space-before-slash self-close case (fix 6) wasn't added
  alongside the `script`/`iframe` ones, even though all three call sites route through the same
  shared function. Manually verified to behave correctly; the gap is in test coverage, not
  behavior.
- Symlinked output paths resolving out of the repository remain unexamined (carried over from the
  first pass).

**CI note:** GitHub stopped triggering `pull_request`-scoped checks for this PR partway through —
the `push` events land (confirmed via the repo's public events feed) but no `synchronize`-derived
check run was created for six consecutive pushes, including after closing and reopening the PR.
No incident was visible on githubstatus.com. In place of GitHub Actions, `npm run lint` and
`npm run unit` were run directly against each revision (repo-pinned `npm ci`, not `npx`), matching
`ci.yml` exactly: lint exit 0 (296 pre-existing warnings outside this diff, 0 errors), unit
42/42 suites and 347/347 non-skipped tests passing on the final revision.

---

**Final pass (340b5305):**
**Coherent:** the same two files as the first pass, extended by six commits that all serve the
same intent — the deletion guard and the sanitizer are the entire scope, still nothing about
layout, content or languages.
**Nothing extra:** each fix commit closes exactly the payload that reproduced against it, re-tested
against every payload found before it. No parser-based rewrite of the sanitizer or the link
integrity check; that remains a named limit, not a silently expanded scope.
**Sources closed:** six independent review passes, each finding either fixed in the following
commit or named under "Not verified" above. All nine reproduced payloads re-checked against the
final revision and confirmed still blocked/sanitized.
