### PR TITLE
01a0397f - Attach release APKs to GitHub Releases, not Actions artifacts

### DIFF
--- a/.github/scripts/update-release-body.js
+++ b/.github/scripts/update-release-body.js
@@ -11,6 +11,12 @@ module.exports = async ({ github, context }) => {
     tag,
   });
 
+  if (!release.data.draft) {
+    throw new Error(
+      `Refusing to update non-draft release ${tag} (would clobber a published release).`,
+    );
+  }
+
   const body = release.data.body || '';
   const pipelineBlockRegex =
     /<!-- build-pipeline:start -->[\s\S]*?<!-- build-pipeline:end -->/m;

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -1,8 +1,9 @@
 name: BuildReleaseApk
 
-# Manual-only. The tag-driven store release is owned by release.yml, whose
-# android-deploy job runs this same attested build (scripts/build-release-apk.sh)
-# at the tag-derived version. Kept here as a standalone on-demand APK/AAB builder.
+# Manual-only. Builds attested APK/AAB assets and attaches them to an existing
+# GitHub Release for the current tag (gh release upload). The tag-driven store
+# release is owned by release.yml, whose android-deploy job runs this same
+# attested build (scripts/build-release-apk.sh) at the tag-derived version.
 on:
   workflow_dispatch:
 

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -16,7 +16,6 @@ jobs:
 
     permissions:
       contents: write
-      actions: read
       id-token: write
       attestations: write
 
@@ -99,6 +98,21 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-path: ${{ env.RELEASE_ASSETS_DIR }}/SHA256SUMS
+
+      - name: Guard existing draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if ! gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Refusing: release ${GITHUB_REF_NAME} does not exist (this workflow attaches to an existing release; it does not create one)."
+            exit 1
+          fi
+          IS_DRAFT=$(gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "Refusing: release $GITHUB_REF_NAME is not a draft (would clobber a published release)."
+            exit 1
+          fi
 
       - name: Add build pipeline link to release body
         uses: actions/github-script@v7

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -112,6 +112,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
+          if ! gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "Refusing to upload: release ${GITHUB_REF_NAME} does not exist (this workflow attaches to an existing release; it does not create one)."
+            exit 1
+          fi
+          IS_DRAFT=$(gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --json isDraft --jq .isDraft)
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "Refusing to upload: release $GITHUB_REF_NAME is not a draft (would clobber a published release)."
+            exit 1
+          fi
           gh release upload "${GITHUB_REF_NAME}" \
             "${RELEASE_ASSETS_DIR}/DFX-Btc-Wallet-${GITHUB_REF_NAME}.apk" \
             "${RELEASE_ASSETS_DIR}/DFX-Btc-Wallet-${GITHUB_REF_NAME}.apk.idsig" \

--- a/.github/workflows/build-release-apk.yml
+++ b/.github/workflows/build-release-apk.yml
@@ -99,14 +99,6 @@ jobs:
         with:
           subject-path: ${{ env.RELEASE_ASSETS_DIR }}/SHA256SUMS
 
-      - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
-        if: success()
-        with:
-          name: DFX-Btc-Wallet-${{ env.VERSION_NAME }}.apk
-          path: ./android/app/build/outputs/apk/release/app-release.apk
-          if-no-files-found: error
-
       - name: Add build pipeline link to release body
         uses: actions/github-script@v7
         with:

--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -1,7 +1,7 @@
 name: Deploy (develop)
 
-# On every merge to develop: build a signed Android APK and upload it as a
-# workflow artifact for quick install/testing. iOS TestFlight and the versioned
+# On every merge to develop: build a signed Android APK so the assemble path
+# stays green. iOS TestFlight and the versioned
 # store releases are owned by the tag flow (auto-tag.yml -> release.yml); this
 # workflow intentionally does not build iOS to avoid a duplicate TestFlight upload.
 #
@@ -70,8 +70,3 @@ jobs:
             -PMYAPP_UPLOAD_STORE_PASSWORD="$KEYSTORE_PASSWORD" \
             -PMYAPP_UPLOAD_KEY_PASSWORD="$KEYSTORE_KEY_PASSWORD" \
             -PMYAPP_VERSION_CODE="$BUILD_NUMBER"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dfx-bitcoin-develop-${{ github.run_number }}
-          path: android/app/build/outputs/apk/release/app-release.apk
-          if-no-files-found: error

--- a/.github/workflows/reclaim-artifact-storage.yml
+++ b/.github/workflows/reclaim-artifact-storage.yml
@@ -1,0 +1,39 @@
+name: Reclaim Actions storage
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "27 4 * * *"
+  push:
+    branches: [develop]
+    paths:
+      - ".github/workflows/reclaim-artifact-storage.yml"
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  reclaim:
+    name: Delete stored Actions artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Delete every Actions artifact in this repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          deleted=0
+          while :; do
+            json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100")
+            count=$(printf '%s' "$json" | jq '.artifacts | length')
+            if [ "$count" -eq 0 ]; then
+              echo "Deleted ${deleted} artifacts."
+              break
+            fi
+            printf '%s' "$json" | jq -r '.artifacts[].id' | while read -r id; do
+              gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}" --silent
+            done
+            deleted=$((deleted + count))
+          done

--- a/.github/workflows/reclaim-artifact-storage.yml
+++ b/.github/workflows/reclaim-artifact-storage.yml
@@ -24,23 +24,52 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          deleted=0
           cutoff=$(date -u -d '24 hours ago' +%s)
-          while read -r id created; do
-            [ -z "${id:-}" ] && continue
-            created_epoch=$(date -u -d "$created" +%s)
-            if [ "$created_epoch" -ge "$cutoff" ]; then
-              continue
-            fi
-            if ! err=$(gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}" --silent 2>&1); then
-              if printf '%s' "$err" | grep -Eqi '404|not found'; then
-                :
-              else
-                printf '%s\n' "$err" >&2
-                exit 1
+          while true; do
+            ids_file=$(mktemp)
+            page=1
+            while true; do
+              response=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100&page=${page}")
+              count=$(printf '%s' "$response" | jq '.artifacts | length')
+              if [ "$count" -eq 0 ]; then
+                break
               fi
+              page_file=$(mktemp)
+              printf '%s' "$response" | jq -r '.artifacts[] | "\(.id)\t\(.created_at)"' > "$page_file"
+              if [ -s "$page_file" ]; then
+                while IFS=$'\t' read -r id created; do
+                  [ -z "${id:-}" ] && continue
+                  created_epoch=$(date -u -d "$created" +%s)
+                  if [ "$created_epoch" -lt "$cutoff" ]; then
+                    printf '%s\n' "$id" >> "$ids_file"
+                  fi
+                done < "$page_file"
+              fi
+              rm -f "$page_file"
+              total=$(printf '%s' "$response" | jq -r '.total_count')
+              if [ "$((page * 100))" -ge "$total" ] || [ "$count" -lt 100 ]; then
+                break
+              fi
+              page=$((page + 1))
+            done
+            deleted=0
+            if [ -s "$ids_file" ]; then
+              while read -r id; do
+                [ -z "${id:-}" ] && continue
+                if ! err=$(gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}" --silent 2>&1); then
+                  if printf '%s' "$err" | grep -Eqi '404|not found'; then
+                    continue
+                  fi
+                  printf '%s\n' "$err" >&2
+                  rm -f "$ids_file"
+                  exit 1
+                fi
+                deleted=$((deleted + 1))
+              done < "$ids_file"
             fi
-            deleted=$((deleted + 1))
-          done < <(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" \
-            --jq '.artifacts[] | "\(.id)\t\(.created_at)"')
-          echo "Deleted ${deleted} artifacts older than 24 hours."
+            rm -f "$ids_file"
+            echo "Deleted ${deleted} artifacts older than 24 hours."
+            if [ "$deleted" -eq 0 ]; then
+              break
+            fi
+          done

--- a/.github/workflows/reclaim-artifact-storage.yml
+++ b/.github/workflows/reclaim-artifact-storage.yml
@@ -19,21 +19,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - name: Delete every Actions artifact in this repository
+      - name: Delete Actions artifacts older than 24 hours
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           deleted=0
-          while :; do
-            json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100")
-            count=$(printf '%s' "$json" | jq '.artifacts | length')
-            if [ "$count" -eq 0 ]; then
-              echo "Deleted ${deleted} artifacts."
-              break
+          cutoff=$(date -u -d '24 hours ago' +%s)
+          while read -r id created; do
+            [ -z "${id:-}" ] && continue
+            created_epoch=$(date -u -d "$created" +%s)
+            if [ "$created_epoch" -ge "$cutoff" ]; then
+              continue
             fi
-            printf '%s' "$json" | jq -r '.artifacts[].id' | while read -r id; do
-              gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}" --silent
-            done
-            deleted=$((deleted + count))
-          done
+            if ! err=$(gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}" --silent 2>&1); then
+              if printf '%s' "$err" | grep -Eqi '404|not found'; then
+                :
+              else
+                printf '%s\n' "$err" >&2
+                exit 1
+              fi
+            fi
+            deleted=$((deleted + 1))
+          done < <(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100" \
+            --jq '.artifacts[] | "\(.id)\t\(.created_at)"')
+          echo "Deleted ${deleted} artifacts older than 24 hours."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,8 +235,18 @@ jobs:
             FLAG="--prerelease=false"
           fi
           if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            IS_DRAFT=$(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft --jq .isDraft)
+            if [ "$IS_DRAFT" != "true" ]; then
+              echo "Refusing to edit a published release $TAG (draft-only writes)."
+              exit 1
+            fi
             gh release edit "$TAG" --repo "${{ github.repository }}" $FLAG
           else
             gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --draft --generate-notes $FLAG
+          fi
+          IS_DRAFT=$(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft --jq .isDraft)
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "Refusing to publish a non-draft release $TAG."
+            exit 1
           fi
           gh release edit "$TAG" --repo "${{ github.repository }}" $FLAG --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
-      contents: read
+      contents: write
       id-token: write # actions/attest: request the OIDC signing token
       attestations: write # actions/attest: write provenance to the attestation store
     env:
@@ -197,12 +197,18 @@ jobs:
         uses: actions/attest@v4
         with:
           subject-path: ${{ env.RELEASE_ASSETS_DIR }}/SHA256SUMS
-      - name: Upload attested assets for the github-release job
-        uses: actions/upload-artifact@v4
-        with:
-          name: android-release-assets
-          path: ${{ env.RELEASE_ASSETS_DIR }}
-          if-no-files-found: error
+      - name: Attach attested assets to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ needs.guard.outputs.is_prerelease }}
+        run: |
+          set -euo pipefail
+          FLAG=""
+          [ "$PRERELEASE" = "true" ] && FLAG="--prerelease"
+          if ! gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --title "$GITHUB_REF_NAME" --generate-notes $FLAG
+          fi
+          gh release upload "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --clobber "$RELEASE_ASSETS_DIR"/*
 
   github-release:
     name: GitHub release
@@ -211,12 +217,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - name: Download attested release assets
-        uses: actions/download-artifact@v4
-        with:
-          name: android-release-assets
-          path: release-assets
-      - name: Create / update release + attach attested assets
+      - name: Create / update release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
@@ -230,4 +231,3 @@ jobs:
           else
             gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --generate-notes $FLAG
           fi
-          gh release upload "$TAG" --repo "${{ github.repository }}" --clobber release-assets/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,11 @@ jobs:
           if ! gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --title "$GITHUB_REF_NAME" --draft --generate-notes $FLAG
           fi
+          IS_DRAFT=$(gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "Refusing to upload: release $GITHUB_REF_NAME is not a draft (would clobber a published release)."
+            exit 1
+          fi
           gh release upload "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --clobber "$RELEASE_ASSETS_DIR"/*
 
   github-release:
@@ -232,6 +237,6 @@ jobs:
           if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             gh release edit "$TAG" --repo "${{ github.repository }}" $FLAG
           else
-            gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --generate-notes $FLAG
+            gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --draft --generate-notes $FLAG
           fi
           gh release edit "$TAG" --repo "${{ github.repository }}" $FLAG --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,7 +206,7 @@ jobs:
           FLAG=""
           [ "$PRERELEASE" = "true" ] && FLAG="--prerelease"
           if ! gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --title "$GITHUB_REF_NAME" --generate-notes $FLAG
+            gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --title "$GITHUB_REF_NAME" --draft --generate-notes $FLAG
           fi
           gh release upload "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --clobber "$RELEASE_ASSETS_DIR"/*
 
@@ -224,10 +224,14 @@ jobs:
           PRERELEASE: ${{ needs.guard.outputs.is_prerelease }}
         run: |
           set -euo pipefail
-          FLAG=""
-          [ "$PRERELEASE" = "true" ] && FLAG="--prerelease"
+          if [ "$PRERELEASE" = "true" ]; then
+            FLAG="--prerelease"
+          else
+            FLAG="--prerelease=false"
+          fi
           if gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             gh release edit "$TAG" --repo "${{ github.repository }}" $FLAG
           else
             gh release create "$TAG" --repo "${{ github.repository }}" --title "$TAG" --generate-notes $FLAG
           fi
+          gh release edit "$TAG" --repo "${{ github.repository }}" $FLAG --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
   github-release:
     name: GitHub release
     needs: [guard, ios-deploy, android-deploy]
-    if: needs.guard.outputs.proceed == 'true'
+    if: needs.guard.outputs.proceed == 'true' && needs.ios-deploy.result == 'success' && needs.android-deploy.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
EN:
Release APKs and AABs attach to the GitHub Release instead of Actions storage, and a cleanup workflow deletes leftover artifacts. Writes to a tag release fail closed unless that release is still a draft.

DE:
Release-APKs und -AABs hängen am GitHub-Release statt im Actions-Speicher, und ein Cleanup-Workflow löscht die Altbestände. Schreibzugriffe auf ein Tag-Release scheitern, wenn es kein Draft mehr ist.

<details>
<summary>Details</summary>

A single `android-release-assets` blob already exceeded the org's included Actions storage.

- `release.yml` / `build-release-apk.yml`: `gh release upload` of attested assets; no `upload-artifact` hop
- Draft-only: `update-release-body.js` and the upload steps refuse a published release
- Publish (`--draft=false`) runs only after both platform deploys succeed
- `deploy-develop.yml`: still assembles the develop APK, no longer uploads it
- New `.github/workflows/reclaim-artifact-storage.yml` deletes every Actions artifact in this repo after merge, then daily

</details>